### PR TITLE
Fix compilation with msvc

### DIFF
--- a/libass/ass_outline.c
+++ b/libass/ass_outline.c
@@ -517,7 +517,7 @@ static bool process_arc(StrokerState *str, ASS_Vector pt,
 static bool draw_arc(StrokerState *str, ASS_Vector pt,
                      ASS_DVector normal0, ASS_DVector normal1, double c, int dir)
 {
-    const int max_subdiv = 15;
+    enum { max_subdiv = 15 };
     double mul[max_subdiv + 1];
 
     ASS_DVector center;
@@ -553,7 +553,7 @@ static bool draw_arc(StrokerState *str, ASS_Vector pt,
  */
 static bool draw_circle(StrokerState *str, ASS_Vector pt, int dir)
 {
-    const int max_subdiv = 15;
+    enum { max_subdiv = 15 };
     double mul[max_subdiv + 1], c = 0;
 
     int pos = max_subdiv;

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -1234,7 +1234,7 @@ get_bitmap_glyph(ASS_Renderer *render_priv, GlyphInfo *info)
         return;
     }
 
-    const int n_outlines = 3;
+    enum { n_outlines = 3 };
     ASS_Outline outline[n_outlines];
     outline_copy(&outline[0], info->outline);
     outline_copy(&outline[1], info->border[0]);


### PR DESCRIPTION
msvc doesn't like a `const int` for the size of an array, so use an enum instead.