### PR TITLE
Fix crash due to stale pointers in font cache after ass_set_fonts

### DIFF
--- a/libass/Makefile.am
+++ b/libass/Makefile.am
@@ -1,6 +1,7 @@
 AM_CFLAGS = -std=gnu99 -Wall -Wextra -Wno-sign-compare -Wno-unused-parameter \
             -Werror-implicit-function-declaration -Wstrict-prototypes        \
-            -Wpointer-arith -Wredundant-decls -D_GNU_SOURCE
+            -Wpointer-arith -Wredundant-decls -Wno-missing-field-initializers\
+            -D_GNU_SOURCE
 
 LIBASS_LT_CURRENT = 9
 LIBASS_LT_REVISION = 1

--- a/libass/ass_outline.h
+++ b/libass/ass_outline.h
@@ -22,15 +22,16 @@
 #include <ft2build.h>
 #include FT_OUTLINE_H
 #include <stdbool.h>
+#include "ass_bitmap.h"
 
 
-typedef struct ass_outline {
+struct ass_outline {
     size_t n_contours, max_contours;
     size_t *contours;
     size_t n_points, max_points;
     FT_Vector *points;
     char *tags;
-} ASS_Outline;
+};
 
 bool outline_alloc(ASS_Outline *outline, size_t n_points, size_t n_contours);
 bool outline_convert(ASS_Outline *outline, const FT_Outline *source);

--- a/libass/ass_render_api.c
+++ b/libass/ass_render_api.c
@@ -146,6 +146,10 @@ void ass_set_fonts(ASS_Renderer *priv, const char *default_font,
 
     ass_reconfigure(priv);
 
+    ass_cache_empty(priv->cache.font_cache);
+    if (priv->shaper)
+        ass_shaper_empty_cache(priv->shaper);
+
     if (priv->fontselect)
         ass_fontselect_free(priv->fontselect);
     priv->fontselect = ass_fontselect_init(priv->library, priv->ftlibrary,

--- a/libass/ass_shaper.c
+++ b/libass/ass_shaper.c
@@ -121,6 +121,13 @@ void ass_shaper_free(ASS_Shaper *shaper)
     free(shaper);
 }
 
+void ass_shaper_empty_cache(ASS_Shaper *shaper)
+{
+#ifdef CONFIG_HARFBUZZ
+    ass_cache_empty(shaper->metrics_cache);
+#endif
+}
+
 void ass_shaper_font_data_free(ASS_ShaperFontData *priv)
 {
 #ifdef CONFIG_HARFBUZZ

--- a/libass/ass_shaper.h
+++ b/libass/ass_shaper.h
@@ -27,6 +27,7 @@ typedef struct ass_shaper ASS_Shaper;
 void ass_shaper_info(ASS_Library *lib);
 ASS_Shaper *ass_shaper_new(size_t prealloc);
 void ass_shaper_free(ASS_Shaper *shaper);
+void ass_shaper_empty_cache(ASS_Shaper *shaper);
 void ass_shaper_set_kerning(ASS_Shaper *shaper, int kern);
 void ass_shaper_find_runs(ASS_Shaper *shaper, ASS_Renderer *render_priv,
                           GlyphInfo *glyphs, size_t len);


### PR DESCRIPTION
I'm kinda confused as to why this doesn't cause more problems.

Also some warning fixes.