### PR TITLE
Port of the build system to meson

### DIFF
--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -1,0 +1,104 @@
+name: Meson CI
+
+on:
+  push:
+    branches: [ master, ci ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    name: ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {
+            name: Windows MSVC Release,
+            os: windows-latest,
+            msvc: true,
+            buildtype: release,
+            args: '-Ddefault_library=static --wrap-mode=forcefallback'
+          }
+          - {
+            name: Windows MinGW Release,
+            os: windows-latest,
+            msvc: false,
+            buildtype: release,
+            args: ''
+          }
+          - {
+            name: Ubuntu Debug,
+            os: ubuntu-latest,
+            buildtype: debugoptimized,
+            args: ''
+          }
+          - {
+            name: Ubuntu Release,
+            os: ubuntu-latest,
+            buildtype: release,
+            args: ''
+          }
+          - {
+            name: macOS Debug,
+            os: macos-latest,
+            buildtype: debugoptimized,
+            args: ''
+          }
+          - {
+            name: macOS Release,
+            os: macos-latest,
+            buildtype: release,
+            args: -Ddefault_library=static
+          }
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: '0'
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Setup Meson
+        run: |
+          python -m pip install --upgrade pip
+          pip install meson
+
+      - name: Setup MSVC
+        if: matrix.config.os == 'windows-latest' && matrix.config.msvc == true
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          case "${{ matrix.config.os }}" in
+            windows-*)
+              choco install ninja nasm
+              ;;
+            macos-*)
+              brew install nasm ninja pkg-config
+              ;;
+            ubuntu-*)
+              sudo apt-get update
+              sudo apt-get install ninja-build build-essential pkg-config nasm libfreetype6-dev libfontconfig1-dev libharfbuzz-dev libfribidi-dev
+              ;;
+          esac
+
+      - name: Set up WrapDB
+        if: matrix.config.os == 'windows-latest' || matrix.config.os == 'macos-latest'
+        run: |
+          meson wrap update-db
+
+      - name: Configure
+        run: meson setup build ${{ matrix.config.args }} -Dbuildtype=${{ matrix.config.buildtype }}
+
+      - name: Build
+        run: meson compile -C build
+
+      - name: Dump Meson Debug Info
+        if: failure()
+        run: cat build/meson-logs/meson-log.txt

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ Makefile.in
 /missing
 /m4
 /test-driver
+
+# Meson
+/subprojects

--- a/Makefile.am
+++ b/Makefile.am
@@ -7,6 +7,11 @@ AM_CFLAGS = -std=gnu99 -Wall -Wextra -Wno-sign-compare -Wno-unused-parameter \
 
 EXTRA_DIST = libass.pc.in Changelog MAINTAINERS ltnasm.sh
 
