### PR TITLE
configure: use proper quoting on iconv test

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -227,8 +227,8 @@ AM_CONDITIONAL([ENABLE_PROFILE], [test x$enable_profile = xyes])
 # add packages to pkg-config for static linking
 if test "$use_libiconv" = true; then
     AC_DEFINE(CONFIG_ICONV, 1, [use iconv])
-    if test x$ac_cv_search_libiconv_open != x'none required' &&
-       test x$ac_cv_search_iconv_open != x'none required'; then
+    if test x"$ac_cv_search_libiconv_open" != x"none required" &&
+       test x"$ac_cv_search_iconv_open" != x"none required"; then
         pkg_libs="${pkg_libs} -liconv"
     fi
 fi


### PR DESCRIPTION
Unquoted strings cause an error when the test variable is empty.
