### PR TITLE
Skip memset() when using internal rasterizer

### DIFF
--- a/libass/ass_bitmap.c
+++ b/libass/ass_bitmap.c
@@ -319,20 +319,15 @@ Bitmap *outline_to_bitmap(ASS_Renderer *render_priv,
 
     int tile_w = (w + 2 * bord + mask) & ~mask;
     int tile_h = (h + 2 * bord + mask) & ~mask;
-    Bitmap *bm = alloc_bitmap(tile_w, tile_h);
+    Bitmap *bm = alloc_bitmap_raw(tile_w, tile_h);
     if (!bm)
         return NULL;
     bm->left = x_min - bord;
     bm->top =  y_min - bord;
 
-    int offs = bord & ~mask;
-    if (!rasterizer_fill(rst,
-            bm->buffer + offs * (bm->stride + 1),
-            x_min - bord + offs,
-            y_min - bord + offs,
-            ((w + bord + mask) & ~mask) - offs,
-            ((h + bord + mask) & ~mask) - offs,
-            bm->stride)) {
+    if (!rasterizer_fill(rst, bm->buffer,
+                         x_min - bord, y_min - bord,
+                         bm->stride, tile_h, bm->stride)) {
         ass_msg(render_priv->library, MSGL_WARN, "Failed to rasterize glyph!\n");
         ass_free_bitmap(bm);
         return NULL;

--- a/libass/ass_rasterizer.h
+++ b/libass/ass_rasterizer.h
@@ -43,15 +43,15 @@ struct segment {
 };
 
 
-typedef void (*FillSolidTileFunc)(uint8_t *buf, ptrdiff_t stride);
+typedef void (*FillSolidTileFunc)(uint8_t *buf, ptrdiff_t stride, int set);
 typedef void (*FillHalfplaneTileFunc)(uint8_t *buf, ptrdiff_t stride,
                                       int32_t a, int32_t b, int64_t c, int32_t scale);
 typedef void (*FillGenericTileFunc)(uint8_t *buf, ptrdiff_t stride,
                                     const struct segment *line, size_t n_lines,
                                     int winding);
 
-void ass_fill_solid_tile16_c(uint8_t *buf, ptrdiff_t stride);
-void ass_fill_solid_tile32_c(uint8_t *buf, ptrdiff_t stride);
+void ass_fill_solid_tile16_c(uint8_t *buf, ptrdiff_t stride, int set);
+void ass_fill_solid_tile32_c(uint8_t *buf, ptrdiff_t stride, int set);
 void ass_fill_halfplane_tile16_c(uint8_t *buf, ptrdiff_t stride,
                                  int32_t a, int32_t b, int64_t c, int32_t scale);
 void ass_fill_halfplane_tile32_c(uint8_t *buf, ptrdiff_t stride,

--- a/libass/ass_rasterizer_c.c
+++ b/libass/ass_rasterizer_c.c
@@ -22,10 +22,10 @@
 
 
 
-void ass_fill_solid_tile16_c(uint8_t *buf, ptrdiff_t stride)
+void ass_fill_solid_tile16_c(uint8_t *buf, ptrdiff_t stride, int set)
 {
     int i, j;
-    int8_t value = 255;
+    int8_t value = set ? 255 : 0;
     for (j = 0; j < 16; ++j) {
         for (i = 0; i < 16; ++i)
             buf[i] = value;
@@ -33,10 +33,10 @@ void ass_fill_solid_tile16_c(uint8_t *buf, ptrdiff_t stride)
     }
 }
 
-void ass_fill_solid_tile32_c(uint8_t *buf, ptrdiff_t stride)
+void ass_fill_solid_tile32_c(uint8_t *buf, ptrdiff_t stride, int set)
 {
     int i, j;
-    int8_t value = 255;
+    int8_t value = set ? 255 : 0;
     for (j = 0; j < 32; ++j) {
         for (i = 0; i < 32; ++i)
             buf[i] = value;

--- a/libass/x86/rasterizer.asm
+++ b/libass/x86/rasterizer.asm
@@ -116,12 +116,21 @@ SECTION .text
 
 ;------------------------------------------------------------------------------
 ; FILL_SOLID_TILE tile_order, suffix
-; void fill_solid_tile%2(uint8_t *buf, ptrdiff_t stride);
+; void fill_solid_tile%2(uint8_t *buf, ptrdiff_t stride, int set);
 ;------------------------------------------------------------------------------
 
 %macro FILL_SOLID_TILE 2
-cglobal fill_solid_tile%2, 2,2,1
-    pcmpeqd m0, m0
+cglobal fill_solid_tile%2, 3,4,1
+    mov r3d, -1
+    test r2d, r2d
+    cmovnz r2d, r3d
+    movd xm0, r2d
+%if mmsize == 32
+    vpbroadcastd m0, xm0
+%else
+    pshufd m0, m0, q0000
+%endif
+
 %rep (1 << %1) - 1
     FILL_LINE r0, 0, 1 << %1
     add r0, r1

--- a/libass/x86/rasterizer.h
+++ b/libass/x86/rasterizer.h
@@ -25,8 +25,8 @@
 
 struct segment;
 
-void ass_fill_solid_tile16_sse2(uint8_t *buf, ptrdiff_t stride);
-void ass_fill_solid_tile32_sse2(uint8_t *buf, ptrdiff_t stride);
+void ass_fill_solid_tile16_sse2(uint8_t *buf, ptrdiff_t stride, int set);
+void ass_fill_solid_tile32_sse2(uint8_t *buf, ptrdiff_t stride, int set);
 void ass_fill_halfplane_tile16_sse2(uint8_t *buf, ptrdiff_t stride,
                                     int32_t a, int32_t b, int64_t c, int32_t scale);
 void ass_fill_halfplane_tile32_sse2(uint8_t *buf, ptrdiff_t stride,
@@ -38,8 +38,8 @@ void ass_fill_generic_tile32_sse2(uint8_t *buf, ptrdiff_t stride,
                                   const struct segment *line, size_t n_lines,
                                   int winding);
 
-void ass_fill_solid_tile16_avx2(uint8_t *buf, ptrdiff_t stride);
-void ass_fill_solid_tile32_avx2(uint8_t *buf, ptrdiff_t stride);
+void ass_fill_solid_tile16_avx2(uint8_t *buf, ptrdiff_t stride, int set);
+void ass_fill_solid_tile32_avx2(uint8_t *buf, ptrdiff_t stride, int set);
 void ass_fill_halfplane_tile16_avx2(uint8_t *buf, ptrdiff_t stride,
                                     int32_t a, int32_t b, int64_t c, int32_t scale);
 void ass_fill_halfplane_tile32_avx2(uint8_t *buf, ptrdiff_t stride,


### PR DESCRIPTION
Utilizing new alloc_bitmap_raw() function for rasterizer.

Not tested with AVX2.