### PR TITLE
render: match cases where VSFilter doesn't paint fill in the shadow

### DIFF
--- a/libass/ass_cache.h
+++ b/libass/ass_cache.h
@@ -69,9 +69,11 @@ typedef struct outline_hash_key {
 } OutlineHashKey;
 
 enum {
-    FILTER_BORDER_STYLE_3 = 1,
-    FILTER_NONZERO_BORDER = 2,
-    FILTER_NONZERO_SHADOW = 4,
+    FILTER_BORDER_STYLE_3 = 0x01,
+    FILTER_NONZERO_BORDER = 0x02,
+    FILTER_NONZERO_SHADOW = 0x04,
+    FILTER_FILL_IN_SHADOW = 0x08,
+    FILTER_FILL_IN_BORDER = 0x10,
 };
 
 typedef struct {

--- a/libass/ass_render.h
+++ b/libass/ass_render.h
@@ -142,6 +142,7 @@ typedef struct glyph_info {
     ASS_Vector offset;
     char linebreak;             // the first (leading) glyph of some line ?
     uint32_t c[4];              // colors
+    uint8_t a_pre_fade[4];      // alpha values before applying fades
     ASS_Vector advance;         // 26.6
     ASS_Vector cluster_advance;
     char effect;                // the first (leading) glyph of some effect ?


### PR DESCRIPTION
Some releases rely on this.
See corresponding VSFilter code: https://github.com/Cyberbeing/xy-VSFilter/blob/cf8f5b27de77fe649341bfab0fdfd498e1ad2fa6/src/subtitles/RTS.cpp#L1270