+# Meson build setup
+EXTRA_DIST += gen_defs.py meson_options.txt meson.build \
+              libass/meson.build libass/ass/meson.build \
+              profile/meson.build test/meson.build
+
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = libass.pc
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,21 @@ Please use the [issue tracker](https://github.com/libass/libass/issues?state=ope
 
 We have an IRC channel, too. Talk to us on [irc.libera.chat/#libass](https://web.libera.chat/#libass). Note that we cannot be online all the time and we cannot answer IRC questions if you leave the channel. Even if you do not get an immediate response, keep your IRC client open, and we will eventually get back to you.
 
+Building
+========
+
+libass offers two build systems to choose from: Autotools and Meson.
+
+Autotools is preferred for development since it integrates with our testing
+infrastructure and is feature-complete on all platforms supported by Autotools.  
+If you are packaging libass for distribution, Autotools is recommended;
+when packaging for Windows Meson should work equally well.
+
+Meson lacks integration with testing infrastructure, but works otherwise well on
+Windows. It is suited for static-only builds on any platform well supported by
+Meson and as a Meson subproject.
+Notably, Meson supports MSVC and generation of VS project files.
+
 Related Links
 =============
 The following projects/companies use libass:

--- a/gen_defs.py
+++ b/gen_defs.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+import sys
+
+symfile_path = sys.argv[1]
+deffile_path = sys.argv[2]
+
+with open(symfile_path) as symfile:
+    lines = symfile.readlines()
+    lines.insert(0, 'EXPORTS\n')
+    with open(deffile_path, 'w') as deffile:
+        deffile.writelines(lines)

--- a/libass/ass/meson.build
+++ b/libass/ass/meson.build
@@ -1,0 +1,13 @@
+# See: https://github.com/mesonbuild/meson/issues/2546
+# This hack is needed because the install directory of the libass public headers
+# ('ass') is different than the name of the directory ('libass') that they live under
+# in the source tree. In the scenario where the libass meson build system is being used
+# as a subproject of some parent project, that parent project will need the libass
+# headers to be copied into the appropriate 'ass' directory either before or during the
+# build process so that they are in an appropriate include path prior to the time that
+# the build system starts trying to build the parent project that needs to include
+# them.
+fs = import('fs')
+foreach header : libass_headers
+    fake_installed_headers += fs.copyfile(header, fs.name(header))
+endforeach

--- a/libass/meson.build
+++ b/libass/meson.build
@@ -1,0 +1,134 @@
+libass_lt_current = 11
+libass_lt_revision = 1
+libass_lt_age = 2
+
+libass_so_version = '@0@.@1@.@2@'.format(
+    libass_lt_current - libass_lt_age,
+    libass_lt_age,
+    libass_lt_revision,
+)
+
+src_x86 = files(
+    'x86/be_blur.asm',
+    'x86/blend_bitmaps.asm',
+    'x86/blur.asm',
+    'x86/cpuid.asm',
+    'x86/rasterizer.asm',
+)
+src_aarch64 = files(
+    'aarch64/asm.S',
+    'aarch64/be_blur.S',
+    'aarch64/blend_bitmaps.S',
+    'aarch64/blur.S',
+    'aarch64/rasterizer.S',
+)
+src_fontconfig = files('ass_fontconfig.c')
+src_directwrite = files('ass_directwrite.c')
+src_coretext = files('ass_coretext.c')
+
+libass_src = files(
+    'c/c_be_blur.c',
+    'c/c_blend_bitmaps.c',
+    'c/c_blur.c',
+    'c/c_rasterizer.c',
+    'ass.c',
+    'ass_bitmap.c',
+    'ass_bitmap_engine.c',
+    'ass_blur.c',
+    'ass_cache.c',
+    'ass_drawing.c',
+    'ass_filesystem.c',
+    'ass_font.c',
+    'ass_fontselect.c',
+    'ass_library.c',
+    'ass_outline.c',
+    'ass_parse.c',
+    'ass_rasterizer.c',
+    'ass_render.c',
+    'ass_render_api.c',
+    'ass_shaper.c',
+    'ass_string.c',
+    'ass_strtod.c',
+    'ass_utils.c',
+)
+
+libass_link_with = []
+
+libass_headers = files('ass.h', 'ass_types.h')
+
+if fontconfig
+    libass_src += src_fontconfig
+endif
+if directwrite
+    libass_src += src_directwrite
+endif
+if coretext
+    libass_src += src_coretext
+endif
+
+if enable_asm
+    asm_sources = []
+    if cpu_family == 'x86'
+        asm_sources = src_x86
+    elif cpu_subfamily == 'aarch64'
+        asm_sources = src_aarch64
+    endif
+
+    if asm_is_nasm
+        libass_src += asm_sources
+    else
+        asm_lib = static_library(
+            'libass_asm',
+            config_h,
+            sources: asm_sources,
+            c_args: asm_args,
+            include_directories: incs,
+        )
+        libass_link_with += asm_lib
+    endif
+endif
+
+if host_system == 'windows'
+    gen_defs = find_program('../gen_defs.py')
+    libass_def = custom_target(
+        'libass.def',
+        input: ['libass.sym'],
+        output: ['libass.def'],
+        command: [gen_defs, '@INPUT@', '@OUTPUT@'],
+    )
+    kwargs = {'vs_module_defs': libass_def}
+else
+    kwargs = {}
+endif
+
+# this is a list of custom targets for copying the libass public headers into the build
+# directory. These targets are passed as part of the libass library build step in order
+# to enforce the desired build sequence.
+fake_installed_headers = []
+subdir('ass')
+
+libass = library(
+    'ass',
+    libass_src,
+    config_h,
+    link_with: libass_link_with,
+    version: libass_so_version,
+    # This emulates the GNU libtool compat/current versioning computation
+    darwin_versions: [
+        '@0@'.format(libass_lt_current + 1),
+        '@0@.@1@'.format(libass_lt_current + 1, libass_lt_revision),
+    ],
+    install: true,
+    include_directories: incs,
+    dependencies: deps,
+    kwargs: kwargs,
+)
+
+libass_dep = declare_dependency(
+    link_with: libass,
+    include_directories: incs,
+    dependencies: deps,
+    sources: fake_installed_headers,
+)
+
+install_headers(libass_headers, subdir: 'ass')

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,407 @@
+project(
+    'libass',
+    'c',
+    license: 'ISC',
+    meson_version: '>= 0.64.0',
+    default_options: [
+        'c_std=c99',
+        'buildtype=debugoptimized',
+        'warning_level=2',
+        'default_library=static',
+    ],
+    version: '0.17.1',
+)
+
+conf = configuration_data()
+deps = []
+test_deps = []
+
+host_system = host_machine.system()
+
+# Compiler setup
+
+cc = meson.get_compiler('c')
+
+cc_warnings = []
+cc_features = []
+
+if cc.get_id() != 'msvc'
+    cc_features += '-D_POSIX_C_SOURCE=200809L'
+endif
+
+if cc.get_argument_syntax() == 'gcc'
+    cc_warnings += [
+        '-Wno-sign-compare',
+        '-Wno-unused-parameter',
+        '-Werror-implicit-function-declaration',
+        '-Wstrict-prototypes',
+        '-Wpointer-arith',
+        '-Wredundant-decls',
+        '-Wno-missing-field-initializers',
+    ]
+endif
+
+add_project_arguments(
+    cc.get_supported_arguments(cc_warnings + cc_features),
+    language: 'c',
+)
+
+# Configuration
+
+str_check_functions = ['strdup', 'strndup']
+
+foreach name : str_check_functions
+    if (
+        cc.has_function(name)
+        and cc.has_header_symbol('string.h', name, args: cc_features)
+    )
+        conf.set('HAVE_@0@'.format(name.to_upper()), 1)
+    endif
+endforeach
+
+if (
+    cc.has_function('fstat')
+    and cc.has_header_symbol(
+        'sys/stat.h',
+        'fstat',
+        args: cc_features,
+        prefix: '#include <sys/types.h>',
+    )
+)
+    conf.set('HAVE_FSTAT', 1)
+endif
+
+# Dependencies
+
+deps += cc.find_library('m', required: false)
+
+iconv_dep = dependency('iconv', required: false)
+if iconv_dep.found()
+    deps += iconv_dep
+    conf.set('CONFIG_ICONV', 1)
+endif
+
+freetype_dep = dependency(
+    'freetype2',
+    version: '>= 9.17.3',
+    default_options: ['harfbuzz=disabled'],
+)
+if freetype_dep.found()
+    deps += freetype_dep
+    conf.set('CONFIG_FREETYPE', 1)
+endif
+
+fribidi_dep = dependency(
+    'fribidi',
+    version: '>= 0.19.1',
+    default_options: ['docs=false', 'tests=false'],
+)
+if fribidi_dep.found()
+    deps += fribidi_dep
+    conf.set('CONFIG_FRIBIDI', 1)
+endif
+
+harfbuzz_options = [
+    'tests=disabled',
+    'cairo=disabled',
+    'gobject=disabled',
+    'glib=disabled',
+    'freetype=disabled',
+]
+harfbuzz_dep = dependency(
+    'harfbuzz',
+    version: '>= 1.2.3',
+    default_options: harfbuzz_options,
+)
+if harfbuzz_dep.found()
+    deps += harfbuzz_dep
+    conf.set('CONFIG_HARFBUZZ', 1)
+endif
+
+libunibreak_dep = dependency(
+    'libunibreak',
+    version: '>= 1.1',
+    required: get_option('libunibreak'),
+)
+if libunibreak_dep.found()
+    deps += libunibreak_dep
+    conf.set('CONFIG_UNIBREAK', 1)
+endif
+
+if get_option('test')
+    test_deps += dependency('libpng', version: '>= 1.2.0')
+    conf.set('CONFIG_LIBPNG', 1)
+endif
+
+font_providers = []
+
+fontconfig_dep = dependency(
+    'fontconfig',
+    version: '>= 2.10.92',
+    required: get_option('fontconfig'),
+)
+fontconfig = fontconfig_dep.found()
+if fontconfig
+    deps += fontconfig_dep
+    conf.set('CONFIG_FONTCONFIG', 1)
+    font_providers += ['Fontconfig']
+endif
+
+# CoreText
+coretext = false
+if not get_option('coretext').disabled()
+    appservices_dep = dependency(
+        'appleframeworks',
+        modules: ['ApplicationServices', 'CoreFoundation'],
+        required: false,
+    )
+    # this intentionally includes a leading newline
+    coretext_check = '''
+        int main(void) {
+            CTFontDescriptorCopyAttribute(NULL, kCTFontNameAttribute);
+            return 0;
+        }
+    '''
+    appservices_snippet = (
+        '#include <ApplicationServices/ApplicationServices.h>' + coretext_check
+    )
+
+    if appservices_dep.found() and cc.compiles(appservices_snippet)
+        deps += appservices_dep
+        conf.set('CONFIG_CORETEXT', 1)
+        coretext = true
+        font_providers += ['CoreText']
+    else
+        coretext_dep = dependency(
+            'appleframeworks',
+            modules: ['CoreText', 'CoreFoundation'],
+            required: false,
+        )
+        coretext_snippet = '#include <CoreText/CoreText.h>' + coretext_check
+        if coretext_dep.found() and cc.compiles(coretext_snippet)
+            deps += coretext_dep
+            conf.set('CONFIG_CORETEXT', 1)
+            coretext = true
+            font_providers += ['CoreText']
+        endif
+    endif
+endif
+
+# DirectWrite
+directwrite = false
+if not get_option('directwrite').disabled()
+    if cc.has_header('windows.h', required: false)
+        directwrite = true
+        conf.set('CONFIG_DIRECTWRITE', 1)
+        code = '''#include <windows.h>
+            #if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+            #error Win32 desktop APIs are available
+            #endif'''
+        if cc.compiles(code)
+            # WinRT/UWP/app build: GDI and LoadLibrary are unavailable,
+            # but DirectWrite is always present
+            deps += cc.find_library('dwrite', required: true)
+            font_providers += ['DirectWrite (WinRT/UWP)']
+        else
+            # Win32/desktop build: GDI is always present;
+            # DirectWrite is optional but can be loaded via LoadLibrary
+            deps += cc.find_library('gdi32', required: true)
+            font_providers += ['DirectWrite and GDI (Win32)']
+        endif
+    endif
+endif
+
+if get_option('directwrite').enabled() and directwrite == false
+    error(
+        'DirectWrite support was requested, but it was not found.',
+    )
+endif
+
+if get_option('coretext').enabled() and coretext == false
+    error(
+        'CoreText support was requested, but it was not found.',
+    )
+endif
+
+if get_option('require-system-font-provider')
+    if font_providers.length() == 0
+        error(
+            'Either DirectWrite (on Windows), CoreText (on OSX), or Fontconfig (Linux, ' +
+            'other) is required. If you really want to compile without a system font ' +
+            'provider, set -Drequire-system-font-provider=false',
+        )
+    endif
+else
+    if font_providers.length() == 0
+        font_providers += 'none'
+    endif
+endif
+
+# ASM
+enable_asm = false
+# used in libass/meson.build
+asm_is_nasm = false
+asm_args = []
+
+# ASM architecture variables
+asm_option = get_option('asm')
+cpu_subfamily = host_machine.cpu_family()
+if cpu_subfamily.startswith('x86')
+    cpu_family = 'x86'
+else
+    cpu_family = cpu_subfamily
+endif
+
+if not asm_option.disabled()
+    if cpu_family == 'x86'
+        asm_is_nasm = add_languages(
+            'nasm',
+            required: false,
+            native: false,
+        )
+        if not asm_is_nasm
+            warning(
+                'nasm was not found; ASM functions are disabled. Install nasm ' +
+                '>= 2.10 for a significantly faster libass build.',
+            )
+        else
+            nasm_ver = meson.get_compiler('nasm').version()
+            if nasm_ver.version_compare('< 2.10')
+                warning(
+                    'nasm is too old (found @0@); ASM functions are disabled. '.format(
+                        nasm_ver,
+                    ) + 'Install nasm >= 2.10 for a significantly faster libass build.',
+                )
+                asm_is_nasm = false
+            endif
+        endif
+        enable_asm = asm_is_nasm
+        if enable_asm
+            conf.set('ARCH_X86', 1)
+            nasm_args = ['-Dprivate_prefix=ass', '-DPIC=1']
+
+            if cpu_subfamily == 'x86_64'
+                conf.set('ARCH_X86_64', 1)
+                nasm_args += '-DARCH_X86_64=1'
+            else
+                nasm_args += '-DARCH_X86_64=0'
+            endif
+
+            if host_system in ['windows', 'cygwin']
+                if cpu_subfamily == 'x86'
+                    nasm_args += '-DPREFIX'
+                endif
+            elif host_system == 'darwin'
+                nasm_args += ['-DPREFIX', '-DSTACK_ALIGNMENT=16']
+            elif host_system in ['linux', 'sunos', 'haiku', 'gnu']
+                nasm_args += ['-DSTACK_ALIGNMENT=16']
+            elif host_system == 'dragonfly' or host_system.endswith('bsd')
+                nasm_args += []
+            else
+                error(
+                    'Please contact libass upstream to figure out if ASM support ' +
+                    'for your platform can be added. In the meantime you will need ' +
+                    'to use -Dasm=disabled.',
+                )
+            endif
+
+            add_project_arguments(nasm_args, language: 'nasm')
+        endif
+    elif cpu_subfamily == 'aarch64'
+        enable_asm = true
+        conf.set('ARCH_AARCH64', 1)
+        if host_system == 'darwin'
+            asm_args += '-DPREFIX'
+        endif
+    else
+        warning(
+            'Assembly optimizations are not yet supported for the "@0@" architecture; disabling.'.format(
+                cpu_subfamily,
+            ),
+        )
+    endif
+
+    if enable_asm
+        conf.set('CONFIG_ASM', 1)
+    elif asm_option.enabled()
+        error(
+            'Assembly was requested, but cannot be built; see prior messages.',
+        )
+    endif
+endif
+
+conf.set('CONFIG_LARGE_TILES', get_option('large-tiles').to_int())
+
+conf.set('CONFIG_SOURCEVERSION', '"meson, commit: @VCS_TAG@"')
+
+config_h_in = configure_file(output: 'config.h.in.in', configuration: conf)
+
+config_h_intermediate = vcs_tag(
+    command: [
+        'git',
+        'describe',
+        '--tags',
+        '--long',
+        '--always',
+        '--broken',
+        '--abbrev=40',
+    ],
+    fallback: '@VCS_TAG_FALLBACK@',
+    input: config_h_in,
+    output: 'config.h.in',
+)
+
+# Fallback command for older git versions (< 2.13.0) that don't support --broken
+config_h = vcs_tag(
+    command: [
+        'git',
+        'describe',
+        '--tags',
+        '--long',
+        '--always',
+        '--dirty',
+        '--abbrev=40',
+    ],
+    replace_string: '@VCS_TAG_FALLBACK@',
+    fallback: 'failed to determine (>= @0@)'.format(meson.project_version()),
+    input: config_h_intermediate,
+    output: 'config.h',
+)
+
+incs = include_directories('.', 'libass')
+
+subdir('libass')
+
+default_library = get_option('default_library')
+
+if default_library == 'both'
+    libass_for_tools = libass.get_static_lib()
+else
+    libass_for_tools = libass
+endif
+
+if get_option('test')
+    subdir('test')
+endif
+if get_option('profile')
+    subdir('profile')
+endif
+
+# libass.pc
+pkg = import('pkgconfig')
+pkg.generate(
+    libass,
+    name: 'libass',
+    description: 'libass is an SSA/ASS subtitles rendering library',
+)
+# `libass_dep` comes from subdir('libass')
+meson.override_dependency('libass', libass_dep)
+
+if default_library != 'static' and host_system != 'windows'
+    warning(
+        'this build does not properly support symbol visibility and the resulting shared lib is not suitable for distribution!',
+    )
+endif
+
+summary('Font providers', font_providers)
+summary('ASM optimizations', enable_asm, bool_yn: true)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,13 @@
+option('test', type: 'boolean', value: false, description: 'enable test program (requires libpng)')
+option('profile', type: 'boolean', value: false, description: 'enable profiling program')
+
+option('fontconfig', type: 'feature', description: 'fontconfig support')
+option('directwrite', type: 'feature', description: 'DirectWrite support (win32 only)')
+option('coretext', type: 'feature', description: 'CoreText support (OSX only)')
+option('asm', type: 'feature', description: 'ASM support (better performance)')
+option('libunibreak', type: 'feature', description: 'libunibreak support')
+
+option('require-system-font-provider', type: 'boolean', value: true,
+       description: 'disallow compilation if no system font provider was found')
+option('large-tiles', type: 'boolean', value: false,
+       description: 'use larger tiles in the rasterizer (better performance, slightly worse quality)')

--- a/profile/meson.build
+++ b/profile/meson.build
@@ -1,0 +1,10 @@
+profile_src = files('profile.c')
+
+libass_profile = executable(
+    'profile',
+    profile_src,
+    install: false,
+    include_directories: incs,
+    dependencies: deps,
+    link_with: libass_for_tools,
+)

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,0 +1,10 @@
+test_src = files('test.c')
+
+libass_test = executable(
+    'libass_test',
+    test_src,
+    install: false,
+    include_directories: incs,
+    dependencies: deps + test_deps,
+    link_with: libass_for_tools,
+)


### PR DESCRIPTION
Opened the PR for feedback despite a few remaining things that need to be cleaned up. The biggest benefit of this over autotools is that it enables easy compilation with MSVC, avoiding the need for a manual solution file which is difficult to maintain.

---

## Current PR Status

Not-CoffeeFlux here, since this PR went on for quite a while and GitHub likes to hide comments not near the start or very end, i’ve taken the liberty to edit details about the current status here for better discoverability *(mostly based on an updated version of [this comment](https://github.com/libass/libass/pull/330#issuecomment-1847988603)):

### TODOs before merge

- [x] remove bundled wrap files https://github.com/libass/libass/pull/330#discussion_r1411107315
- [x] display warning for builds affected by symbol-visibility issue https://github.com/libass/libass/pull/330#discussion_r1419742198
- [x] check why `default_library` is forced for freetype https://github.com/libass/libass/pull/330#discussion_r1411097432
- [x] test args https://github.com/libass/libass/pull/330#discussion_r1555288161
- [x] raise min ver to 0.64 to deal with
  - drop global `cpp_std`
  - use built-in NASM support
  - Future-deprecated features used: `* 0.64.0: {'copy arg in configure_file'}`
- [x] cosmetics?
   - https://github.com/libass/libass/pull/330#discussion_r1399568357
   - https://github.com/libass/libass/pull/330#discussion_r1399572001
- [x] checking and if needed fixing the additional new changes
- [X] **for libass maintainers:** add documentation about the second build system and when to (not) use it

### Nice-to-haves which can be added after merge

- CI for muon + samurai, possibly including `muon fmt` and `muon analyze`
- check meson builds work from tarballs in CI
- automated libtool version upgrades read from `configure.ac`
- drop macro defines for hard dependecies from both buildsystems
- investigate replacing the python dep on Windows with muon’s script support *(if we can gracefully fallback to Python for non-muon meson)*

### Missing features/deficiencies, which will not be added/resolved

 - x86 assembly is always forced into PIC mode
 - support for the compare utility
 - support for the fuzz utility
   -  support for the special build required for OSS Fuzz
 - support for checkasm tests and benchmarks
 - built-in support for running the regression test collection
 
 ### Missing due to meson deficiencies
 
  - proper symbol export control on non-Windows (https://github.com/mesonbuild/meson/issues/4298 and https://github.com/mesonbuild/meson/issues/3047)
 - no X32 assembly support;
   - previously with custom nasm generator as far a I recall detecting X32 was the issue?  (probably related?: https://github.com/mesonbuild/meson/issues/6361 *(and I see I linked to it before around one and a half years ago, though I’m not sure where)*)
   - now with built-in nasm, meson mistakelnly configures nasm with `-felf64` instead of `-felfx32` on a fully x32 host *(perhaps itself suffering from the same limitation as above)* (same for muon)
 
 ### Contained Workarounds for Meson bugs or missing features
 
 (after the pre-merge TODOs are resolved)
 
 - header install location (https://github.com/mesonbuild/meson/issues/2546)
 - no `CCASFLAGS` alike, thus an internal static lib for assembly on non-x86
   *(atm it _probably_ works even if the non-x86 CCASFLAGS and CFLAGS get mixed together, but future-proofing by keeping the seperation from autotools is likely a good idea)*
 
 ### Other noteworthy things
 
 - FreeType Wrap force-disables HarfBuzz to avoid issues in case both are built as subprojects. I don't really expect Meson to transparently handle circular dependencies like this, but it means HarfBuzz is still force-disabled even if _only_ (a newer version of) FreeType is built as a wrap and a suitable HarfBuzz is already present on the system.
 - Same for the HarfBuzz wrap force-disabling FreeType support
  - the checked symbol for CoreText detection differs, but (now that we actually support even the oldest CoreText version) this shouldn’t be an issue
 - On Windows the build requires Python (even with muon+samurai or similar) for generating the symbol file *(for good reason: we don't want to maintain the basically same symbol list twice; a proper platform-independent  symbol export control in meson would also resolve this)*
 - The library version is now duplicated from `libass/Makefile_library.am` to `libass/meson.build` and we’ll need to remember to always bump both and keep them in sync. Since we probably want to avoid requiring Python on more platforms this is acceptable I guess
 - In case anyone relying on this default reads this: when building both static and dynamic library on systems which do not generally require/enforce PIC, libtool will build the static lib without and the dynamic with PIC by default. Meson will by default build both with PIC (reusing the same object files for both). This can be changed with the `b_staticpic` user option or the `pic` argument in which case sources will be compiled twice. *(but ofc the most perf-critical part, the assembly, is always built with PIC in this Meson setup regardless)*
 
 #### muon
 
 (possibly a bit outdated, recheck; originally for muon `5e2b27d446cd`)
 
  - muon fails to find `iconv` with the new logic (despite claiming compatibility with `meson 1.1.99`); see https://todo.sr.ht/~lattis/muon/105
 - but otherwise builds this PRs setup just fine
 - it apparently internally treats C and assembly as different languages and as a result has a bug atm of not adding `c_args` to the assembler (https://todo.sr.ht/~lattis/muon/99)  *(ironically this closer to what we’d ideally like to have, but it’s incompatible with meson and no way to specifically set `AS_FLAGS` was exposed anyway)*
 
 
 