### PR TITLE
Make adding in-memory fonts work/simpler

### DIFF
--- a/libass/ass.h
+++ b/libass/ass.h
@@ -473,6 +473,18 @@ void ass_add_font(ASS_Library *library, char *name, char *data,
                   int data_size);
 
 /**
+ * \brief Add a memory font
+ * \param library library handle
+ * \param renderer renderer handle
+ * \param data binary font data
+ * \param data_size data size
+*/
+void ass_add_memory_font(ASS_Library *library,
+                         const ASS_Renderer *renderer,
+                         const unsigned char *data,
+                         size_t data_size);
+
+/**
  * \brief Remove all fonts stored in an ass_library object.
  * \param library library handle
  */

--- a/libass/ass_font.c
+++ b/libass/ass_font.c
@@ -766,3 +766,18 @@ void fix_freetype_stroker(FT_Outline *outline, int border_x, int border_y)
     free(valid_cont);
 }
 
+void ass_add_memory_font(ASS_Library *library,
+                         const ASS_Renderer *renderer,
+                         const unsigned char *data,
+                         size_t size)
+{
+    FT_Face face;
+    if (FT_New_Memory_Face(renderer->ftlibrary, data, size, 0, &face) == 0)
+    {
+        ass_add_font(library,
+                     (char *)face->family_name,
+                     (char *)data,
+                     (int)size);
+        FT_Done_Face(face);
+    }
+}


### PR DESCRIPTION
- fix wrong font name used when searching in-memory fonts
- use freetype to figure out correct font family name
- use ass_add_font to add in-memory font with correct name
