### PR TITLE
Integer overflow fixes

### DIFF
--- a/libass/ass.c
+++ b/libass/ass.c
@@ -1498,7 +1498,7 @@ void ass_lazy_track_init(ASS_Library *lib, ASS_Track *track)
             ass_msg(lib, MSGL_WARN,
                    "PlayResY undefined, setting to %d", track->PlayResY);
         } else if (track->PlayResY <= 0) {
-            track->PlayResY = FFMAX(1, track->PlayResX * 3 / 4);
+            track->PlayResY = FFMAX(1, track->PlayResX * 3LL / 4);
             ass_msg(lib, MSGL_WARN,
                    "PlayResY undefined, setting to %d", track->PlayResY);
         } else if (track->PlayResX <= 0 && track->PlayResY == 1024) {
@@ -1506,7 +1506,7 @@ void ass_lazy_track_init(ASS_Library *lib, ASS_Track *track)
             ass_msg(lib, MSGL_WARN,
                    "PlayResX undefined, setting to %d", track->PlayResX);
         } else if (track->PlayResX <= 0) {
-            track->PlayResX = FFMAX(1, track->PlayResY * 4 / 3);
+            track->PlayResX = FFMAX(1, track->PlayResY * 4LL / 3);
             ass_msg(lib, MSGL_WARN,
                    "PlayResX undefined, setting to %d", track->PlayResX);
         }

--- a/libass/ass_parse.c
+++ b/libass/ass_parse.c
@@ -176,11 +176,12 @@ inline void change_alpha(uint32_t *var, int32_t new, double pwr)
  * \param a first value
  * \param b second value
  * \return result of multiplication
- * Parameters and result are limited by 0xFF.
+ * At least one of the parameters must be less than or equal to 0xFF.
+ * The result is less than or equal to max(a, b, 0xFF).
  */
 inline uint32_t mult_alpha(uint32_t a, uint32_t b)
 {
-    return 0xFF - (0xFF - a) * (0xFF - b) / 0xFF;
+    return a - (uint64_t) a * b / 0xFF + b;
 }
 
 /**

--- a/libass/ass_parse.c
+++ b/libass/ass_parse.c
@@ -603,7 +603,12 @@ char *parse_tags(ASS_Renderer *render_priv, char *p, char *end, double pwr,
             if (t1 == -1 && t4 == -1) {
                 t1 = 0;
                 t4 = render_priv->state.event->Duration;
-                t3 = t4 - t3;
+                // The value we parsed in t3 is an offset from the event end.
+                // What we really want in t3 is an offset from the event start.
+                // To this end, set t3 to (event duration - parsed value).
+                // If t3 >= t4, the exact value of t3 will not matter,
+                // so clamp it to avoid overflow in the subtraction.
+                t3 = t4 - FFMAX(t3, 0);
             }
             if ((render_priv->state.parsed_tags & PARSED_FADE) == 0) {
                 render_priv->state.fade =

--- a/libass/ass_parse.c
+++ b/libass/ass_parse.c
@@ -181,7 +181,7 @@ inline void change_alpha(uint32_t *var, int32_t new, double pwr)
  */
 inline uint32_t mult_alpha(uint32_t a, uint32_t b)
 {
-    return a - (uint64_t) a * b / 0xFF + b;
+    return a - ((uint64_t) a * b + 0x7F) / 0xFF + b;
 }
 
 /**

--- a/libass/ass_parse.c
+++ b/libass/ass_parse.c
@@ -128,6 +128,17 @@ void update_font(ASS_Renderer *render_priv)
     render_priv->state.font = ass_font_new(render_priv, &desc);
 }
 
+/**
+ * \brief Convert double to int32_t without UB
+ * on out-of-range values; match x86 behavior
+ */
+static inline int32_t dtoi32(double val)
+{
+    if (isnan(val) || val <= INT32_MIN || val >= INT32_MAX + 1LL)
+        return INT32_MIN;
+    return val;
+}
+
 static double calc_anim(double new, double old, double pwr)
 {
    return (1 - pwr) * old + new * pwr;
@@ -135,13 +146,7 @@ static double calc_anim(double new, double old, double pwr)
 
 static int32_t calc_anim_int32(uint32_t new, uint32_t old, double pwr)
 {
-    double ret = calc_anim(new, old, pwr);
-
-    // Avoid UB on out-of-range values; match x86 behavior
-    if (isnan(ret) || ret < INT32_MIN || ret > INT32_MAX)
-        return INT32_MIN;
-
-    return ret;
+    return dtoi32(calc_anim(new, old, pwr));
 }
 
 /**

--- a/libass/ass_strtod.c
+++ b/libass/ass_strtod.c
@@ -259,7 +259,7 @@ ass_strtod(
             } else if (exp > ((size_t) -1 - (*p - '0')) / 10) {
                 expWraparound = 1;
             }
-            exp = exp * 10 + (*p - '0');
+            exp = exp * 10u + (*p - '0');
             p += 1;
         }
         if (expSign == fracExpSign) {

--- a/libass/ass_utils.c
+++ b/libass/ass_utils.c
@@ -154,14 +154,14 @@ void rskip_spaces(char **str, char *limit)
     *str = p;
 }
 
-static int read_digits(char **str, int base, uint32_t *res)
+static int read_digits(char **str, unsigned base, uint32_t *res)
 {
     char *p = *str;
     char *start = p;
     uint32_t val = 0;
 
     while (1) {
-        int digit;
+        unsigned digit;
         if (*p >= '0' && *p < FFMIN(base, 10) + '0')
             digit = *p - '0';
         else if (*p >= 'a' && *p < base - 10 + 'a')
@@ -184,7 +184,7 @@ static int read_digits(char **str, int base, uint32_t *res)
  * Follows the rules for strtoul but reduces the number modulo 2**32
  * instead of saturating it to 2**32 - 1.
  */
-static int mystrtou32_modulo(char **p, int base, uint32_t *res)
+static int mystrtou32_modulo(char **p, unsigned base, uint32_t *res)
 {
     // This emulates scanf with %d or %x format as it works on
     // Windows, because that's what is used by VSFilter. In practice,
@@ -240,7 +240,7 @@ uint32_t parse_color_tag(char *str)
 uint32_t parse_color_header(char *str)
 {
     uint32_t color = 0;
-    int base;
+    unsigned base;
 
     if (!ass_strncasecmp(str, "&h", 2) || !ass_strncasecmp(str, "0x", 2)) {
         str += 2;


### PR DESCRIPTION
A bunch of integer overflow fixes plus a few other fixes that I made along the way.

Unresolved issues:

  * Event timestamps can overflow `long long`. What should we do then? Saturate to LLONG_MIN/LLONG_MAX? This would be fine for the purposes of deciding which event to show when but could break animations that depend on the event duration. Then again, VSFilter doesn’t even support `long long` timestamps like we do. (It uses `int`. Which, of course, practically means `int32_t`.)

  * When `PlayResY` is set (to a positive value) but `PlayResX` isn’t, it is computed as ⁴⁄₃ × `PlayResY`. This value may not fit in `int`. What should we do then? VSFilter does `PlayResY * 4 / 3` (all in `LONG` aka `int32_t`) and doesn’t care. I forget if I’ve tested what actually happens then.