### PR TITLE
render: Fix overflow causing out of bounds memory access

### DIFF
--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -1575,7 +1575,7 @@ wrap_lines_smart(ASS_Renderer *render_priv, double max_text_width)
         s1 = s2 = 0;
         for (i = 0; i <= text_info->length; ++i) {
             cur = text_info->glyphs + i;
-            if ((i == text_info->length) || cur->linebreak) {
+            if (cur->linebreak) {
                 s1 = s2;
                 s2 = s3;
                 s3 = cur;
@@ -1614,8 +1614,6 @@ wrap_lines_smart(ASS_Renderer *render_priv, double max_text_width)
                     }
                 }
             }
-            if (i == text_info->length)
-                break;
         }
 
     }


### PR DESCRIPTION
I don't know if this breaks something else, but...

The following .ass file breaks libass:

```
[V4+ Styles]
Style:Default,DejaVuSans,5,,,,,,,,,100,,7680000
[Events]
Dialogue:1,0:00:00.0,1:00:0.0,Default,,,,,,lol ass
```

Also, I removed the `if (...) break` because it is pointless code (the for-loop will terminate immediately, regardless of if it is there).
