### PR TITLE
Fix issues found by fuzzing

### DIFF
--- a/libass/ass.c
+++ b/libass/ass.c
@@ -590,6 +590,7 @@ static int process_styles_line(ASS_Track *track, char *str)
     if (!strncmp(str, "Format:", 7)) {
         char *p = str + 7;
         skip_spaces(&p);
+        free(track->style_format);
         track->style_format = strdup(p);
         ass_msg(track->library, MSGL_DBG2, "Style format: %s",
                track->style_format);

--- a/libass/ass_blur.c
+++ b/libass/ass_blur.c
@@ -744,7 +744,7 @@ static void calc_coeff(double mu[4], const int index[4], int prefilter, double r
         (  17 -  126 * mul +  273 * mul2 -  164 * mul3) / 12096,
     };
 
-    double mat_freq[13];
+    double mat_freq[14];
     memcpy(mat_freq, kernel, sizeof(kernel));
     memset(mat_freq + 4, 0, sizeof(mat_freq) - sizeof(kernel));
     int n = 6;

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -1607,7 +1607,9 @@ wrap_lines_smart(ASS_Renderer *render_priv, double max_text_width)
                         ((s3 - 1)->bbox.xMax + (s3 - 1)->pos.x) -
                         (w->bbox.xMin + w->pos.x));
 
-                    if (DIFF(l1_new, l2_new) < DIFF(l1, l2)) {
+                    if (DIFF(l1_new, l2_new) < DIFF(l1, l2) && w > text_info->glyphs) {
+                        if (w->linebreak)
+                            text_info->n_lines--;
                         w->linebreak = 1;
                         s2->linebreak = 0;
                         exit = 0;

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -1518,7 +1518,6 @@ wrap_lines_smart(ASS_Renderer *render_priv, double max_text_width)
     double pen_shift_x;
     double pen_shift_y;
     int cur_line;
-    int run_offset;
     TextInfo *text_info = &render_priv->text_info;
 
     last_space = -1;
@@ -1628,7 +1627,6 @@ wrap_lines_smart(ASS_Renderer *render_priv, double max_text_width)
     trim_whitespace(render_priv);
 
     cur_line = 1;
-    run_offset = 0;
 
     i = 0;
     cur = text_info->glyphs + i;
@@ -1649,7 +1647,6 @@ wrap_lines_smart(ASS_Renderer *render_priv, double max_text_width)
                 text_info->lines[cur_line - 1].offset;
             text_info->lines[cur_line].offset = i;
             cur_line++;
-            run_offset++;
             pen_shift_x = d6_to_double(-cur->pos.x);
             pen_shift_y += height + render_priv->settings.line_spacing;
         }

--- a/libass/ass_shaper.c
+++ b/libass/ass_shaper.c
@@ -100,6 +100,7 @@ static bool check_allocations(ASS_Shaper *shaper, size_t new_size)
             !ASS_REALLOC_ARRAY(shaper->emblevels, new_size) ||
             !ASS_REALLOC_ARRAY(shaper->cmap, new_size))
             return false;
+        shaper->n_glyphs = new_size;
     }
     return true;
 }

--- a/test/test.c
+++ b/test/test.c
@@ -186,6 +186,7 @@ static void print_font_providers(ASS_Library *ass_library)
         printf("%s'%s'", separator,  font_provider_labels[providers[i]]);
     }
     printf(".\n");
+    free(providers);
 }
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
This should fix the more severe issues reported by @brandonprry's fuzzing. The problems aren't that bad overall, so we decided to do this in public.

This addresses the test cases except for "id:000248,sig:11,src:004326,op:havoc,rep:16" which is a pure DoS issue that occurs simply because lots of huge bitmaps need to be processed. I'm not sure if we should add any safeguards for these kinds of things, as they tend to break.

The overall plan is to get this reviewed and merged fast, so that we can spin a new release quickly. So please review!