### PR TITLE
fixed wrong frame top to clip

### DIFF
--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -2303,7 +2303,7 @@ ass_render_event(ASS_Renderer *render_priv, ASS_Event *event,
                 y2scr(render_priv, render_priv->state.clip_y1);
         } else if (valign == VALIGN_SUB) {
             render_priv->state.clip_y0 =
-                y2scr_sub(render_priv, render_priv->state.clip_y0);
+                y2scr_top(render_priv, render_priv->state.clip_y0);
             render_priv->state.clip_y1 =
                 y2scr_sub(render_priv, render_priv->state.clip_y1);
         }


### PR DESCRIPTION
this bug make the subtitle invisible when ass_set_line_position set line_position to top(100.0) and ass_set_use_margins set as true(1)
