### PR TITLE
Hack to fix MS Symbol-encoded fonts

### DIFF
--- a/libass/ass_font.h
+++ b/libass/ass_font.h
@@ -68,6 +68,7 @@ void ass_font_get_asc_desc(ASS_Font *font, uint32_t ch, int *asc,
                            int *desc);
 int ass_font_get_index(void *fcpriv, ASS_Font *font, uint32_t symbol,
                        int *face_index, int *glyph_index);
+uint32_t ass_font_index_magic(FT_Face face, uint32_t symbol);
 FT_Glyph ass_font_get_glyph(void *fontconfig_priv, ASS_Font *font,
                             uint32_t ch, int face_index, int index,
                             ASS_Hinting hinting, int deco);

--- a/libass/ass_shaper.c
+++ b/libass/ass_shaper.c
@@ -220,9 +220,9 @@ get_glyph(hb_font_t *font, void *font_data, hb_codepoint_t unicode,
     FT_Face face = font_data;
 
     if (variation)
-        *glyph = FT_Face_GetCharVariantIndex(face, unicode, variation);
+        *glyph = FT_Face_GetCharVariantIndex(face, ass_font_index_magic(face, unicode), variation);
     else
-        *glyph = FT_Get_Char_Index(face, unicode);
+        *glyph = FT_Get_Char_Index(face, ass_font_index_magic(face, unicode));
 
     return *glyph != 0;
 }
@@ -668,7 +668,7 @@ static void shape_fribidi(ASS_Shaper *shaper, GlyphInfo *glyphs, size_t len)
         GlyphInfo *info = glyphs + i;
         FT_Face face = info->font->faces[info->face_index];
         info->symbol = shaper->event_text[i];
-        info->glyph_index = FT_Get_Char_Index(face, shaper->event_text[i]);
+        info->glyph_index = FT_Get_Char_Index(face, ass_font_index_magic(face, shaper->event_text[i]));
     }
 
     free(joins);


### PR DESCRIPTION
Fonts encoded with format 0 (symbol) need to have 0xF000 added to charcodes for some reason. This does that.
http://lists.gnu.org/archive/html/freetype/2001-10/msg00027.html
Fixes #4
