### PR TITLE
Fix ass_render_frame's change detection when using BorderStyle=4

### DIFF
--- a/libass/ass.h
+++ b/libass/ass.h
@@ -53,7 +53,8 @@ typedef struct ass_image {
     enum {
         IMAGE_TYPE_CHARACTER,
         IMAGE_TYPE_OUTLINE,
-        IMAGE_TYPE_SHADOW
+        IMAGE_TYPE_SHADOW,
+        IMAGE_TYPE_BACKGROUND
     } type;
 
 } ASS_Image;

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -2291,6 +2291,7 @@ static void add_background(ASS_Renderer *render_priv, EventImages *event_images)
     ASS_Image *img = my_draw_bitmap(nbuffer, w, h, w, left, top,
                                     render_priv->state.c[3], NULL);
     if (img) {
+        img->type = IMAGE_TYPE_BACKGROUND;
         img->next = event_images->imgs;
         event_images->imgs = img;
     }

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -2790,7 +2790,10 @@ static int ass_image_compare(ASS_Image *i1, ASS_Image *i2)
         return 2;
     if (i1->color != i2->color)
         return 2;
-    if (i1->bitmap != i2->bitmap)
+    if (i1->type != i2->type)
+        return 2;
+    if (i1->type != IMAGE_TYPE_BACKGROUND &&
+        i1->bitmap != i2->bitmap)
         return 2;
     if (i1->dst_x != i2->dst_x)
         return 1;


### PR DESCRIPTION
I discovered a bug where using BorderStyle=4 would cause `ass_render_frame` to always set `detect_change=2`, causing unnecessary re-rendering.

This PR tags any `ASS_Image` added as a background with `IMAGE_TYPE_BACKGROUND`, and uses that new type to ensure `ass_image_compare` works as expected.