### PR TITLE
Fix CoreText font provider in GCC and on old Mac OS X

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -163,7 +163,7 @@ OLDLIBS="$LIBS"
 # Linking to CoreText directly only works from Mountain Lion and iOS6. In
 # earlier OS releases CoreText was part of the ApplicationServices umbrella
 # framework.
-LIBS="$LIBS -framework CoreText -framework CoreFoundation -framework CoreGraphics"
+LIBS="$LIBS -framework CoreText -framework CoreFoundation"
 AC_MSG_CHECKING([for CORETEXT])
 AC_LINK_IFELSE([
   AC_LANG_PROGRAM(

--- a/configure.ac
+++ b/configure.ac
@@ -159,24 +159,33 @@ fi
 AM_CONDITIONAL([FONTCONFIG], [test x$fontconfig = xtrue])
 
 if test x$enable_coretext != xno; then
-OLDLIBS="$LIBS"
-# Linking to CoreText directly only works from Mountain Lion and iOS6. In
-# earlier OS releases CoreText was part of the ApplicationServices umbrella
-# framework.
-LIBS="$LIBS -framework CoreText -framework CoreFoundation"
+# Linking to CoreText directly only works from Mountain Lion and iOS.
+# In earlier OS X releases CoreText was part of the ApplicationServices
+# umbrella framework.
 AC_MSG_CHECKING([for CORETEXT])
-AC_LINK_IFELSE([
+AC_COMPILE_IFELSE([
   AC_LANG_PROGRAM(
-    [[#include <CoreText/CoreText.h>]],
-    [[CTFontCreateWithFontDescriptor(NULL, 0.0, NULL);]],)
+    [[#include <ApplicationServices/ApplicationServices.h>]],
+    [[CTFontDescriptorCopyAttribute(NULL, kCTFontURLAttribute);]])
   ], [
-    AC_DEFINE(CONFIG_CORETEXT, 1, [found CoreText in System library])
+    LIBS="$LIBS -framework ApplicationServices -framework CoreFoundation"
+    AC_DEFINE(CONFIG_CORETEXT, 1, [found CoreText in ApplicationServices framework])
     coretext=true
     AC_MSG_RESULT([yes])
   ], [
-    LIBS="$OLDLIBS"
-    coretext=false
-    AC_MSG_RESULT([no])
+    AC_COMPILE_IFELSE([
+      AC_LANG_PROGRAM(
+        [[#include <CoreText/CoreText.h>]],
+        [[CTFontDescriptorCopyAttribute(NULL, kCTFontURLAttribute);]])
+      ], [
+        LIBS="$LIBS -framework CoreText -framework CoreFoundation"
+        AC_DEFINE(CONFIG_CORETEXT, 1, [found CoreText framework])
+        coretext=true
+        AC_MSG_RESULT([yes])
+      ], [
+        coretext=false
+        AC_MSG_RESULT([no])
+      ])
   ])
 fi
 AM_CONDITIONAL([CORETEXT], [test x$coretext = xtrue])

--- a/libass/ass_coretext.c
+++ b/libass/ass_coretext.c
@@ -20,7 +20,12 @@
 #include "ass_compat.h"
 
 #include <CoreFoundation/CoreFoundation.h>
+#include <TargetConditionals.h>
+#if TARGET_OS_IPHONE
 #include <CoreText/CoreText.h>
+#else
+#include <ApplicationServices/ApplicationServices.h>
+#endif
 
 #include "ass_coretext.h"
 

--- a/libass/ass_coretext.c
+++ b/libass/ass_coretext.c
@@ -232,7 +232,7 @@ static void process_descriptors(ASS_FontProvider *provider, CFArrayRef fontsd)
 static void match_fonts(ASS_Library *lib, ASS_FontProvider *provider,
                         char *name)
 {
-    const size_t attributes_n = 3;
+    enum { attributes_n = 3 };
     CTFontDescriptorRef ctdescrs[attributes_n];
     CFMutableDictionaryRef cfattrs[attributes_n];
     CFStringRef attributes[attributes_n] = {


### PR DESCRIPTION
I remembered today that I had this lying around almost finished for two years. So I finally polished it to my liking, and well, here it is.

I know I’m probably the only one around here who cares about old OSs (and over the last two years this has gotten even less relevant than it once was), but hey, this change is not terribly complicated, is it?

I’ve been using this on Mac OS X 10.6 Snow Leopard for just over two years without any trouble.

The configure script could use `AC_CHECK_DECL`, and in fact my original version of this commit did exactly that, but then (a) behdad/harfbuzz#342 must be minded and (b) the message `./configure` prints on screen is `checking whether kCTFontURLAttribute is declared` (plus a second similar message on iOS), which makes it far from obvious that it’s checking for CoreText: this is why I changed it to an explicit `AC_COMPILE_IFELSE`.