### PR TITLE
Only enable DirectWrite if the Dwrite.h header is found

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -190,7 +190,8 @@ if test x$enable_directwrite != xno; then
 AC_MSG_CHECKING([for DIRECTWRITE])
 AC_LINK_IFELSE([
   AC_LANG_PROGRAM(
-    [[#include <windows.h>]],
+    [[#include <windows.h>
+      #include <Dwrite.h>]],
     [[;]],)
   ], [
     AC_DEFINE(CONFIG_DIRECTWRITE, 1, [found DirectWrite])


### PR DESCRIPTION
Older Windows versions don't have this.