### PR TITLE
\be fixes including clipping and value range

### DIFF
--- a/libass/ass_bitmap.c
+++ b/libass/ass_bitmap.c
@@ -749,6 +749,35 @@ void be_blur_post(uint8_t *buf, intptr_t w, intptr_t h, intptr_t stride)
     }
 }
 
+/*
+ * To find these values, simulate blur on the border between two
+ * half-planes, one zero-filled (background) and the other filled
+ * with the maximum supported value (foreground). Keep incrementing
+ * the \be argument. The necessary padding is the distance by which
+ * the blurred foreground image extends beyond the original border
+ * and into the background. Initially it increases along with \be,
+ * but very soon it grinds to a halt. At some point, the blurred
+ * image actually reaches a stationary point and stays unchanged
+ * forever after, simply _shifting_ by one pixel for each \be
+ * step--moving in the direction of the non-zero half-plane and
+ * thus decreasing the necessary padding (although the large
+ * padding is still needed for intermediate results). In practice,
+ * images are finite rather than infinite like half-planes, but
+ * this can only decrease the required padding. Half-planes filled
+ * with extreme values are the theoretical limit of the worst case.
+ * Make sure to use the right pixel value range in the simulation!
+ */
+int be_padding(int be)
+{
+    if (be <= 3)
+        return be;
+    if (be <= 7)
+        return 4;
+    if (be <= 123)
+        return 5;
+    return FFMAX(128 - be, 0);
+}
+
 int outline_to_bitmap2(ASS_Renderer *render_priv,
                        ASS_Outline *outline, ASS_Outline *border,
                        Bitmap **bm_g, Bitmap **bm_o)

--- a/libass/ass_bitmap.c
+++ b/libass/ass_bitmap.c
@@ -126,7 +126,8 @@ static bool resize_tmp(ASS_SynthPriv *priv, int w, int h)
 {
     if (w >= INT_MAX || (w + 1) > SIZE_MAX / 2 / sizeof(unsigned) / FFMAX(h, 1))
         return false;
-    size_t needed = sizeof(unsigned) * (w + 1) * h;
+    size_t needed = FFMAX(sizeof(unsigned) * (w + 1) * h,
+                          sizeof(uint16_t) * ass_align(32, w) * 2);
     if (priv->tmp && priv->tmp_allocated >= needed)
         return true;
 

--- a/libass/ass_bitmap.c
+++ b/libass/ass_bitmap.c
@@ -651,7 +651,7 @@ void ass_gauss_blur(unsigned char *buffer, unsigned *tmp2,
 }
 
 /**
- * \brief Blur with [[1,2,1]. [2,4,2], [1,2,1]] kernel
+ * \brief Blur with [[1,2,1], [2,4,2], [1,2,1]] kernel
  * This blur is the same as the one employed by vsfilter.
  * Pure C implementation.
  */
@@ -659,12 +659,11 @@ void be_blur_c(uint8_t *buf, intptr_t w,
                intptr_t h, intptr_t stride,
                uint16_t *tmp)
 {
-    unsigned short *col_pix_buf = tmp;
-    unsigned short *col_sum_buf = tmp + w * sizeof(unsigned short);
+    uint16_t *col_pix_buf = tmp;
+    uint16_t *col_sum_buf = tmp + w;
     unsigned x, y, old_pix, old_sum, temp1, temp2;
-    unsigned char *src, *dst;
-    memset(col_pix_buf, 0, w * sizeof(unsigned short));
-    memset(col_sum_buf, 0, w * sizeof(unsigned short));
+    uint8_t *src, *dst;
+    memset(tmp, 0, sizeof(uint16_t) * w * 2);
     y = 0;
 
     {

--- a/libass/ass_bitmap.c
+++ b/libass/ass_bitmap.c
@@ -146,6 +146,20 @@ void ass_synth_blur(ASS_SynthPriv *priv_blur, int opaque_box, int be,
             return;
     }
 
+    // Apply gaussian blur
+    if (blur_radius > 0.0 && generate_tables(priv_blur, blur_radius)) {
+        if (bm_o)
+            ass_gauss_blur(bm_o->buffer, priv_blur->tmp,
+                           bm_o->w, bm_o->h, bm_o->stride,
+                           priv_blur->gt2, priv_blur->g_r,
+                           priv_blur->g_w);
+        if (!bm_o || opaque_box)
+            ass_gauss_blur(bm_g->buffer, priv_blur->tmp,
+                           bm_g->w, bm_g->h, bm_g->stride,
+                           priv_blur->gt2, priv_blur->g_r,
+                           priv_blur->g_w);
+    }
+
     // Apply box blur (multiple passes, if requested)
     if (be) {
         uint16_t* tmp = priv_blur->tmp;
@@ -179,20 +193,6 @@ void ass_synth_blur(ASS_SynthPriv *priv_blur, int opaque_box, int be,
                 }
             }
         }
-    }
-
-    // Apply gaussian blur
-    if (blur_radius > 0.0 && generate_tables(priv_blur, blur_radius)) {
-        if (bm_o)
-            ass_gauss_blur(bm_o->buffer, priv_blur->tmp,
-                           bm_o->w, bm_o->h, bm_o->stride,
-                           priv_blur->gt2, priv_blur->g_r,
-                           priv_blur->g_w);
-        if (!bm_o || opaque_box)
-            ass_gauss_blur(bm_g->buffer, priv_blur->tmp,
-                           bm_g->w, bm_g->h, bm_g->stride,
-                           priv_blur->gt2, priv_blur->g_r,
-                           priv_blur->g_w);
     }
 }
 

