### PR TITLE
Trim trailing whitespace from Dialogue lines early

### DIFF
--- a/libass/ass.c
+++ b/libass/ass.c
@@ -354,12 +354,12 @@ static int process_event_tail(ASS_Track *track, ASS_Event *event,
     while (1) {
         NEXT(q, tname);
         if (ass_strcasecmp(tname, "Text") == 0) {
-            char *last;
             event->Text = strdup(p);
             if (*event->Text != 0) {
-                last = event->Text + strlen(event->Text) - 1;
-                if (last >= event->Text && *last == '\r')
-                    *last = 0;
+                char *end = event->Text + strlen(event->Text);
+                while (end > event->Text &&
+                       (end[-1] == '\r' || end[-1] == '\t' || end[-1] == ' '))
+                    *--end = 0;
             }
             event->Duration -= event->Start;
             free(format);


### PR DESCRIPTION
**Not for merge yet (probably).**

Match VSFilter. In particular, trailing `\N` (with any non-zero number of spaces) no longer produces an empty line. VSFilter trims both trailing and leading whitespace early, but trimming leading whitespace late presents no such problem.

After #46 is fixed, I think `x->symbol == '\n'` can be removed from `IS_WHITESPACE` and the trailing whitespace trimming loop removed from `trim_whitespace`.
