### PR TITLE
directwrite: fix font collections

### DIFF
--- a/libass/ass_directwrite.c
+++ b/libass/ass_directwrite.c
@@ -352,6 +352,19 @@ static bool check_postscript(void *data)
 }
 
 /*
+ * Lazily return index of font. It requires the FontFace to be present, which is expensive to initialize.
+ */
+static unsigned get_font_index(void *data)
+{
+    FontPrivate *priv = (FontPrivate *)data;
+
+    if (!init_font_private_face(priv))
+        return 0;
+
+    return IDWriteFontFace_GetIndex(priv->face);
+}
+
+/*
  * Check if the passed font has a specific unicode character.
  */
 static bool check_glyph(void *data, uint32_t code)
@@ -719,6 +732,7 @@ static ASS_FontProviderFuncs directwrite_callbacks = {
     .destroy_provider   = destroy_provider,
     .get_substitutions  = get_substitutions,
     .get_fallback       = get_fallback,
+    .get_font_index     = get_font_index,
 };
 
 typedef HRESULT (WINAPI *DWriteCreateFactoryFn)(

--- a/libass/ass_fontselect.c
+++ b/libass/ass_fontselect.c
@@ -609,6 +609,11 @@ find_font(ASS_FontSelector *priv, ASS_Library *library,
             result = selected->path;
     }
 
+    // set up index, if lazy evaluation function exists
+    if (selected->provider->funcs.get_font_index) {
+        *index = selected->provider->funcs.get_font_index(selected->priv);
+    }
+
     return result;
 }
 

--- a/libass/ass_fontselect.h
+++ b/libass/ass_fontselect.h
@@ -71,6 +71,16 @@ typedef bool    (*CheckPostscriptFunc)(void *font_priv);
 typedef bool    (*CheckGlyphFunc)(void *font_priv, uint32_t codepoint);
 
 /**
+* Get index of a font in context of a font collection.
+* This function is optional and may be needed to initialize the font index
+* lazily.
+*
+* \param font_priv font private data
+* \return font index inside the collection, or 0 in case of a single font
+*/
+typedef unsigned    (*GetFontIndex)(void *font_priv);
+
+/**
  * Destroy a font's private data.
  *
  *  \param font_priv font private data
@@ -150,6 +160,7 @@ typedef struct font_provider_funcs {
     MatchFontsFunc      match_fonts;            /* optional */
     SubstituteFontFunc  get_substitutions;      /* optional */
     GetFallbackFunc     get_fallback;           /* optional */
+    GetFontIndex        get_font_index;         /* optional */
 } ASS_FontProviderFuncs;
 
 /*

--- a/libass/dwrite_c.h
+++ b/libass/dwrite_c.h
@@ -335,6 +335,8 @@ DECLARE_INTERFACE_(IDWriteFontFace,IUnknown)
         UINT32 *numberOfFiles,
         IDWriteFontFile **fontFiles) PURE;
 
+    STDMETHOD_(UINT32, GetIndex)(THIS) PURE;
+
     /* rest dropped */
     END_INTERFACE
 };
@@ -342,6 +344,7 @@ DECLARE_INTERFACE_(IDWriteFontFace,IUnknown)
 #define IDWriteFontFace_Release(This) (This)->lpVtbl->Release(This)
 #define IDWriteFontFace_GetType(This) (This)->lpVtbl->GetType(This)
 #define IDWriteFontFace_GetFiles(This,fontFiles,b) (This)->lpVtbl->GetFiles(This,fontFiles,b)
+#define IDWriteFontFace_GetIndex(This) (This)->lpVtbl->GetIndex(This)
 #endif /*COBJMACROS*/
 
 #undef  INTERFACE


### PR DESCRIPTION
DirectWrite's FontFileStream does not actually use the data of a specific
font in a collection, which was an expectation of the existing code. It
simply returns a stream to the underlying file, collection or not. So we
need to get the index of the font. This needs to be done lazily as this
information is only available in a FontFace, which is expensive to
initialize.

Add a new optional font provider function for lazy initialization of the
index and use it. This is similar to the check_postscript callback.

Fixes libass#275.