--- a/libass/ass_bitmap.h
+++ b/libass/ass_bitmap.h
@@ -69,6 +69,7 @@ void ass_free_bitmap(Bitmap *bm);
 void ass_gauss_blur(unsigned char *buffer, unsigned *tmp2,
                     int width, int height, int stride,
                     unsigned *m2, int r, int mwidth);
+int be_padding(int be);
 void be_blur_c(uint8_t *buf, intptr_t w,
                intptr_t h, intptr_t stride,
                uint16_t *tmp);

--- a/libass/ass_bitmap.h
+++ b/libass/ass_bitmap.h
@@ -72,6 +72,10 @@ void ass_gauss_blur(unsigned char *buffer, unsigned *tmp2,
 void be_blur_c(uint8_t *buf, intptr_t w,
                intptr_t h, intptr_t stride,
                uint16_t *tmp);
+void be_blur_pre(uint8_t *buf, intptr_t w,
+                 intptr_t h, intptr_t stride);
+void be_blur_post(uint8_t *buf, intptr_t w,
+                  intptr_t h, intptr_t stride);
 void add_bitmaps_c(uint8_t *dst, intptr_t dst_stride,
                    uint8_t *src, intptr_t src_stride,
                    intptr_t height, intptr_t width);

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -2257,7 +2257,7 @@ static void render_and_combine_glyphs(ASS_Renderer *render_priv,
             continue;
         }
 
-        int bbord = info->filter.be > 0 ? sqrt(2 * info->filter.be) : 0;
+        int bbord = be_padding(info->filter.be);
         int gbord = info->filter.blur > 0.0 ? FFMIN(info->filter.blur + 1, INT_MAX) : 0;
         int bord = FFMAX(bbord, gbord);
 


### PR DESCRIPTION
Of particular note: as discussed in #9,

* VSFilter has pixel values in the range from 0 to 64 inclusive, while libass uses the range from 0 to 255. Normally this doesn’t matter at all. For \blur, this merely means VSFilter’s has banding. But for \be with a large iteration count, the output is very different. This pull request makes libass use the range from 0 to 64 for all \be iterations but the last. The range conversions are correctly rounded (towards positive infinity where relevant). If the \be argument is 1 or 0, no range conversion takes place. The last \be pass is done on the full range to smooth out the output to make better use of the full range and hide whatever little banding was introduced by the reduced range.

* Blurs, both \blur and \be, cause bitmaps to expand. All renderers add some blur-dependent margins to bitmaps to accommodate this. However, the margins renderers add \be are too small. (In particular, traditional VSFilter always adds a single pixel*, presumably because \be originally did not support values bigger than 1.) libass already adds the largest margin of all renderers, but this pull request makes it always add just enough—and no more.

…Wait, my notes say there are some more edge cases (literally!) that are not handled correctly by our `be_blur`. I’ll double-check them.

\* And never writes to the said pixel during \be, only reads from it, so effectively it doesn’t add any margin at all.