### PR TITLE
Fix overflow in strtod function

### DIFF
--- a/libass/ass_strtod.c
+++ b/libass/ass_strtod.c
@@ -225,7 +225,7 @@ ass_strtod(
     } else {
         expSign = 0;
     }
-    if (exp > maxExponent) {
+    if (exp > maxExponent || exp < 0) {
         exp = maxExponent;
         errno = ERANGE;
     }


### PR DESCRIPTION
Just fix this for now. We may drop ass_strtod completely, but this is still being discussed.
