### PR TITLE
Update ouline internal representation

### DIFF
--- a/libass/ass_bitmap.c
+++ b/libass/ass_bitmap.c
@@ -202,13 +202,13 @@ Bitmap *outline_to_bitmap(ASS_Renderer *render_priv,
 
     if (bord < 0 || bord > INT_MAX / 2)
         return NULL;
-    if (rst->x_max > INT_MAX - 63 || rst->y_max > INT_MAX - 63)
+    if (rst->bbox.x_max > INT_MAX - 63 || rst->bbox.y_max > INT_MAX - 63)
         return NULL;
 
-    int x_min = rst->x_min >> 6;
-    int y_min = rst->y_min >> 6;
-    int x_max = (rst->x_max + 63) >> 6;
-    int y_max = (rst->y_max + 63) >> 6;
+    int x_min = rst->bbox.x_min >> 6;
+    int y_min = rst->bbox.y_min >> 6;
+    int x_max = (rst->bbox.x_max + 63) >> 6;
+    int y_max = (rst->bbox.y_max + 63) >> 6;
     int w = x_max - x_min;
     int h = y_max - y_min;
 

--- a/libass/ass_bitmap.h
+++ b/libass/ass_bitmap.h
@@ -24,6 +24,7 @@
 #include FT_GLYPH_H
 
 #include "ass.h"
+#include "ass_outline.h"
 
 
 struct segment;
@@ -87,8 +88,6 @@ extern const BitmapEngine ass_bitmap_engine_c;
 extern const BitmapEngine ass_bitmap_engine_sse2;
 extern const BitmapEngine ass_bitmap_engine_avx2;
 
-
-typedef struct ass_outline ASS_Outline;
 
 typedef struct {
     int left, top;

--- a/libass/ass_cache.h
+++ b/libass/ass_cache.h
@@ -45,8 +45,8 @@ typedef struct {
     bool valid;
     ASS_Outline outline;
     ASS_Outline border[2];
-    FT_BBox bbox_scaled;        // bbox after scaling, but before rotation
-    FT_Vector advance;          // 26.6, advance distance to the next outline in line
+    ASS_Rect bbox_scaled;       // bbox after scaling, but before rotation
+    ASS_Vector advance;         // 26.6, advance distance to the next outline in line
     int asc, desc;              // ascender/descender
 } OutlineHashValue;
 

--- a/libass/ass_cache_template.h
+++ b/libass/ass_cache_template.h
@@ -6,8 +6,8 @@
         type member;
 #define STRING(member) \
         char *member;
-#define FTVECTOR(member) \
-        FT_Vector member;
+#define VECTOR(member) \
+        ASS_Vector member;
 #define BITMAPHASHKEY(member) \
         BitmapHashKey member;
 #define END(typedefnamename) \
@@ -25,7 +25,7 @@
             a->member == b->member &&
 #define STRING(member) \
             strcmp(a->member, b->member) == 0 &&
-#define FTVECTOR(member) \
+#define VECTOR(member) \
             a->member.x == b->member.x && a->member.y == b->member.y &&
 #define BITMAPHASHKEY(member) \
             bitmap_compare(&a->member, &b->member, sizeof(a->member)) &&
@@ -44,7 +44,7 @@
         hval = fnv_32a_buf(&p->member, sizeof(p->member), hval);
 #define STRING(member) \
         hval = fnv_32a_str(p->member, hval);
-#define FTVECTOR(member) GENERIC(, member.x); GENERIC(, member.y);
+#define VECTOR(member) GENERIC(, member.x); GENERIC(, member.y);
 #define BITMAPHASHKEY(member) { \
         unsigned temp = bitmap_hash(&p->member, sizeof(p->member)); \
         hval = fnv_32a_buf(&temp, sizeof(temp), hval); \
@@ -72,7 +72,7 @@ START(outline_bitmap, outline_bitmap_hash_key)
     // = (glyph base point) - (rotation origin), otherwise
     GENERIC(int, shift_x)
     GENERIC(int, shift_y)
-    FTVECTOR(advance) // subpixel shift vector
+    VECTOR(advance) // subpixel shift vector
 END(OutlineBitmapHashKey)
 
 // describe a clip mask bitmap
@@ -90,7 +90,7 @@ START(glyph, glyph_hash_key)
     GENERIC(int, italic)
     GENERIC(unsigned, scale_x) // 16.16
     GENERIC(unsigned, scale_y) // 16.16
-    FTVECTOR(outline) // border width, 26.6
+    VECTOR(outline) // border width, 26.6
     GENERIC(unsigned, flags)    // glyph decoration flags
     GENERIC(unsigned, border_style)
     GENERIC(int, hspacing) // 16.16
@@ -110,7 +110,7 @@ START(drawing, drawing_hash_key)
     GENERIC(unsigned, scale_x)
     GENERIC(unsigned, scale_y)
     GENERIC(int, pbo)
-    FTVECTOR(outline)
+    VECTOR(outline)
     GENERIC(unsigned, border_style)
     GENERIC(int, hspacing)
     GENERIC(int, scale)
@@ -123,12 +123,12 @@ START(filter, filter_desc)
     GENERIC(int, flags)
     GENERIC(int, be)
     GENERIC(double, blur)
-    FTVECTOR(shadow)
+    VECTOR(shadow)
 END(FilterDesc)
 
 #undef START
 #undef GENERIC
 #undef STRING
-#undef FTVECTOR
+#undef VECTOR
 #undef BITMAPHASHKEY
 #undef END

--- a/libass/ass_drawing.c
+++ b/libass/ass_drawing.c
@@ -174,28 +174,15 @@ static void drawing_free_tokens(ASS_DrawingToken *token)
 }
 
 /*
- * \brief Update drawing cbox
- */
-static inline void update_cbox(ASS_Drawing *drawing, ASS_Vector *point)
-{
-    ASS_Rect *box = &drawing->cbox;
-
-    box->x_min = FFMIN(box->x_min, point->x);
-    box->x_max = FFMAX(box->x_max, point->x);
-    box->y_min = FFMIN(box->y_min, point->y);
-    box->y_max = FFMAX(box->y_max, point->y);
-}
-
-/*
  * \brief Translate and scale a point coordinate according to baseline
  * offset and scale.
  */
 static inline void translate_point(ASS_Drawing *drawing, ASS_Vector *point)
 {
-    point->x = drawing->point_scale_x * point->x;
-    point->y = drawing->point_scale_y * point->y;
+    point->x = lrint(drawing->point_scale_x * point->x);
+    point->y = lrint(drawing->point_scale_y * point->y);
 
-    update_cbox(drawing, point);
+    rectangle_update(&drawing->cbox, point->x, point->y, point->x, point->y);
 }
 
 /*
@@ -244,8 +231,7 @@ ASS_Drawing *ass_drawing_new(ASS_Library *lib)
     ASS_Drawing *drawing = calloc(1, sizeof(*drawing));
     if (!drawing)
         return NULL;
-    drawing->cbox.x_min = drawing->cbox.y_min = INT32_MAX;
-    drawing->cbox.x_max = drawing->cbox.y_max = INT32_MIN;
+    rectangle_reset(&drawing->cbox);
     drawing->library = lib;
     drawing->scale_x = 1.;
     drawing->scale_y = 1.;

--- a/libass/ass_drawing.c
+++ b/libass/ass_drawing.c
@@ -67,7 +67,7 @@ static void drawing_finish(ASS_Drawing *drawing, bool raw_mode)
 
     // Place it onto the baseline
     for (size_t i = 0; i < ol->n_points; i++)
-        ol->points[i].y += drawing->asc;
+        ol->points[i].y -= drawing->asc;
 }
 
 /*
@@ -193,7 +193,7 @@ static inline void update_cbox(ASS_Drawing *drawing, ASS_Vector *point)
 static inline void translate_point(ASS_Drawing *drawing, ASS_Vector *point)
 {
     point->x = drawing->point_scale_x * point->x;
-    point->y = drawing->point_scale_y * -point->y;
+    point->y = drawing->point_scale_y * point->y;
 
     update_cbox(drawing, point);
 }

--- a/libass/ass_drawing.h
+++ b/libass/ass_drawing.h
@@ -19,9 +19,6 @@
 #ifndef LIBASS_DRAWING_H
 #define LIBASS_DRAWING_H
 
-#include <ft2build.h>
-#include FT_OUTLINE_H
-
 #include "ass.h"
 #include "ass_outline.h"
 #include "ass_bitmap.h"
@@ -39,7 +36,7 @@ typedef enum {
 
 typedef struct ass_drawing_token {
     ASS_TokenType type;
-    FT_Vector point;
+    ASS_Vector point;
     struct ass_drawing_token *next;
     struct ass_drawing_token *prev;
 } ASS_DrawingToken;
@@ -48,26 +45,26 @@ typedef struct {
     char *text; // drawing string
     int scale;  // scale (1-64) for subpixel accuracy
     double pbo; // drawing will be shifted in y direction by this amount
-    double scale_x;     // FontScaleX
-    double scale_y;     // FontScaleY
-    int asc;            // ascender
-    int desc;           // descender
+    double scale_x;      // FontScaleX
+    double scale_y;      // FontScaleY
+    int asc;             // ascender
+    int desc;            // descender
     ASS_Outline outline; // target outline
-    FT_Vector advance;  // advance (from cbox)
-    int hash;           // hash value (for caching)
+    ASS_Vector advance;  // advance (from cbox)
+    int hash;            // hash value (for caching)
 
     // private
     ASS_Library *library;
     ASS_DrawingToken *tokens;    // tokenized drawing
     double point_scale_x;
     double point_scale_y;
-    FT_BBox cbox;   // bounding box, or let's say... VSFilter's idea of it
+    ASS_Rect cbox;   // bounding box, or let's say... VSFilter's idea of it
 } ASS_Drawing;
 
-ASS_Drawing *ass_drawing_new(ASS_Library *lib, FT_Library ftlib);
-void ass_drawing_free(ASS_Drawing* drawing);
-void ass_drawing_set_text(ASS_Drawing* drawing, char *str, size_t n);
-void ass_drawing_hash(ASS_Drawing* drawing);
-ASS_Outline *ass_drawing_parse(ASS_Drawing *drawing, int raw_mode);
+ASS_Drawing *ass_drawing_new(ASS_Library *lib);
+void ass_drawing_free(ASS_Drawing *drawing);
+void ass_drawing_set_text(ASS_Drawing *drawing, char *str, size_t n);
+void ass_drawing_hash(ASS_Drawing *drawing);
+ASS_Outline *ass_drawing_parse(ASS_Drawing *drawing, bool raw_mode);
 
 #endif /* LIBASS_DRAWING_H */

--- a/libass/ass_outline.c
+++ b/libass/ass_outline.c
@@ -284,15 +284,17 @@ void outline_translate(const ASS_Outline *outline, int32_t dx, int32_t dy)
     }
 }
 
