### PR TITLE
Travis CI improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ branches:
 
 before_install:
   - (sudo apt-get update || brew update)
-  - (sudo apt-get install -y libfontconfig1-dev libfribidi-dev yasm || (brew uninstall libtool; brew install freetype fribidi libtool yasm)) && ./autogen.sh && ./configure
+  - (sudo apt-get install -y libfontconfig1-dev libfreetype6-dev libfribidi-dev yasm || (brew uninstall libtool; brew install freetype fribidi libtool yasm)) && ./autogen.sh && ./configure
 script:
   - make -j4
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ branches:
 
 before_install:
   - (sudo apt-get update || brew update)
-  - (sudo apt-get install -y libfontconfig1-dev libfreetype6-dev libfribidi-dev yasm || brew install freetype fribidi yasm) && ./autogen.sh && ./configure
+  - (sudo apt-get install -y libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev yasm || brew install freetype fribidi harfbuzz yasm --without-gobject-introspection --without-icu4c) && ./autogen.sh && ./configure
 script:
   - make -j4
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ branches:
 
 before_install:
   - (sudo apt-get update || brew update)
-  - (sudo apt-get install -y libfontconfig1-dev libfreetype6-dev libfribidi-dev yasm || (brew uninstall libtool; brew install freetype fribidi libtool yasm)) && ./autogen.sh && ./configure
+  - (sudo apt-get install -y libfontconfig1-dev libfreetype6-dev libfribidi-dev yasm || brew install freetype fribidi yasm) && ./autogen.sh && ./configure
 script:
   - make -j4
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ branches:
 
 before_install:
   - (sudo apt-get update || brew update)
-  - (sudo apt-get install -y libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev yasm || (sed -i '' /fc-cache/d "$(brew --repository)/Library/Taps/homebrew/homebrew-core/Formula/fontconfig.rb"; brew install fontconfig freetype fribidi harfbuzz yasm)) && ./autogen.sh && ./configure
+  - (sudo apt-get install -y libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev yasm || brew install freetype fribidi yasm) && ./autogen.sh && ./configure
 script:
   - make -j4
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ branches:
 
 before_install:
   - (sudo apt-get update || brew update)
-  - (sudo apt-get install -y fontconfig libfribidi-dev yasm || (brew uninstall libtool; brew install freetype fribidi libtool yasm)) && ./autogen.sh && ./configure
+  - (sudo apt-get install -y libfontconfig1-dev libfribidi-dev yasm || (brew uninstall libtool; brew install freetype fribidi libtool yasm)) && ./autogen.sh && ./configure
 script:
   - make -j4
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ branches:
 
 before_install:
   - (sudo apt-get update || brew update)
-  - (sudo apt-get install -y libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev yasm || brew install freetype fribidi harfbuzz yasm --without-gobject-introspection --without-icu4c) && ./autogen.sh && ./configure
+  - (sudo apt-get install -y libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev yasm || (sed -i '' /fc-cache/d "$(brew --repository)/Library/Taps/homebrew/homebrew-core/Formula/fontconfig.rb"; brew install fontconfig freetype fribidi harfbuzz yasm)) && ./autogen.sh && ./configure
 script:
   - make -j4
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ branches:
 
 before_install:
   - (sudo apt-get update || brew update)
-  - (sudo apt-get install -y fontconfig libfribidi-dev yasm || (brew uninstall libtool; brew install fontconfig freetype fribidi libtool yasm)) && ./autogen.sh && ./configure
+  - (sudo apt-get install -y fontconfig libfribidi-dev yasm || (brew uninstall libtool; brew install freetype fribidi libtool yasm)) && ./autogen.sh && ./configure
 script:
   - make -j4
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,15 @@ os:
   - linux
   - osx
 
+compiler:
+  - gcc
+  - clang
+
+matrix:
+  exclude:
+    - os: osx
+      compiler: gcc
+
 sudo: required
 dist: trusty
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,4 +49,4 @@ addons:
     notification_email: none@example.com
     build_command_prepend: "./configure"
     build_command:   "make -j4"
-    branch_pattern: coverity_scan
+    branch_pattern: master|coverity_scan


### PR DESCRIPTION
  * Disable Fontconfig on OS X to speed up builds, as Homebrew insists on building Fontconfig’s cache when it’s installed.
  * Enable HarfBuzz.
  * Build with Clang on Linux in addition to GCC. (I assume that OS X builds will still use only Clang, but in any case it shouldn’t get any worse. There is an example in the docs that uses this configuration, so I hope it actually works.)
  * Clean up the command that installs dependencies.
  * Run Coverity Scan on every master build. We’re allowed “[up to 12 builds per week, with a maximum of 3 builds per day](https://scan.coverity.com/faq#frequency)” (assuming we still have less than 100,000 lines of code). Looking at [our build history](https://travis-ci.org/libass/libass/builds), we _may_ have reached 3 builds per day occasionally? but rarely.

~If this looks fine, I’ll try pushing this to branch `ci`. If all goes well, I will then push to `master`, but if not, I’d like to rewrite these commits via an interactive rebase and force-push `ci`. Is this OK?~

Oh wait, Travis will build this as a pull request anyway. No need to push to `ci` then.