### PR TITLE
Use FT_Outline_EmboldenXY

### DIFF
--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -954,9 +954,15 @@ static void stroke_outline(ASS_Renderer *render_priv, FT_Outline *outline,
         outline->n_points = outline->n_contours = 0;
         FT_Stroker_ExportBorder(render_priv->state.stroker, border, outline);
 
-    // "Stroke" with the outline emboldener in two passes.
+    // "Stroke" with the outline emboldener (in two passes if needed).
     // The outlines look uglier, but the emboldening never adds any points
     } else {
+#if (FREETYPE_MAJOR > 2) || \
+    ((FREETYPE_MAJOR == 2) && (FREETYPE_MINOR > 4)) || \
+    ((FREETYPE_MAJOR == 2) && (FREETYPE_MINOR == 4) && (FREETYPE_PATCH >= 10))
+        FT_Outline_EmboldenXY(outline, sx * 2, sy * 2);
+        FT_Outline_Translate(outline, -sx, -sy);
+#else
         int i;
         FT_Outline nol;
 
@@ -973,6 +979,7 @@ static void stroke_outline(ASS_Renderer *render_priv, FT_Outline *outline,
             outline->points[i].y = nol.points[i].y;
 
         FT_Outline_Done(render_priv->ftlibrary, &nol);
+#endif
     }
 }
 


### PR DESCRIPTION
Do we want version macro checks?
- We could raise the minimum version requirement.
- We could put this change off until such a time when we’re happy to raise the minimum version requirement. I didn’t actually notice any difference in the output, although I only did one quick test.

Do we want a runtime version check? Older FreeType is ABI-compatible but doesn’t have this function.

(Speaking of performance, the new version has to be twice as fast at emboldening. But I have no idea how slow or fast emboldening is to begin with.)
