### PR TITLE
Fix missing pointer dereference in 1636a551

### DIFF
--- a/libass/ass_shaper.c
+++ b/libass/ass_shaper.c
@@ -239,7 +239,7 @@ get_glyph(hb_font_t *font, void *font_data, hb_codepoint_t unicode,
 
     // rotate glyph advances for @fonts while we still know the Unicode codepoints
     if (*glyph != 0)
-        get_cached_metrics(metrics_priv, face, unicode, glyph);
+        get_cached_metrics(metrics_priv, face, unicode, *glyph);
 
     return *glyph != 0;
 }


### PR DESCRIPTION
I no longer have any idea what in particular this embarrassing typo actually does or doesn’t break; it needs to be fixed regardless. Originally found by @11rcombs by simply enabling and reading compiler warnings.
