### PR TITLE
render: remove redundant has_clips

### DIFF
--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -406,25 +406,17 @@ render_glyph(ASS_Renderer *render_priv, Bitmap *bm, int dst_x, int dst_y,
     b_y1 = bm->h;
 
     tmp = dst_x - clip_x0;
-    if (tmp < 0) {
+    if (tmp < 0)
         b_x0 = -tmp;
-        render_priv->state.has_clips = 1;
-    }
     tmp = dst_y - clip_y0;
-    if (tmp < 0) {
+    if (tmp < 0)
         b_y0 = -tmp;
-        render_priv->state.has_clips = 1;
-    }
     tmp = clip_x1 - dst_x - bm->w;
-    if (tmp < 0) {
+    if (tmp < 0)
         b_x1 = bm->w + tmp;
-        render_priv->state.has_clips = 1;
-    }
     tmp = clip_y1 - dst_y - bm->h;
-    if (tmp < 0) {
+    if (tmp < 0)
         b_y1 = bm->h + tmp;
-        render_priv->state.has_clips = 1;
-    }
 
     if ((b_y0 >= b_y1) || (b_x0 >= b_x1))
         return tail;
@@ -522,8 +514,6 @@ static void blend_vector_clip(ASS_Renderer *render_priv,
         int bx, by, bw, bh, bs;
         int aleft, atop, bleft, btop;
         unsigned char *abuffer, *bbuffer, *nbuffer;
-
-        render_priv->state.has_clips = 1;
 
         abuffer = cur->bitmap;
         bbuffer = clip_bm->buffer;
@@ -882,7 +872,6 @@ init_render_context(ASS_Renderer *render_priv, ASS_Event *event)
 {
     render_priv->state.event = event;
     render_priv->state.parsed_tags = 0;
-    render_priv->state.has_clips = 0;
     render_priv->state.evt_type = EVENT_NORMAL;
 
     reset_render_context(render_priv, NULL);
@@ -2952,9 +2941,6 @@ static int ass_detect_change(ASS_Renderer *priv)
 {
     ASS_Image *img, *img2;
     int diff;
-
-    if (priv->state.has_clips)
-        return 2;
 
     img = priv->prev_images_root;
     img2 = priv->images_root;

--- a/libass/ass_render.h
+++ b/libass/ass_render.h
@@ -213,7 +213,6 @@ typedef struct {
     ASS_Event *event;
     ASS_Style *style;
     int parsed_tags;
-    int has_clips;              // clips that conflict with cache change detection
 
     ASS_Font *font;
     double font_size;


### PR DESCRIPTION
That variable was workaround for case when new frame images
reuse memory from previous frame images. Due to that reuse
physically different images could be indistinguishable in
ass_detect_change(). After cache PR such memory aliasing is
no longer possible and workaround is redundant.