### PR TITLE
ass_blur: check for memory allocation size overflows

### DIFF
--- a/libass/ass_blur.c
+++ b/libass/ass_blur.c
@@ -849,8 +849,14 @@ bool ass_gaussian_blur(const BitmapEngine *engine, Bitmap *bm, double r2)
     int end_w = ((w + offset) & ~((1 << blur.level) - 1)) - 4;
     int end_h = ((h + offset) & ~((1 << blur.level) - 1)) - 4;
 
+    if (end_w >= INT_MAX / 4)
+        return false;
+
     const int stripe_width = 1 << (engine->align_order - 1);
-    int size = end_h * ((end_w + stripe_width - 1) & ~(stripe_width - 1));
+    int aligned_end_w = (end_w + stripe_width - 1) & ~(stripe_width - 1);
+    if (end_h >= INT_MAX / 8 / aligned_end_w)
+        return false;
+    int size = end_h * aligned_end_w;
     int16_t *tmp = ass_aligned_alloc(2 * stripe_width, 4 * size, false);
     if (!tmp)
         return false;


### PR DESCRIPTION
Check for overflows that could happen with alignment and the
multiplication. The INT_MAX / 4 is somewhat approximate and assumes that
degenerate alignment values won't happen.

This still assumes that a possibly overflowing end_w/end_h calculation
doesn't make the compiler's optimizer destroy the overflow checks.

---

Sample at: https://github.com/mpv-player/mpv/issues/7435
This fixes a crash I encountered with the sample (at slightly below 4K display resolution), but doesn't fix much of the sample itself.