-void outline_transform(const ASS_Outline *outline, const FT_Matrix *matrix)
+void outline_adjust(const ASS_Outline *outline, double scale_x, int32_t dx, int32_t dy)
 {
+    int32_t mul = lrint(scale_x * 0x10000);
+    if (mul == 0x10000) {
+        outline_translate(outline, dx, dy);
+        return;
+    }
     for (size_t i = 0; i < outline->n_points; i++) {
-        int32_t x = FT_MulFix(outline->points[i].x, matrix->xx) +
-                    FT_MulFix(outline->points[i].y, matrix->xy);
-        int32_t y = FT_MulFix(outline->points[i].x, matrix->yx) +
-                    FT_MulFix(outline->points[i].y, matrix->yy);
-        outline->points[i].x = x;
-        outline->points[i].y = y;
+        int32_t x = (int64_t) outline->points[i].x * mul >> 16;
+        outline->points[i].x = x + dx;
+        outline->points[i].y += dy;
     }
 }
 

--- a/libass/ass_outline.c
+++ b/libass/ass_outline.c
@@ -216,12 +216,12 @@ void outline_get_cbox(const ASS_Outline *outline, FT_BBox *cbox)
  * For splines algorithm first tries to offset individual points,
  * then estimates error of such approximation and subdivide recursively if necessary.
  *
