### PR TITLE
font load from dir: use MSGL_INFO instead of MSGL_WARN

### DIFF
--- a/libass/ass_fontselect.c
+++ b/libass/ass_fontselect.c
@@ -175,7 +175,7 @@ static void load_fonts_from_dir(ASS_Library *library, const char *dir)
         char fullname[4096];
         snprintf(fullname, sizeof(fullname), "%s/%s", dir, entry->d_name);
         size_t bufsize = 0;
-        ass_msg(library, MSGL_WARN, "Loading font file '%s'", fullname);
+        ass_msg(library, MSGL_INFO, "Loading font file '%s'", fullname);
         void *data = read_file(library, fullname, &bufsize);
         if (data) {
             ass_add_font(library, entry->d_name, data, bufsize);


### PR DESCRIPTION
This is a normal course of action and should not generate a warning,
especially for applications which use libass and might notify the user
on such "warnings", while in fact it should be info or even verbose.

Fixes #231