### PR TITLE
Add function to get the width of a font from the OS/2 table

### DIFF
--- a/libass/ass_font.c
+++ b/libass/ass_font.c
@@ -87,7 +87,7 @@ uint32_t ass_font_index_magic(FT_Face face, uint32_t symbol)
     if (!face->charmap)
         return symbol;
 
-    switch(face->charmap->encoding){
+    switch (face->charmap->encoding) {
     case FT_ENCODING_MS_SYMBOL:
         return 0xF000 | symbol;
     default:
@@ -317,6 +317,37 @@ int ass_face_get_weight(FT_Face face)
         return os2->usWeightClass;
     else
         return 300 * !!(face->style_flags & FT_STYLE_FLAG_BOLD) + 400;
+}
+
+/**
+ * \brief Get face width
+ **/
+int ass_face_get_width(FT_Face face)
+{
+#if FREETYPE_MAJOR > 2 || (FREETYPE_MAJOR == 2 && FREETYPE_MINOR >= 6)
+    TT_OS2 *os2 = FT_Get_Sfnt_Table(face, FT_SFNT_OS2);
+#else
+    // This old name is still included (as a macro), but deprecated as of 2.6, so avoid using it if we can
+    TT_OS2 *os2 = FT_Get_Sfnt_Table(face, ft_sfnt_os2);
+#endif
+    if (os2 && os2->version != 0xffff && os2->usWidthClass) {
+		WidthClass wdth = os2->usWidthClass;
+		switch (wdth) {
+		case FWIDTH_ULTRA_CONDENSED:	return 50;
+		case FWIDTH_EXTRA_CONDENSED:	return 62;
+		case FWIDTH_CONDENSED:		return FONT_WIDTH_CONDENSED;
+		case FWIDTH_SEMI_CONDENSED:	return 87;
+		case FWIDTH_NORMAL:		return FONT_WIDTH_NORMAL;
+		case FWIDTH_SEMI_EXPANDED:	return 112;
+		case FWIDTH_EXPANDED:		return FONT_WIDTH_EXPANDED;
+		case FWIDTH_EXTRA_EXPANDED:	return 150;
+		case FWIDTH_ULTRA_EXPANDED:	return 200;
+		default:
+			return FONT_WIDTH_NORMAL;
+	}
+    }
+    else
+        return FONT_WIDTH_NORMAL;
 }
 
 /**

--- a/libass/ass_font.h
+++ b/libass/ass_font.h
@@ -57,11 +57,24 @@ struct ass_font {
     double size;
 };
 
+typedef enum WidthClass { 
+  FWIDTH_ULTRA_CONDENSED = 1, 
+  FWIDTH_EXTRA_CONDENSED = 2, 
+  FWIDTH_CONDENSED = 3, 
+  FWIDTH_SEMI_CONDENSED = 4, 
+  FWIDTH_NORMAL = 5, 
+  FWIDTH_SEMI_EXPANDED = 6, 
+  FWIDTH_EXPANDED = 7, 
+  FWIDTH_EXTRA_EXPANDED = 8, 
+  FWIDTH_ULTRA_EXPANDED = 9 
+} WidthClass;
+
 void charmap_magic(ASS_Library *library, FT_Face face);
 ASS_Font *ass_font_new(ASS_Renderer *render_priv, ASS_FontDesc *desc);
 void ass_face_set_size(FT_Face face, double size);
 void ass_font_set_size(ASS_Font *font, double size);
 int ass_face_get_weight(FT_Face face);
+int ass_face_get_width(FT_Face face);
 void ass_font_get_asc_desc(ASS_Font *font, int face_index,
                            int *asc, int *desc);
 int ass_font_get_index(ASS_FontSelector *fontsel, ASS_Font *font,

--- a/libass/ass_fontselect.c
+++ b/libass/ass_fontselect.c
@@ -758,7 +758,7 @@ get_font_info(FT_Library lib, FT_Face face, ASS_FontProviderMetaData *info)
     int num_fullname = 0;
     int num_family   = 0;
     int num_names = FT_Get_Sfnt_Name_Count(face);
-    int slant, weight;
+    int slant, weight, width;
     char *fullnames[MAX_FULLNAME];
     char *families[MAX_FULLNAME];
 
@@ -809,11 +809,12 @@ get_font_info(FT_Library lib, FT_Face face, ASS_FontProviderMetaData *info)
     // calculate sensible slant and weight from style attributes
     slant  = 110 * !!(face->style_flags & FT_STYLE_FLAG_ITALIC);
     weight = ass_face_get_weight(face);
+    width = ass_face_get_width(face);
 
     // fill our struct
     info->slant  = slant;
     info->weight = weight;
-    info->width  = 100;     // FIXME, should probably query the OS/2 table
+    info->width  = width;
 
     info->postscript_name = (char *)FT_Get_Postscript_Name(face);
 


### PR DESCRIPTION
I saw the FIXME in the source code on font width, and basically copied ass_face_get_weight while substituting usWidthClass for usWeightClass. So it will query the OS/2 table for the actual font width, and if it fails, it returns 100.