- * List of problems that need to be solved:
+ * List of border cases handled by this algorithm:
  * 1) Too close points lead to random derivatives or even division by zero.
  *    Algorithm solves that by merging such points into one.
- * 2) Degenerate cases--near zero derivative in some spline points.
+ * 2) Degenerate cases--near zero derivative at some spline points.
  *    Algorithm adds circular cap in such cases.
- * 3) Negative curvative--offset amount is larger than spline curvative.
+ * 3) Negative curvature--offset amount is larger than radius of curvature.
  *    Algorithm checks if produced splines can potentially have self-intersection
  *    and handles them accordingly. It's mostly done by skipping
  *    problematic spline and replacing it with polyline that covers only
@@ -237,8 +237,8 @@ void outline_get_cbox(const ASS_Outline *outline, FT_BBox *cbox)
  * 2) Multiplication of B-splines of order N and M is B-spline of order N+M.
  * 3) B-spline is fully contained inside convex hull of its control points.
  *
- * So, for radial error its possible to check only control points of
- * offset spline multiplication by itself. And for angular error its
+ * So, for radial error it's possible to check only control points of
+ * offset spline multiplication by itself. And for angular error it's
  * possible to check control points of cross and dot product between
  * offset spline and derivative spline.
  */
@@ -495,7 +495,7 @@ static bool start_segment(StrokerState *str, OutlinePoint pt,
     }
     str->last_normal = normal;
 
