### PR TITLE
parse_tags: fix case where t==t1==t2

### DIFF
--- a/libass/ass_coretext.c
+++ b/libass/ass_coretext.c
@@ -117,8 +117,6 @@ static char *get_name(CTFontDescriptorRef fontd, CFStringRef attr)
 static void process_descriptors(ASS_Library *lib, ASS_FontProvider *provider,
                                 CFArrayRef fontsd)
 {
-    ASS_FontProviderMetaData meta;
-
     if (!fontsd)
         return;
 
@@ -129,6 +127,7 @@ static void process_descriptors(ASS_Library *lib, ASS_FontProvider *provider,
     }
 
     for (int i = 0; i < CFArrayGetCount(fontsd); i++) {
+        ASS_FontProviderMetaData meta = {0};
         CTFontDescriptorRef fontd = CFArrayGetValueAtIndex(fontsd, i);
         int index = -1;
 
@@ -138,8 +137,6 @@ static void process_descriptors(ASS_Library *lib, ASS_FontProvider *provider,
             free(path);
             continue;
         }
-
-        memset(&meta, 0, sizeof(meta));
 
         char *ps_name = get_name(fontd, kCTFontNameAttribute);
 

--- a/libass/ass_fontselect.c
+++ b/libass/ass_fontselect.c
@@ -843,6 +843,9 @@ error:
     free(info->families);
     free(info->fullnames);
 
+    info->families = info->fullnames = NULL;
+    info->n_family = info->n_fullname = 0;
+
     return false;
 }
 

--- a/libass/ass_parse.c
+++ b/libass/ass_parse.c
@@ -629,7 +629,7 @@ char *parse_tags(ASS_Renderer *render_priv, char *p, char *end, double pwr,
                 t2 = render_priv->state.event->Duration;
             delta_t = t2 - t1;
             t = render_priv->time - render_priv->state.event->Start;        // FIXME: move to render_context
-            if (t <= t1)
+            if (t < t1)
                 k = 0.;
             else if (t >= t2)
                 k = 1.;

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -655,7 +655,7 @@ static void blend_vector_clip(ASS_Renderer *render_priv, ASS_Image *head)
     ol_key.type = OUTLINE_DRAWING;
     ol_key.u.drawing.text = render_priv->state.clip_drawing_text;
 
-    double m[3][3] = {0};
+    double m[3][3] = {{0}};
     double w = render_priv->font_scale / (1 << (render_priv->state.clip_drawing_scale - 1));
     m[0][0] = render_priv->font_scale_x * w;
     m[1][1] = w;


### PR DESCRIPTION
This previously gave the pre-transition value; VSFilter's behavior is to give the post-transition value.

hi @skiddiks