### PR TITLE
Simplify storage size handling

### DIFF
--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -2589,9 +2589,9 @@ ass_start_frame(ASS_Renderer *render_priv, ASS_Track *track,
 
     render_priv->font_scale = settings_priv->font_size_coeff *
         render_priv->orig_height / render_priv->track->PlayResY;
-    if (render_priv->storage_height)
+    if (settings_priv->storage_height)
         render_priv->blur_scale = ((double) render_priv->orig_height) /
-            render_priv->storage_height;
+            settings_priv->storage_height;
     else
         render_priv->blur_scale = 1.;
     if (render_priv->track->ScaledBorderAndShadow)

--- a/libass/ass_render.h
+++ b/libass/ass_render.h
@@ -70,8 +70,8 @@ typedef struct free_list {
 typedef struct {
     int frame_width;
     int frame_height;
-    int storage_width;          // width of the source image
-    int storage_height;         // height of the source image
+    int storage_width;          // video width before any rescaling
+    int storage_height;         // video height before any rescaling
     double font_size_coeff;     // font size multiplier
     double line_spacing;        // additional line spacing (in frame pixels)
     double line_position;       // vertical position for subtitles, 0-100 (0 = no change)
@@ -339,8 +339,6 @@ struct ass_renderer {
     int orig_width;             // frame width ( = screen width - margins )
     int orig_height_nocrop;     // frame height ( = screen height - margins + cropheight)
     int orig_width_nocrop;      // frame width ( = screen width - margins + cropwidth)
-    int storage_height;         // video height before any rescaling
-    int storage_width;          // video width before any rescaling
     ASS_Track *track;
     long long time;             // frame's timestamp, ms
     double font_scale;

--- a/libass/ass_render_api.c
+++ b/libass/ass_render_api.c
@@ -43,13 +43,6 @@ static void ass_reconfigure(ASS_Renderer *priv)
     priv->orig_height_nocrop =
         settings->frame_height - FFMAX(settings->top_margin, 0) -
         FFMAX(settings->bottom_margin, 0);
-    if (settings->storage_height) {
-        priv->storage_width = settings->storage_width;
-        priv->storage_height = settings->storage_height;
-    } else {
-        priv->storage_width = priv->orig_width;
-        priv->storage_height = priv->orig_height;
-    }
 }
 
 void ass_set_frame_size(ASS_Renderer *priv, int w, int h)


### PR DESCRIPTION
Just a bit of code simplification, because I got confused by the current code (`storage_height` is both in `settings_priv` and in `render_priv` and has different values in case `ass_set_storage_size` hasn’t been called). No functional changes.
