### PR TITLE
ass_strtod fixes

### DIFF
--- a/libass/ass_strtod.c
+++ b/libass/ass_strtod.c
@@ -80,7 +80,8 @@ ass_strtod(
     )
 {
     int sign, fracExpSign, expSign;
-    double fraction, dblExp, *d;
+    double fraction, dblExp;
+    const double *d;
     register const char *p;
     register int c;
     size_t exp = 0;         /* Exponent read from "EX" field. */
@@ -274,7 +275,7 @@ expOverflow:
         }
     }
     dblExp = 1.0;
-    for (d = (double *) powersOf10; exp != 0; exp >>= 1, d += 1) {
+    for (d = powersOf10; exp != 0; exp >>= 1, d += 1) {
         if (exp & 01) {
             dblExp *= *d;
         }

--- a/libass/ass_strtod.c
+++ b/libass/ass_strtod.c
@@ -228,7 +228,9 @@ ass_strtod(
 
     if (exp > maxExponent) {
         exp = maxExponent;
-        errno = ERANGE;
+        if (fraction != 0.0) {
+            errno = ERANGE;
+        }
     }
     dblExp = 1.0;
     for (d = (double *) powersOf10; exp != 0; exp >>= 1, d += 1) {


### PR DESCRIPTION
Several fixes for `ass_strtod` including the buffer overrun #244.

Hm, now that I think about it, #244 is fixed by two of these commits in tandem. The crash should be fixed by the very first commit, and the wrong output value is fixed by 8df6e2f. How can I reword the commit messages to make this clear?

In the first commit, I assume that `size_t` is enough to hold any substring size, although I’ve been unable to find a guarantee of this in the C standard. I avoid `ptrdiff_t` because it definitely can overflow.

I’ve kept the code C90 because it’s rather self-contained and can be usefully reused in other projects.

With these changes, `ass_strtod` almost conforms to C90 assuming the `"C"` locale and IEEE double (or any other double that has appropriate mantissa and exponent limits). It can produce results that are off by an ulp and maybe more, but C doesn’t actually mandate the precision of decimal string-to-double conversions. The only other problem is that `errno` is not always set on overflow or underflow. For libass, this doesn’t matter, as we never check `errno` after a `ass_strtod` call anyway. As for C99 conformance, `ass_strtod` doesn’t even come close, as C99 added syntax for NaN, infinities and hexadecimal numbers to `strtod`, none of which is implemented in `ass_strtod`. I believe it _shouldn’t_ be, either, as ASS doesn’t support these syntaxes to the best of my knowledge.