-    // check for negative curvative
+    // check for negative curvature
     double s = vec_crs(prev, normal);
     int skip_dir = s < 0 ? 1 : 2;
     if (dir & skip_dir) {

--- a/libass/ass_outline.h
+++ b/libass/ass_outline.h
@@ -37,20 +37,41 @@ typedef struct {
     int32_t x_min, y_min, x_max, y_max;
 } ASS_Rect;
 
-typedef struct ass_outline {
-    size_t n_contours, max_contours;
-    size_t *contours;
+/*
+ * Outline represented with array of points and array of segments.
+ * Segment here is spline of order 1 (line), 2 (quadratic) or 3 (cubic).
+ * Each segment owns number of points equal to its order in point array
+ * and uses first point owned by the next segment as last point.
+ * Last segment in each contour instead of the next segment point uses
+ * point owned by the first segment in that contour. Correspondingly
+ * total number of points is equal to the sum of spline orders of all segments.
+ */
+
+enum {
+    OUTLINE_LINE_SEGMENT     = 1,  // line segment
+    OUTLINE_QUADRATIC_SPLINE = 2,  // quadratic spline
+    OUTLINE_CUBIC_SPLINE     = 3,  // cubic spline
+    OUTLINE_COUNT_MASK       = 3,  // spline order mask
+    OUTLINE_CONTOUR_END      = 4   // last segment in contour flag
+};
+
+typedef struct {
     size_t n_points, max_points;
+    size_t n_segments, max_segments;
     ASS_Vector *points;
-    char *tags;
+    char *segments;
 } ASS_Outline;
 
-bool outline_alloc(ASS_Outline *outline, size_t n_points, size_t n_contours);
+#define OUTLINE_MIN  (-((int32_t) 1 << 28))
+#define OUTLINE_MAX  (((int32_t) 1 << 28) - 1)
+
+bool outline_alloc(ASS_Outline *outline, size_t n_points, size_t n_segments);
 bool outline_convert(ASS_Outline *outline, const FT_Outline *source);
 bool outline_copy(ASS_Outline *outline, const ASS_Outline *source);
 void outline_free(ASS_Outline *outline);
 
-bool outline_add_point(ASS_Outline *outline, ASS_Vector pt, char tag);
+bool outline_add_point(ASS_Outline *outline, ASS_Vector pt, char segment);
+bool outline_add_segment(ASS_Outline *outline, char segment);
 bool outline_close_contour(ASS_Outline *outline);
 
 void outline_translate(const ASS_Outline *outline, int32_t dx, int32_t dy);

--- a/libass/ass_outline.h
+++ b/libass/ass_outline.h
@@ -22,13 +22,26 @@
 #include <ft2build.h>
 #include FT_OUTLINE_H
 #include <stdbool.h>
+#include <stdint.h>
 
+
+typedef struct {
+    int32_t x, y;
+} ASS_Vector;
+
+typedef struct {
+    double x, y;
+} ASS_DVector;
+
+typedef struct {
+    int32_t x_min, y_min, x_max, y_max;
+} ASS_Rect;
 
 typedef struct ass_outline {
     size_t n_contours, max_contours;
     size_t *contours;
     size_t n_points, max_points;
-    FT_Vector *points;
+    ASS_Vector *points;
     char *tags;
 } ASS_Outline;
 
@@ -37,13 +50,12 @@ bool outline_convert(ASS_Outline *outline, const FT_Outline *source);
 bool outline_copy(ASS_Outline *outline, const ASS_Outline *source);
 void outline_free(ASS_Outline *outline);
 
-bool outline_add_point(ASS_Outline *outline, FT_Vector pt, char tag);
+bool outline_add_point(ASS_Outline *outline, ASS_Vector pt, char tag);
 bool outline_close_contour(ASS_Outline *outline);
 
-void outline_translate(const ASS_Outline *outline, FT_Pos dx, FT_Pos dy);
-void outline_transform(const ASS_Outline *outline, const FT_Matrix *matrix);
-void outline_update_cbox(const ASS_Outline *outline, FT_BBox *cbox);
-void outline_get_cbox(const ASS_Outline *outline, FT_BBox *cbox);
+void outline_translate(const ASS_Outline *outline, int32_t dx, int32_t dy);
+void outline_transform(const ASS_Outline *outline, const FT_Matrix *matrix);  // XXX: replace with outline_scale
+void outline_get_cbox(const ASS_Outline *outline, ASS_Rect *cbox);
 
 bool outline_stroke(ASS_Outline *result, ASS_Outline *result1,
                     const ASS_Outline *path, int xbord, int ybord, int eps);

--- a/libass/ass_outline.h
+++ b/libass/ass_outline.h
@@ -24,6 +24,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "ass_utils.h"
+
 
 typedef struct {
     int32_t x, y;
@@ -40,6 +42,21 @@ typedef struct {
 typedef struct {
     double x_min, y_min, x_max, y_max;
 } ASS_DRect;
+
+static inline void rectangle_reset(ASS_Rect *rect)
+{
+    rect->x_min = rect->y_min = INT32_MAX;
+    rect->x_max = rect->y_max = INT32_MIN;
+}
+
+static inline void rectangle_update(ASS_Rect *rect,
+    int32_t x_min, int32_t y_min, int32_t x_max, int32_t y_max)
+{
+    rect->x_min = FFMIN(rect->x_min, x_min);
+    rect->y_min = FFMIN(rect->y_min, y_min);
+    rect->x_max = FFMAX(rect->x_max, x_max);
+    rect->y_max = FFMAX(rect->y_max, y_max);
+}
 
 /*
  * Outline represented with array of points and array of segments.

--- a/libass/ass_outline.h
+++ b/libass/ass_outline.h
@@ -75,7 +75,7 @@ bool outline_add_segment(ASS_Outline *outline, char segment);
 bool outline_close_contour(ASS_Outline *outline);
 
 void outline_translate(const ASS_Outline *outline, int32_t dx, int32_t dy);
-void outline_transform(const ASS_Outline *outline, const FT_Matrix *matrix);  // XXX: replace with outline_scale
+void outline_adjust(const ASS_Outline *outline, double scale_x, int32_t dx, int32_t dy);
 void outline_get_cbox(const ASS_Outline *outline, ASS_Rect *cbox);
 
 bool outline_stroke(ASS_Outline *result, ASS_Outline *result1,

--- a/libass/ass_outline.h
+++ b/libass/ass_outline.h
@@ -37,6 +37,10 @@ typedef struct {
     int32_t x_min, y_min, x_max, y_max;
 } ASS_Rect;
 
+typedef struct {
+    double x_min, y_min, x_max, y_max;
+} ASS_DRect;
+
 /*
  * Outline represented with array of points and array of segments.
  * Segment here is spline of order 1 (line), 2 (quadratic) or 3 (cubic).

--- a/libass/ass_parse.c
+++ b/libass/ass_parse.c
@@ -211,8 +211,7 @@ static int parse_vector_clip(ASS_Renderer *render_priv,
     struct arg text = args[nargs - 1];
 
     ass_drawing_free(drawing);
-    render_priv->state.clip_drawing =
-        ass_drawing_new(render_priv->library, render_priv->ftlibrary);
+    render_priv->state.clip_drawing = ass_drawing_new(render_priv->library);
     drawing = render_priv->state.clip_drawing;
     if (drawing) {
         drawing->scale = scale;
@@ -957,8 +956,8 @@ void process_karaoke_effects(ASS_Renderer *render_priv)
                 x_start = 1000000;
                 x_end = -1000000;
                 for (cur2 = s1; cur2 <= e1; ++cur2) {
-                    x_start = FFMIN(x_start, d6_to_int(cur2->bbox.xMin + cur2->pos.x));
-                    x_end = FFMAX(x_end, d6_to_int(cur2->bbox.xMax + cur2->pos.x));
+                    x_start = FFMIN(x_start, d6_to_int(cur2->bbox.x_min + cur2->pos.x));
+                    x_end = FFMAX(x_end, d6_to_int(cur2->bbox.x_max + cur2->pos.x));
                 }
 
                 dt = (tm_current - tm_start);

--- a/libass/ass_rasterizer.c
+++ b/libass/ass_rasterizer.c
@@ -117,18 +117,14 @@ void rasterizer_done(RasterizerData *rst)
  */
 
 
-typedef struct {
-    int32_t x, y;
-} OutlinePoint;
-
 // Helper struct for spline split decision
 typedef struct {
-    OutlinePoint r;
+    ASS_Vector r;
     int64_t r2, er;
 } OutlineSegment;
 
 static inline void segment_init(OutlineSegment *seg,
-                                OutlinePoint beg, OutlinePoint end,
+                                ASS_Vector beg, ASS_Vector end,
                                 int32_t outline_error)
 {
     int32_t x = end.x - beg.x;
@@ -143,7 +139,7 @@ static inline void segment_init(OutlineSegment *seg,
 }
 
 static inline bool segment_subdivide(const OutlineSegment *seg,
-                                     OutlinePoint beg, OutlinePoint pt)
+                                     ASS_Vector beg, ASS_Vector pt)
 {
     int32_t x = pt.x - beg.x;
     int32_t y = pt.y - beg.y;
@@ -156,7 +152,7 @@ static inline bool segment_subdivide(const OutlineSegment *seg,
 /**
  * \brief Add new segment to polyline
  */
-static bool add_line(RasterizerData *rst, OutlinePoint pt0, OutlinePoint pt1)
+static bool add_line(RasterizerData *rst, ASS_Vector pt0, ASS_Vector pt1)
 {
     int32_t x = pt1.x - pt0.x;
     int32_t y = pt1.y - pt0.y;
@@ -203,14 +199,14 @@ static bool add_line(RasterizerData *rst, OutlinePoint pt0, OutlinePoint pt1)
  * \brief Add quadratic spline to polyline
  * Performs recursive subdivision if necessary.
  */
-static bool add_quadratic(RasterizerData *rst, const OutlinePoint *pt)
+static bool add_quadratic(RasterizerData *rst, const ASS_Vector *pt)
 {
     OutlineSegment seg;
     segment_init(&seg, pt[0], pt[2], rst->outline_error);
     if (!segment_subdivide(&seg, pt[0], pt[1]))
         return add_line(rst, pt[0], pt[2]);
 
-    OutlinePoint next[5];
+    ASS_Vector next[5];
     next[1].x = pt[0].x + pt[1].x;
     next[1].y = pt[0].y + pt[1].y;
     next[3].x = pt[1].x + pt[2].x;
@@ -230,14 +226,14 @@ static bool add_quadratic(RasterizerData *rst, const OutlinePoint *pt)
  * \brief Add cubic spline to polyline
  * Performs recursive subdivision if necessary.
  */
-static bool add_cubic(RasterizerData *rst, const OutlinePoint *pt)
+static bool add_cubic(RasterizerData *rst, const ASS_Vector *pt)
 {
     OutlineSegment seg;
     segment_init(&seg, pt[0], pt[3], rst->outline_error);
     if (!segment_subdivide(&seg, pt[0], pt[1]) && !segment_subdivide(&seg, pt[0], pt[2]))
         return add_line(rst, pt[0], pt[3]);
 
-    OutlinePoint next[7], center;
+    ASS_Vector next[7], center;
     next[1].x = pt[0].x + pt[1].x;
     next[1].y = pt[0].y + pt[1].y;
     center.x = pt[1].x + pt[2].x + 2;
@@ -278,7 +274,7 @@ bool rasterizer_set_outline(RasterizerData *rst,
     }
     rst->size[0] = rst->n_first;
     for (size_t i = 0, j = 0; i < path->n_contours; i++) {
-        OutlinePoint start, p[4];
+        ASS_Vector start, p[4];
         int process_end = 1;
         enum Status st;
 

--- a/libass/ass_rasterizer.c
+++ b/libass/ass_rasterizer.c
@@ -282,15 +282,14 @@ bool rasterizer_set_outline(RasterizerData *rst,
         if (j > last)
             return false;
 
-        if (path->points[j].x <  -(1 << 28) || path->points[j].x >= (1 << 28))
+        if (path->points[j].x < -(1 << 28) || path->points[j].x >= (1 << 28))
             return false;
-        if (path->points[j].y <= -(1 << 28) || path->points[j].y >  (1 << 28))
+        if (path->points[j].y < -(1 << 28) || path->points[j].y >= (1 << 28))
             return false;
 
         switch (FT_CURVE_TAG(path->tags[j])) {
         case FT_CURVE_TAG_ON:
-            p[0].x =  path->points[j].x;
-            p[0].y = -path->points[j].y;
+            p[0] = path->points[j];
             start = p[0];
             st = S_ON;
             break;
@@ -298,19 +297,16 @@ bool rasterizer_set_outline(RasterizerData *rst,
         case FT_CURVE_TAG_CONIC:
             switch (FT_CURVE_TAG(path->tags[last])) {
             case FT_CURVE_TAG_ON:
-                p[0].x =  path->points[last].x;
-                p[0].y = -path->points[last].y;
-                p[1].x =  path->points[j].x;
-                p[1].y = -path->points[j].y;
+                p[0] = path->points[last];
+                p[1] = path->points[j];
                 process_end = 0;
                 st = S_Q;
                 break;
 
             case FT_CURVE_TAG_CONIC:
-                p[1].x =  path->points[j].x;
-                p[1].y = -path->points[j].y;
+                p[1] = path->points[j];
                 p[0].x = (p[1].x + path->points[last].x) >> 1;
-                p[0].y = (p[1].y - path->points[last].y) >> 1;
+                p[0].y = (p[1].y + path->points[last].y) >> 1;
                 start = p[0];
                 st = S_Q;
                 break;
@@ -325,25 +321,23 @@ bool rasterizer_set_outline(RasterizerData *rst,
         }
 
         for (j++; j <= last; j++) {
-            if (path->points[j].x <  -(1 << 28) || path->points[j].x >= (1 << 28))
+            if (path->points[j].x < -(1 << 28) || path->points[j].x >= (1 << 28))
                 return false;
-            if (path->points[j].y <= -(1 << 28) || path->points[j].y >  (1 << 28))
+            if (path->points[j].y < -(1 << 28) || path->points[j].y >= (1 << 28))
                 return false;
 
             switch (FT_CURVE_TAG(path->tags[j])) {
             case FT_CURVE_TAG_ON:
                 switch (st) {
                 case S_ON:
-                    p[1].x =  path->points[j].x;
-                    p[1].y = -path->points[j].y;
+                    p[1] = path->points[j];
                     if (!add_line(rst, p[0], p[1]))
                         return false;
                     p[0] = p[1];
                     break;
 
                 case S_Q:
-                    p[2].x =  path->points[j].x;
-                    p[2].y = -path->points[j].y;
+                    p[2] = path->points[j];
                     if (!add_quadratic(rst, p))
                         return false;
                     p[0] = p[2];
@@ -351,8 +345,7 @@ bool rasterizer_set_outline(RasterizerData *rst,
                     break;
 
                 case S_C2:
-                    p[3].x =  path->points[j].x;
-                    p[3].y = -path->points[j].y;
+                    p[3] = path->points[j];
                     if (!add_cubic(rst, p))
                         return false;
                     p[0] = p[3];
@@ -367,14 +360,12 @@ bool rasterizer_set_outline(RasterizerData *rst,
             case FT_CURVE_TAG_CONIC:
                 switch (st) {
                 case S_ON:
-                    p[1].x =  path->points[j].x;
-                    p[1].y = -path->points[j].y;
+                    p[1] = path->points[j];
                     st = S_Q;
                     break;
 
                 case S_Q:
-                    p[3].x =  path->points[j].x;
-                    p[3].y = -path->points[j].y;
+                    p[3] = path->points[j];
                     p[2].x = (p[1].x + p[3].x) >> 1;
                     p[2].y = (p[1].y + p[3].y) >> 1;
                     if (!add_quadratic(rst, p))
@@ -391,14 +382,12 @@ bool rasterizer_set_outline(RasterizerData *rst,
             case FT_CURVE_TAG_CUBIC:
                 switch (st) {
                 case S_ON:
-                    p[1].x =  path->points[j].x;
-                    p[1].y = -path->points[j].y;
+                    p[1] = path->points[j];
                     st = S_C1;
                     break;
 
                 case S_C1:
-                    p[2].x =  path->points[j].x;
-                    p[2].y = -path->points[j].y;
+                    p[2] = path->points[j];
                     st = S_C2;
                     break;
 

--- a/libass/ass_rasterizer.h
+++ b/libass/ass_rasterizer.h
@@ -46,7 +46,7 @@ typedef struct {
     int outline_error;  // acceptable error (in 1/64 pixel units)
 
     // usable after rasterizer_set_outline
-    int32_t x_min, x_max, y_min, y_max;
+    ASS_Rect bbox;
 
     // internal buffers
     struct segment *linebuf[2];

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -2034,18 +2034,11 @@ static void calculate_rotation_params(ASS_Renderer *render_priv, ASS_DRect *bbox
 }
 
 
-static inline void rectangle_reset(ASS_Rect *rect)
-{
-    rect->x_min = rect->y_min = INT32_MAX;
-    rect->x_max = rect->y_max = INT32_MIN;
-}
-
 static inline void rectangle_combine(ASS_Rect *rect, const Bitmap *bm, int x, int y)
 {
-    rect->x_min = FFMIN(rect->x_min, x + bm->left);
-    rect->y_min = FFMIN(rect->y_min, y + bm->top);
-    rect->x_max = FFMAX(rect->x_max, x + bm->left + bm->w);
-    rect->y_max = FFMAX(rect->y_max, y + bm->top + bm->h);
+    x += bm->left;
+    y += bm->top;
+    rectangle_update(rect, x, y, x + bm->w, y + bm->h);
 }
 
 // Convert glyphs to bitmaps, combine them, apply blur, generate shadows.

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -943,14 +943,20 @@ static void draw_opaque_box(ASS_Renderer *render_priv, GlyphInfo *info,
         { .x = -sx,         .y = desc + sy },
     };
 
-    ol->n_points = ol->n_contours = 0;
-    if (!outline_alloc(ol, 4, 1))
+    const char segments[4] = {
+        OUTLINE_LINE_SEGMENT,
+        OUTLINE_LINE_SEGMENT,
+        OUTLINE_LINE_SEGMENT,
+        OUTLINE_LINE_SEGMENT | OUTLINE_CONTOUR_END
+    };
+
+    ol->n_points = ol->n_segments = 0;
+    if (!outline_alloc(ol, 4, 4))
         return;
-    for (int i = 0; i < 4; ++i) {
-        ol->points[ol->n_points] = points[i];
-        ol->tags[ol->n_points++] = FT_CURVE_TAG_ON;
+    for (int i = 0; i < 4; i++) {
+        ol->points[ol->n_points++] = points[i];
+        ol->segments[ol->n_segments++] = segments[i];
     }
-    ol->contours[ol->n_contours++] = ol->n_points - 1;
 }
 
 /**
@@ -1088,8 +1094,8 @@ get_outline_glyph(ASS_Renderer *priv, GlyphInfo *info)
             int xbord = double_to_d6(info->border_x * priv->border_scale);
             int ybord = double_to_d6(info->border_y * priv->border_scale);
             if(xbord >= eps || ybord >= eps) {
-                outline_alloc(&val->border[0], 2 * val->outline.n_points, val->outline.n_contours);
-                outline_alloc(&val->border[1], 2 * val->outline.n_points, val->outline.n_contours);
+                outline_alloc(&val->border[0], 2 * val->outline.n_points, 2 * val->outline.n_segments);
+                outline_alloc(&val->border[1], 2 * val->outline.n_points, 2 * val->outline.n_segments);
                 if (!val->border[0].max_points || !val->border[1].max_points ||
                         !outline_stroke(&val->border[0], &val->border[1],
                                         &val->outline, xbord, ybord, eps)) {

--- a/libass/ass_render.h
+++ b/libass/ass_render.h
@@ -57,11 +57,6 @@ typedef struct {
 } DBBox;
 
 typedef struct {
-    double x;
-    double y;
-} DVector;
-
-typedef struct {
     ASS_Image result;
     CompositeHashValue *source;
     size_t ref_count;
@@ -106,11 +101,6 @@ typedef enum {
     EF_KARAOKE_KO
 } Effect;
 
-typedef struct
-{
-    int x_min, y_min, x_max, y_max;
-} Rectangle;
-
 // describes a combined bitmap
 typedef struct {
     FilterDesc filter;
@@ -126,7 +116,7 @@ typedef struct {
     BitmapRef *bitmaps;
 
     int x, y;
-    Rectangle rect, rect_o;
+    ASS_Rect rect, rect_o;
     size_t n_bm, n_bm_o;
 
     Bitmap *bm, *bm_o, *bm_s;   // glyphs, outline, shadow bitmaps
@@ -150,13 +140,13 @@ typedef struct glyph_info {
     ASS_Drawing *drawing;
     ASS_Outline *outline;
     ASS_Outline *border[2];
-    FT_BBox bbox;
-    FT_Vector pos;
-    FT_Vector offset;
+    ASS_Rect bbox;
+    ASS_Vector pos;
+    ASS_Vector offset;
     char linebreak;             // the first (leading) glyph of some line ?
     uint32_t c[4];              // colors
-    FT_Vector advance;          // 26.6
-    FT_Vector cluster_advance;
+    ASS_Vector advance;         // 26.6
+    ASS_Vector cluster_advance;
     char effect;                // the first (leading) glyph of some effect ?
     Effect effect_type;
     int effect_timing;          // time duration of current karaoke word

--- a/libass/ass_render.h
+++ b/libass/ass_render.h
@@ -50,13 +50,6 @@
 #define PARSED_A    (1<<1)
 
 typedef struct {
-    double xMin;
-    double xMax;
-    double yMin;
-    double yMax;
-} DBBox;
-
-typedef struct {
     ASS_Image result;
     CompositeHashValue *source;
     size_t ref_count;


### PR DESCRIPTION
This PR mainly do the following things:

- replaces `FT_Vector`, `FT_BBox`, `FT_Pos` with fixed size types based on `int32_t`;
- uses libass native coordinates in outlines instead of FreeType's reversed Y axis;
- simplifies outline internal format for more straightforward processing;
- consolidates similar types and functions from different files.

The main goal of this PR is to simplify code and there shouldn't be any difference in rendering results.