### PR TITLE
coretext: fix reading weights of some fonts

### DIFF
--- a/libass/ass_coretext.c
+++ b/libass/ass_coretext.c
@@ -116,17 +116,17 @@ static void get_name(CTFontDescriptorRef fontd, CFStringRef attr,
 }
 
 static void get_trait(CFDictionaryRef traits, CFStringRef attribute,
-                      float *trait)
+                      double *trait)
 {
     CFNumberRef cftrait = CFDictionaryGetValue(traits, attribute);
-    if (!CFNumberGetValue(cftrait, kCFNumberFloatType, trait))
-        *trait = 0.0;
+    *trait = 0.0;
+    CFNumberGetValue(cftrait, kCFNumberDoubleType, trait);
 }
 
 static void get_font_traits(CTFontDescriptorRef fontd,
                             ASS_FontProviderMetaData *meta)
 {
-    float weight, slant, width;
+    double weight, slant, width;
 
     CFDictionaryRef traits =
         CTFontDescriptorCopyAttribute(fontd, kCTFontTraitsAttribute);

--- a/libass/ass_coretext.c
+++ b/libass/ass_coretext.c
@@ -123,6 +123,20 @@ static void get_trait(CFDictionaryRef traits, CFStringRef attribute,
     CFNumberGetValue(cftrait, kCFNumberDoubleType, trait);
 }
 
+// These are available as kCTFontWeightUltraLight, etc. in newer SDKs.
+// For some reason they switched the terms "ultra light" and "thin"
+#define FontWeightUltraLight -0.8
+#define FontWeightThin -0.6
+#define FontWeightLight -0.4
+#define FontWeightRegular 0
+#define FontWeightMedium 0.23
+#define FontWeightSemibold 0.3
+#define FontWeightBold 0.4
+#define FontWeightHeavy 0.56
+#define FontWeightBlack 0.62
+
+#define AVG(x, y) ((x + y) / 2.)
+
 static void get_font_traits(CTFontDescriptorRef fontd,
                             ASS_FontProviderMetaData *meta)
 {
@@ -145,18 +159,24 @@ static void get_font_traits(CTFontDescriptorRef fontd,
     // libass:                   LIGHT  MEDIUM            BOLD
     // coretext:            -0.4         0.0   0.23  0.3   0.4   0.62
 
-    if (weight >= 0.62)
+    if (weight >= AVG(FontWeightHeavy, FontWeightBlack))
+        meta->weight = 900;
+    else if (weight >= AVG(FontWeightBold, FontWeightHeavy))
         meta->weight = 800;
-    else if (weight >= 0.4)
+    else if (weight >= AVG(FontWeightSemibold, FontWeightBold))
         meta->weight = 700;
-    else if (weight >= 0.3)
+    else if (weight >= AVG(FontWeightMedium, FontWeightSemibold))
         meta->weight = 600;
-    else if (weight >= 0.23)
+    else if (weight >= AVG(FontWeightRegular, FontWeightMedium))
         meta->weight = 500;
-    else if (weight >= -0.4)
+    else if (weight >= AVG(FontWeightLight, FontWeightMedium))
         meta->weight = 400;
-    else
+    else if (weight >= AVG(FontWeightThin, FontWeightLight))
+        meta->weight = 300;
+    else if (weight >= AVG(FontWeightUltraLight, FontWeightThin))
         meta->weight = 200;
+    else
+        meta->weight = 100;
 
     if (slant > 0.03)
         meta->slant  = FONT_SLANT_ITALIC;

--- a/libass/ass_font.c
+++ b/libass/ass_font.c
@@ -303,6 +303,23 @@ void ass_font_set_size(ASS_Font *font, double size)
 }
 
 /**
+ * \brief Get face weight
+ **/
+int ass_face_get_weight(FT_Face face)
+{
+#if FREETYPE_MAJOR > 2 || (FREETYPE_MAJOR == 2 && FREETYPE_MINOR >= 6)
+    TT_OS2 *os2 = FT_Get_Sfnt_Table(face, FT_SFNT_OS2);
+#else
+    // This old name is still included (as a macro), but deprecated as of 2.6, so avoid using it if we can
+    TT_OS2 *os2 = FT_Get_Sfnt_Table(face, ft_sfnt_os2);
+#endif
+    if (os2 && os2->version != 0xffff && os2->usWeightClass)
+        return os2->usWeightClass;
+    else
+        return 300 * !!(face->style_flags & FT_STYLE_FLAG_BOLD) + 400;
+}
+
+/**
  * \brief Get maximal font ascender and descender.
  **/
 void ass_font_get_asc_desc(ASS_Font *font, int face_index,

--- a/libass/ass_font.c
+++ b/libass/ass_font.c
@@ -557,8 +557,7 @@ FT_Glyph ass_font_get_glyph(ASS_Font *font, int face_index, int index,
         FT_GlyphSlot_Oblique(face->glyph);
     }
 
-    if (!(face->style_flags & FT_STYLE_FLAG_BOLD) &&
-        (font->desc.bold > 400)) {
+    if (font->desc.bold > ass_face_get_weight(face) + 150) {
         ass_glyph_embolden(face->glyph);
     }
     error = FT_Get_Glyph(face->glyph, &glyph);

--- a/libass/ass_font.h
+++ b/libass/ass_font.h
@@ -61,6 +61,7 @@ void charmap_magic(ASS_Library *library, FT_Face face);
 ASS_Font *ass_font_new(ASS_Renderer *render_priv, ASS_FontDesc *desc);
 void ass_face_set_size(FT_Face face, double size);
 void ass_font_set_size(ASS_Font *font, double size);
+int ass_face_get_weight(FT_Face face);
 void ass_font_get_asc_desc(ASS_Font *font, int face_index,
                            int *asc, int *desc);
 int ass_font_get_index(ASS_FontSelector *fontsel, ASS_Font *font,

--- a/libass/ass_fontconfig.c
+++ b/libass/ass_fontconfig.c
@@ -117,12 +117,43 @@ static void scan_fonts(FcConfig *config, ASS_FontProvider *provider)
         // fontconfig uses its own weight scale, apparently derived
         // from typographical weight. we're using truetype weights, so
         // convert appropriately
-        if (weight <= FC_WEIGHT_LIGHT)
-            meta.weight = FONT_WEIGHT_LIGHT;
-        else if (weight <= FC_WEIGHT_MEDIUM)
-            meta.weight = FONT_WEIGHT_MEDIUM;
+#if FC_VERSION >= 21191
+        meta.weight = FcWeightToOpenType(weight);
+#else
+        // On older fontconfig, FcWeightToOpenType is unavailable, and its inverse was
+        // implemented more simply, using an if/else ladder instead of linear interpolation.
+        // We implement an inverse of that ladder here.
+        // We don't expect actual FC caches from these versions to have intermediate
+        // values, so the average checks are only for completeness.
+#define AVG(x, y) ((x + y) / 2)
+#ifndef FC_WEIGHT_SEMILIGHT
+#define FC_WEIGHT_SEMILIGHT 55
+#endif
+        if (weight < AVG(FC_WEIGHT_THIN, FC_WEIGHT_EXTRALIGHT))
+            meta.weight = 100;
+        else if (weight < AVG(FC_WEIGHT_EXTRALIGHT, FC_WEIGHT_LIGHT))
+            meta.weight = 200;
+        else if (weight < AVG(FC_WEIGHT_LIGHT, FC_WEIGHT_SEMILIGHT))
+            meta.weight = 300;
+        else if (weight < AVG(FC_WEIGHT_SEMILIGHT, FC_WEIGHT_BOOK))
+            meta.weight = 350;
+        else if (weight < AVG(FC_WEIGHT_BOOK, FC_WEIGHT_REGULAR))
+            meta.weight = 380;
+        else if (weight < AVG(FC_WEIGHT_REGULAR, FC_WEIGHT_MEDIUM))
+            meta.weight = 400;
+        else if (weight < AVG(FC_WEIGHT_MEDIUM, FC_WEIGHT_SEMIBOLD))
+            meta.weight = 500;
+        else if (weight < AVG(FC_WEIGHT_SEMIBOLD, FC_WEIGHT_BOLD))
+            meta.weight = 600;
+        else if (weight < AVG(FC_WEIGHT_BOLD, FC_WEIGHT_EXTRABOLD))
+            meta.weight = 700;
+        else if (weight < AVG(FC_WEIGHT_EXTRABOLD, FC_WEIGHT_BLACK))
+            meta.weight = 800;
+        else if (weight < AVG(FC_WEIGHT_BLACK, FC_WEIGHT_EXTRABLACK))
+            meta.weight = 900;
         else
-            meta.weight = FONT_WEIGHT_BOLD;
+            meta.weight = 1000;
+#endif
 
         // path
         result = FcPatternGetString(pat, FC_FILE, 0, (FcChar8 **)&path);

--- a/libass/ass_fontselect.c
+++ b/libass/ass_fontselect.c
@@ -810,7 +810,7 @@ get_font_info(FT_Library lib, FT_Face face, ASS_FontProviderMetaData *info)
 
     // calculate sensible slant and weight from style attributes
     slant  = 110 * !!(face->style_flags & FT_STYLE_FLAG_ITALIC);
-    weight = 300 * !!(face->style_flags & FT_STYLE_FLAG_BOLD) + 400;
+    weight = ass_face_get_weight(face);
 
     // fill our struct
     info->slant  = slant;


### PR DESCRIPTION
Some fonts have weights that can be expressed more precisely as doubles than as floats. In these cases, when writing to a float, CFNumberGetValue will set the value to the closest approximation, but return false (so we'd just clobber whatever it set with 0).
Easy fix: just store to a double instead.