### PR TITLE
Reflect border_scale in outline cache keys

### DIFF
--- a/libass/ass_cache_template.h
+++ b/libass/ass_cache_template.h
@@ -90,7 +90,7 @@ START(glyph, glyph_hash_key)
     GENERIC(int, italic)
     GENERIC(unsigned, scale_x) // 16.16
     GENERIC(unsigned, scale_y) // 16.16
-    FTVECTOR(outline) // border width, 16.16
+    FTVECTOR(outline) // border width, 26.6
     GENERIC(unsigned, flags)    // glyph decoration flags
     GENERIC(unsigned, border_style)
     GENERIC(int, hspacing) // 16.16

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -1084,8 +1084,8 @@ fill_glyph_hash(ASS_Renderer *priv, OutlineHashKey *outline_key,
         outline_key->type = OUTLINE_DRAWING;
         key->scale_x = double_to_d16(info->scale_x);
         key->scale_y = double_to_d16(info->scale_y);
-        key->outline.x = double_to_d16(info->border_x);
-        key->outline.y = double_to_d16(info->border_y);
+        key->outline.x = double_to_d16(info->border_x * priv->border_scale);
+        key->outline.y = double_to_d16(info->border_y * priv->border_scale);
         key->border_style = info->border_style;
         // hpacing only matters for opaque box borders (see draw_opaque_box),
         // so for normal borders, maximize cache utility by ignoring it
@@ -1106,8 +1106,8 @@ fill_glyph_hash(ASS_Renderer *priv, OutlineHashKey *outline_key,
         key->italic = info->italic;
         key->scale_x = double_to_d16(info->scale_x);
         key->scale_y = double_to_d16(info->scale_y);
-        key->outline.x = double_to_d16(info->border_x);
-        key->outline.y = double_to_d16(info->border_y);
+        key->outline.x = double_to_d16(info->border_x * priv->border_scale);
+        key->outline.y = double_to_d16(info->border_y * priv->border_scale);
         key->flags = info->flags;
         key->border_style = info->border_style;
         key->hspacing =

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -1084,8 +1084,8 @@ fill_glyph_hash(ASS_Renderer *priv, OutlineHashKey *outline_key,
         outline_key->type = OUTLINE_DRAWING;
         key->scale_x = double_to_d16(info->scale_x);
         key->scale_y = double_to_d16(info->scale_y);
-        key->outline.x = double_to_d16(info->border_x * priv->border_scale);
-        key->outline.y = double_to_d16(info->border_y * priv->border_scale);
+        key->outline.x = double_to_d6(info->border_x * priv->border_scale);
+        key->outline.y = double_to_d6(info->border_y * priv->border_scale);
         key->border_style = info->border_style;
         // hpacing only matters for opaque box borders (see draw_opaque_box),
         // so for normal borders, maximize cache utility by ignoring it
@@ -1106,8 +1106,8 @@ fill_glyph_hash(ASS_Renderer *priv, OutlineHashKey *outline_key,
         key->italic = info->italic;
         key->scale_x = double_to_d16(info->scale_x);
         key->scale_y = double_to_d16(info->scale_y);
-        key->outline.x = double_to_d16(info->border_x * priv->border_scale);
-        key->outline.y = double_to_d16(info->border_y * priv->border_scale);
+        key->outline.x = double_to_d6(info->border_x * priv->border_scale);
+        key->outline.y = double_to_d6(info->border_y * priv->border_scale);
         key->flags = info->flags;
         key->border_style = info->border_style;
         key->hspacing =


### PR DESCRIPTION
An actual example of breakage that this PR should fix was reported on IRC: when `ScaledBorderAndShadow` is changed in Aegisub, no difference is visible because the old outlines are fetched from the cache.