### PR TITLE
Blur fixes

### DIFF
--- a/libass/ass_bitmap.c
+++ b/libass/ass_bitmap.c
@@ -444,6 +444,8 @@ static void be_blur(Bitmap *bm)
             buf[y * s + x] = (old_sum + new_sum) >> 2;
             old_sum = new_sum;
         }
+        new_sum = 2 * buf[y * s + w - 1];
+        buf[y * s + w - 1] = (old_sum + new_sum) >> 2;
     }
 
     for (x = 0; x < w; x++) {
@@ -453,6 +455,8 @@ static void be_blur(Bitmap *bm)
             buf[y * s + x] = (old_sum + new_sum) >> 2;
             old_sum = new_sum;
         }
+        new_sum = 2 * buf[(h - 1) * s + x];
+        buf[(h - 1) * s + x] = (old_sum + new_sum) >> 2;
     }
 }
 


### PR DESCRIPTION
I made this a while ago but thought I’d do more related stuff, then I realized I wouldn’t, then I posted about this on IRC, but my posts were lost in an uncharacteristic text wall of other discussion.

If this is pulled before rcombs’ glyph run work, he’ll have to do a bit of conflict resolving, but it should be easy.

Gaussian blur quality:
- old: http://i.minus.com/iRabqfqbboGuO.png
- new: http://i.minus.com/ibnMJIDfG3gfk0.png

I don’t have a screenshot of blur corruption due to the out-of-bounds accesses, and I don’t think I can remember where it happened, but I have actually seen it (which made me track down and fix it).

Now, a word about “speed up \blur table generation”, f226ef1. I thought it would help because xy-VSFilter had done it and wrote the patch before profiling anything. When I did start profiling, I couldn’t get the old table generation to exceed 2% of total CPU time however I tried. Which doesn’t necessarily mean it isn’t possible, as I could’ve missed something obvious… But feel free to cherry-pick the other commits and drop this one.

Finally, it’s just occurred to me that I should test VSFilter’s \be. Turns out it ignores the last row/column just like libass does before my patch _and also_ ignores the first row/column. But the bitmap’s size depends on things like font rasterization which are already different between VSFilter and libass, so this isn’t very predictable. I’m not entirely sure how I feel about this myself, but at the moment I’m inclined to say my current patch is still the way to go.
