### PR TITLE
Fix caching of combined bitmaps after complex shaping

### DIFF
--- a/libass/ass_cache.c
+++ b/libass/ass_cache.c
@@ -132,7 +132,7 @@ static void composite_destruct(void *key, void *value)
         ass_free_bitmap(v->bm_o);
     if (v->bm_s)
         ass_free_bitmap(v->bm_s);
-    free(k->str);
+    free(k->str.data);
     free(key);
     free(value);
 }

--- a/libass/ass_cache_template.h
+++ b/libass/ass_cache_template.h
@@ -6,6 +6,8 @@
         type member;
 #define STRING(member) \
         char *member;
+#define BINSTRING(member) \
+        struct { size_t size; void *data; } member;
 #define FTVECTOR(member) \
         FT_Vector member;
 #define BITMAPHASHKEY(member) \
@@ -25,6 +27,9 @@
             a->member == b->member &&
 #define STRING(member) \
             strcmp(a->member, b->member) == 0 &&
+#define BINSTRING(member) \
+            a->member.size == b->member.size && \
+            memcmp(a->member.data, b->member.data, a->member.size) == 0 &&
 #define FTVECTOR(member) \
             a->member.x == b->member.x && a->member.y == b->member.y &&
 #define BITMAPHASHKEY(member) \
@@ -44,6 +49,9 @@
         hval = fnv_32a_buf(&p->member, sizeof(p->member), hval);
 #define STRING(member) \
         hval = fnv_32a_str(p->member, hval);
+#define BINSTRING(member) \
+        hval = fnv_32a_buf(&p->member.size, sizeof(p->member.size), hval); \
+        hval = fnv_32a_buf(p->member.data, p->member.size, hval);
 #define FTVECTOR(member) GENERIC(, member.x); GENERIC(, member.y);
 #define BITMAPHASHKEY(member) { \
         unsigned temp = bitmap_hash(&p->member, sizeof(p->member)); \
@@ -152,7 +160,7 @@ START(composite, composite_hash_key)
     GENERIC(int, shift_x)
     GENERIC(int, shift_y)
     FTVECTOR(advance)
-    STRING(str)
+    BINSTRING(str)
 END(CompositeHashKey)
 
 #undef START


### PR DESCRIPTION
Should I define the struct with a proper name somewhere? Where?

Is it a concern that CompositeHashKey::str now takes up ≥ 4 times as much space? (Only for non-drawings.)
