### PR TITLE
Use the Unicode line breaking algorithm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ branches:
 
 before_install:
   - (sudo apt-get update || brew update)
-  - (sudo apt-get install -y libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev nasm || brew install freetype fribidi nasm) && ./autogen.sh && ./configure
+  - (sudo apt-get install -y libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev libunibreak-dev nasm || brew install freetype fribidi nasm) && ./autogen.sh && ./configure
 script:
   - make -j4
 

--- a/configure.ac
+++ b/configure.ac
@@ -51,6 +51,8 @@ AC_ARG_ENABLE([asm], AS_HELP_STRING([--disable-asm],
     [disable compiling with ASM @<:@default=check@:>@]))
 AC_ARG_ENABLE([large-tiles], AS_HELP_STRING([--enable-large-tiles],
     [use larger tiles in the rasterizer (better performance, slightly worse quality) @<:@default=disabled@:>@]))
+AC_ARG_ENABLE([libunibreak], AS_HELP_STRING([--disable-libunibreak],
+    [disable libunibreak support @<:@default=check@:>@]))
 
 AS_IF([test x$enable_asm != xno], [
     AS_CASE([$host],
@@ -217,6 +219,14 @@ PKG_CHECK_MODULES([HARFBUZZ], harfbuzz >= 0.9.5, [
     ], [harfbuzz=false])
 fi
 
+if test x$enable_libunibreak != xno; then
+PKG_CHECK_MODULES([LIBUNIBREAK], libunibreak >= 1.1, [
+    CFLAGS="$CFLAGS $LIBUNIBREAK_CFLAGS"
+    AC_DEFINE(CONFIG_LIBUNIBREAK, 1, [found libunibreak via pkg-config])
+	libunibreak=true
+    ], [libunibreak=false])
+fi
+
 libpng=false
 if test x$enable_test = xyes; then
 PKG_CHECK_MODULES([LIBPNG], libpng >= 1.2.0, [
@@ -244,6 +254,9 @@ if test x$fontconfig = xtrue; then
 fi
 if test x$harfbuzz = xtrue; then
     pkg_requires="harfbuzz >= 0.9.5, ${pkg_requires}"
+fi
+if test x$libunibreak = xtrue; then
+    pkg_requires="libunibreak >= 1.1, ${pkg_requires}"
 fi
 
 if test x$enable_require_system_font_provider != xno &&

--- a/libass/ass_parse.c
+++ b/libass/ass_parse.c
@@ -1044,62 +1044,19 @@ utf32_t text_info_get_next_char_utf32(
     return ch;
 }
 
-char *text_info_choose_ub_lang(TextInfo *text_info, char *track_lang)
+int is_valid_ub_lang(char *lang)
 {
-    // use track_lang if it's supported
-    if (track_lang) {
-        if      (strncmp(track_lang, "de", 2) == 0) return "de";
-        else if (strncmp(track_lang, "en", 2) == 0) return "en";
-        else if (strncmp(track_lang, "es", 2) == 0) return "es";
-        else if (strncmp(track_lang, "fr", 2) == 0) return "fr";
-        else if (strncmp(track_lang, "ja", 2) == 0) return "ja";
-        else if (strncmp(track_lang, "ko", 2) == 0) return "ko";
-        else if (strncmp(track_lang, "ru", 2) == 0) return "ru";
-        else if (strncmp(track_lang, "zh", 2) == 0) return "zh";
+    if (lang) {
+        if      (strncmp(lang, "de", 2) == 0) return 1;
+        else if (strncmp(lang, "en", 2) == 0) return 1;
+        else if (strncmp(lang, "es", 2) == 0) return 1;
+        else if (strncmp(lang, "fr", 2) == 0) return 1;
+        else if (strncmp(lang, "ja", 2) == 0) return 1;
+        else if (strncmp(lang, "ko", 2) == 0) return 1;
+        else if (strncmp(lang, "ru", 2) == 0) return 1;
+        else if (strncmp(lang, "zh", 2) == 0) return 1;
     }
-
-    char *lang = NULL;
-    GlyphInfo *cur;
-    unsigned symbol;
-
-    int kana_count = 0;
-    int cyrillic_count = 0;
-    int hangul_count = 0;
-    int cjk_count = 0;
-    for (int i = 0; i < text_info->length; ++i) {
-        cur = text_info->glyphs + i;
-        symbol = cur->symbol;
-        if (symbol < CYRILLIC_START) { // optimize
-            continue;
-        } else if (CJK_START <= symbol && CJK_END >= symbol) {
-            cjk_count += 1;
-        } else if (KANA_START <= symbol && KANA_END >= symbol) {
-            kana_count += 1;
-            break;
-        } else if (CYRILLIC_START <= symbol && CYRILLIC_END >= symbol) {
-            cyrillic_count += 1;
-            break;
-        } else if ((HANGUL_SYLLABLES_START  <= symbol &&  HANGUL_SYLLABLES_END  >= symbol) ||
-                   (HANGUL_JAMO_START       <= symbol &&  HANGUL_JAMO_END       >= symbol) ||
-                   (HANGUL_COMP_JAMO_START  <= symbol &&  HANGUL_COMP_JAMO_END  >= symbol) ||
-                   (HANGUL_EXTENDED_A_START <= symbol &&  HANGUL_EXTENDED_A_END >= symbol) ||
-                   (HANGUL_EXTENDED_B_START <= symbol &&  HANGUL_EXTENDED_B_END >= symbol)) {
-            hangul_count += 1;
-            break;
-        }
-    }
-
-    if (kana_count > 0) {
-        lang = "ja";
-    } else if (cyrillic_count > 0) {
-        lang = "ru";
-    } else if (hangul_count > 0) {
-        lang = "ko";
-    } else if (cjk_count > 0) {
-        lang = "zh";
-    }
-
-    return lang;
+    return 0;
 }
 
 // Return 1 if the event contains tags that will apply overrides the selective

--- a/libass/ass_parse.c
+++ b/libass/ass_parse.c
@@ -1044,6 +1044,64 @@ utf32_t text_info_get_next_char_utf32(
     return ch;
 }
 
+char *text_info_choose_ub_lang(TextInfo *text_info, char *track_lang)
+{
+    // use track_lang if it's supported
+    if (track_lang) {
+        if      (strncmp(track_lang, "de", 2) == 0) return "de";
+        else if (strncmp(track_lang, "en", 2) == 0) return "en";
+        else if (strncmp(track_lang, "es", 2) == 0) return "es";
+        else if (strncmp(track_lang, "fr", 2) == 0) return "fr";
+        else if (strncmp(track_lang, "ja", 2) == 0) return "ja";
+        else if (strncmp(track_lang, "ko", 2) == 0) return "ko";
+        else if (strncmp(track_lang, "ru", 2) == 0) return "ru";
+        else if (strncmp(track_lang, "zh", 2) == 0) return "zh";
+    }
+
+    char *lang = NULL;
+    GlyphInfo *cur;
+    unsigned symbol;
+
+    int kana_count = 0;
+    int cyrillic_count = 0;
+    int hangul_count = 0;
+    int cjk_count = 0;
+    for (int i = 0; i < text_info->length; ++i) {
+        cur = text_info->glyphs + i;
+        symbol = cur->symbol;
+        if (symbol < CYRILLIC_START) { // optimize
+            continue;
+        } else if (CJK_START <= symbol && CJK_END >= symbol) {
+            cjk_count += 1;
+        } else if (KANA_START <= symbol && KANA_END >= symbol) {
+            kana_count += 1;
+            break;
+        } else if (CYRILLIC_START <= symbol && CYRILLIC_END >= symbol) {
+            cyrillic_count += 1;
+            break;
+        } else if ((HANGUL_SYLLABLES_START  <= symbol &&  HANGUL_SYLLABLES_END  >= symbol) ||
+                   (HANGUL_JAMO_START       <= symbol &&  HANGUL_JAMO_END       >= symbol) ||
+                   (HANGUL_COMP_JAMO_START  <= symbol &&  HANGUL_COMP_JAMO_END  >= symbol) ||
+                   (HANGUL_EXTENDED_A_START <= symbol &&  HANGUL_EXTENDED_A_END >= symbol) ||
+                   (HANGUL_EXTENDED_B_START <= symbol &&  HANGUL_EXTENDED_B_END >= symbol)) {
+            hangul_count += 1;
+            break;
+        }
+    }
+
+    if (kana_count > 0) {
+        lang = "ja";
+    } else if (cyrillic_count > 0) {
+        lang = "ru";
+    } else if (hangul_count > 0) {
+        lang = "ko";
+    } else if (cjk_count > 0) {
+        lang = "zh";
+    }
+
+    return lang;
+}
+
 // Return 1 if the event contains tags that will apply overrides the selective
 // style override code should not touch. Return 0 otherwise.
 int event_has_hard_overrides(char *str)

--- a/libass/ass_parse.c
+++ b/libass/ass_parse.c
@@ -1025,6 +1025,7 @@ unsigned get_next_char(ASS_Renderer *render_priv, char **str)
     return chr;
 }
 
+#ifdef CONFIG_LIBUNIBREAK
 utf32_t text_info_get_next_char_utf32(
         TextInfo *text_info,
         size_t len,
@@ -1058,6 +1059,7 @@ int is_valid_ub_lang(char *lang)
     }
     return 0;
 }
+#endif
 
 // Return 1 if the event contains tags that will apply overrides the selective
 // style override code should not touch. Return 0 otherwise.

--- a/libass/ass_parse.c
+++ b/libass/ass_parse.c
@@ -1025,6 +1025,25 @@ unsigned get_next_char(ASS_Renderer *render_priv, char **str)
     return chr;
 }
 
+utf32_t text_info_get_next_char_utf32(
+        TextInfo *text_info,
+        size_t len,
+        size_t *ip)
+{
+    GlyphInfo *cur;
+    unsigned ch;
+
+    assert(*ip <= len);
+    if (*ip == len)
+        return EOS;
+
+    cur = text_info->glyphs + *ip;
+    ch = cur->symbol;
+    *ip += 1;
+
+    return ch;
+}
+
 // Return 1 if the event contains tags that will apply overrides the selective
 // style override code should not touch. Return 0 otherwise.
 int event_has_hard_overrides(char *str)

--- a/libass/ass_parse.h
+++ b/libass/ass_parse.h
@@ -19,6 +19,9 @@
 #ifndef LIBASS_PARSE_H
 #define LIBASS_PARSE_H
 
+#include <linebreakdef.h>
+#include <linebreak.h>
+
 #define BLUR_MAX_RADIUS 100.0
 
 #define _r(c)   ((c) >> 24)
@@ -31,6 +34,7 @@ double ensure_font_size(ASS_Renderer *priv, double size);
 void apply_transition_effects(ASS_Renderer *render_priv, ASS_Event *event);
 void process_karaoke_effects(ASS_Renderer *render_priv);
 unsigned get_next_char(ASS_Renderer *render_priv, char **str);
+utf32_t text_info_get_next_char_utf32(TextInfo *text_info, size_t len, size_t *ip);
 char *parse_tags(ASS_Renderer *render_priv, char *p, char *end, double pwr,
                  bool nested);
 int event_has_hard_overrides(char *str);

--- a/libass/ass_parse.h
+++ b/libass/ass_parse.h
@@ -29,33 +29,13 @@
 #define _b(c)   (((c) >> 8) & 0xFF)
 #define _a(c)   ((c) & 0xFF)
 
-#define CJK_START 0x4E00
-#define CJK_END   0x9FFF
-
-#define KANA_START 0x3040
-#define KANA_END   0x30FF
-
-#define CYRILLIC_START 0x0400
-#define CYRILLIC_END   0x04FF
-
-#define HANGUL_SYLLABLES_START  0xAC00
-#define HANGUL_SYLLABLES_END    0xD7AF
-#define HANGUL_JAMO_START       0x1100
-#define HANGUL_JAMO_END         0x11FF
-#define HANGUL_COMP_JAMO_START  0x3130
-#define HANGUL_COMP_JAMO_END    0x318F
-#define HANGUL_EXTENDED_A_START 0xA960
-#define HANGUL_EXTENDED_A_END   0xA97F
-#define HANGUL_EXTENDED_B_START 0xD7B0
-#define HANGUL_EXTENDED_B_END   0xD7FF
-
 void update_font(ASS_Renderer *render_priv);
 double ensure_font_size(ASS_Renderer *priv, double size);
 void apply_transition_effects(ASS_Renderer *render_priv, ASS_Event *event);
 void process_karaoke_effects(ASS_Renderer *render_priv);
 unsigned get_next_char(ASS_Renderer *render_priv, char **str);
 utf32_t text_info_get_next_char_utf32(TextInfo *text_info, size_t len, size_t *ip);
-char *text_info_choose_ub_lang(TextInfo *text_info, char *track_lang);
+int is_valid_ub_lang(char *lang);
 char *parse_tags(ASS_Renderer *render_priv, char *p, char *end, double pwr,
                  bool nested);
 int event_has_hard_overrides(char *str);

--- a/libass/ass_parse.h
+++ b/libass/ass_parse.h
@@ -29,12 +29,33 @@
 #define _b(c)   (((c) >> 8) & 0xFF)
 #define _a(c)   ((c) & 0xFF)
 
+#define CJK_START 0x4E00
+#define CJK_END   0x9FFF
+
+#define KANA_START 0x3040
+#define KANA_END   0x30FF
+
+#define CYRILLIC_START 0x0400
+#define CYRILLIC_END   0x04FF
+
+#define HANGUL_SYLLABLES_START  0xAC00
+#define HANGUL_SYLLABLES_END    0xD7AF
+#define HANGUL_JAMO_START       0x1100
+#define HANGUL_JAMO_END         0x11FF
+#define HANGUL_COMP_JAMO_START  0x3130
+#define HANGUL_COMP_JAMO_END    0x318F
+#define HANGUL_EXTENDED_A_START 0xA960
+#define HANGUL_EXTENDED_A_END   0xA97F
+#define HANGUL_EXTENDED_B_START 0xD7B0
+#define HANGUL_EXTENDED_B_END   0xD7FF
+
 void update_font(ASS_Renderer *render_priv);
 double ensure_font_size(ASS_Renderer *priv, double size);
 void apply_transition_effects(ASS_Renderer *render_priv, ASS_Event *event);
 void process_karaoke_effects(ASS_Renderer *render_priv);
 unsigned get_next_char(ASS_Renderer *render_priv, char **str);
 utf32_t text_info_get_next_char_utf32(TextInfo *text_info, size_t len, size_t *ip);
+char *text_info_choose_ub_lang(TextInfo *text_info, char *track_lang);
 char *parse_tags(ASS_Renderer *render_priv, char *p, char *end, double pwr,
                  bool nested);
 int event_has_hard_overrides(char *str);

--- a/libass/ass_parse.h
+++ b/libass/ass_parse.h
@@ -19,8 +19,10 @@
 #ifndef LIBASS_PARSE_H
 #define LIBASS_PARSE_H
 
+#ifdef CONFIG_LIBUNIBREAK
 #include <linebreakdef.h>
 #include <linebreak.h>
+#endif
 
 #define BLUR_MAX_RADIUS 100.0
 
@@ -34,8 +36,10 @@ double ensure_font_size(ASS_Renderer *priv, double size);
 void apply_transition_effects(ASS_Renderer *render_priv, ASS_Event *event);
 void process_karaoke_effects(ASS_Renderer *render_priv);
 unsigned get_next_char(ASS_Renderer *render_priv, char **str);
+#ifdef CONFIG_LIBUNIBREAK
 utf32_t text_info_get_next_char_utf32(TextInfo *text_info, size_t len, size_t *ip);
 int is_valid_ub_lang(char *lang);
+#endif
 char *parse_tags(ASS_Renderer *render_priv, char *p, char *end, double pwr,
                  bool nested);
 int event_has_hard_overrides(char *str);

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -1599,11 +1599,9 @@ wrap_lines_smart(ASS_Renderer *render_priv, double max_text_width)
     int cur_line;
     TextInfo *text_info = &render_priv->text_info;
     char brks[text_info->length];
-    char *brksPtr;
 
     if (render_priv->settings.wrap_tr14) {
-        brksPtr = brks;
-        set_linebreaks(text_info, text_info->length, "ja", brksPtr,
+        set_linebreaks(text_info, text_info->length, "ja", brks,
                        (get_next_char_t)text_info_get_next_char_utf32);
     }
 

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -1601,7 +1601,9 @@ wrap_lines_smart(ASS_Renderer *render_priv, double max_text_width)
     char brks[text_info->length];
 
     if (render_priv->settings.wrap_tr14) {
-        set_linebreaks(text_info, text_info->length, "ja", brks,
+        char *ub_lang = render_priv->track->Language;
+        ub_lang = text_info_choose_ub_lang(text_info, ub_lang);
+        set_linebreaks(text_info, text_info->length, ub_lang, brks,
                        (get_next_char_t)text_info_get_next_char_utf32);
     }
 

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -1602,7 +1602,8 @@ wrap_lines_smart(ASS_Renderer *render_priv, double max_text_width)
 
     if (render_priv->settings.wrap_tr14) {
         char *ub_lang = render_priv->track->Language;
-        ub_lang = text_info_choose_ub_lang(text_info, ub_lang);
+        if (!is_valid_ub_lang(ub_lang))
+            ub_lang = NULL;
         set_linebreaks(text_info, text_info->length, ub_lang, brks,
                        (get_next_char_t)text_info_get_next_char_utf32);
     }

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -106,6 +106,7 @@ ASS_Renderer *ass_renderer_init(ASS_Library *library)
 
     priv->settings.font_size_coeff = 1.;
     priv->settings.selective_style_overrides = ASS_OVERRIDE_BIT_SELECTIVE_FONT_SCALE;
+    priv->settings.wrap_cjk = 0;
 
     priv->shaper = ass_shaper_new(0);
     ass_shaper_info(library);
@@ -1628,7 +1629,7 @@ wrap_lines_smart(ASS_Renderer *render_priv, double max_text_width)
             break_type = 1;
             if (last_space != -1) {
                 break_at = last_space;
-            } else if (last_cjk != -1) {
+            } else if (last_cjk != -1 && render_priv->settings.wrap_cjk) {
                 break_at = last_cjk - 1;
             }
             if (break_at >= 0)

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -1591,13 +1591,14 @@ wrap_lines_smart(ASS_Renderer *render_priv, double max_text_width)
     int i;
     GlyphInfo *cur, *s1, *e1, *s2, *s3;
     int last_space;
-    int last_break;
     int break_type;
     int exit;
     double pen_shift_x;
     double pen_shift_y;
     int cur_line;
     TextInfo *text_info = &render_priv->text_info;
+#ifdef CONFIG_LIBUNIBREAK
+    int last_break;
     char brks[text_info->length];
 
     if (render_priv->settings.wrap_tr14) {
@@ -1608,8 +1609,9 @@ wrap_lines_smart(ASS_Renderer *render_priv, double max_text_width)
                        (get_next_char_t)text_info_get_next_char_utf32);
     }
 
-    last_space = -1;
     last_break = 0;
+#endif
+    last_space = -1;
     text_info->n_lines = 1;
     break_type = 0;
     s1 = text_info->glyphs;     // current line start
@@ -1621,6 +1623,7 @@ wrap_lines_smart(ASS_Renderer *render_priv, double max_text_width)
         s_offset = d6_to_double(s1->bbox.x_min + s1->pos.x);
         len = d6_to_double(cur->bbox.x_max + cur->pos.x) - s_offset;
 
+#ifdef CONFIG_LIBUNIBREAK
         if (render_priv->settings.wrap_tr14) {
             GlyphInfo *next;
             if ((i - 1) < text_info->length)
@@ -1651,7 +1654,11 @@ wrap_lines_smart(ASS_Renderer *render_priv, double max_text_width)
                     ass_msg(render_priv->library, MSGL_DBG2, "line break at %d",
                             break_at);
             }
-        } else {
+        }
+        else {
+#else
+        {
+#endif
             if (cur->symbol == '\n') {
                 break_type = 2;
                 break_at = i;

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -104,7 +104,7 @@ ASS_Renderer *ass_renderer_init(ASS_Library *library)
 
     priv->settings.font_size_coeff = 1.;
     priv->settings.selective_style_overrides = ASS_OVERRIDE_BIT_SELECTIVE_FONT_SCALE;
-    priv->settings.wrap_tr14 = 0;
+    priv->settings.improve_rendering = 0;
 
     priv->shaper = ass_shaper_new(0);
     ass_shaper_info(library);
@@ -1601,7 +1601,7 @@ wrap_lines_smart(ASS_Renderer *render_priv, double max_text_width)
     int last_break;
     char brks[text_info->length];
 
-    if (render_priv->settings.wrap_tr14) {
+    if (render_priv->settings.improve_rendering) {
         char *ub_lang = render_priv->track->Language;
         if (!is_valid_ub_lang(ub_lang))
             ub_lang = NULL;
@@ -1624,7 +1624,7 @@ wrap_lines_smart(ASS_Renderer *render_priv, double max_text_width)
         len = d6_to_double(cur->bbox.x_max + cur->pos.x) - s_offset;
 
 #ifdef CONFIG_LIBUNIBREAK
-        if (render_priv->settings.wrap_tr14) {
+        if (render_priv->settings.improve_rendering) {
             GlyphInfo *next;
             if ((i - 1) < text_info->length)
                 next = cur + 1;

--- a/libass/ass_render.h
+++ b/libass/ass_render.h
@@ -74,8 +74,8 @@ typedef struct {
     ASS_Hinting hinting;
     ASS_ShapingLevel shaper;
     int selective_style_overrides; // ASS_OVERRIDE_* flags
-    int wrap_cjk;               // 0 - don't allow word wrap between CJK characters
-    // 1 - prefer spaces for wrapping, but allow wrapping between CJK characters
+    int wrap_tr14;               // 0 - word wrap only from newlines or spaces
+    // 1 - word wrap according to https://unicode.org/reports/tr14/
 
     char *default_font;
     char *default_family;

--- a/libass/ass_render.h
+++ b/libass/ass_render.h
@@ -74,6 +74,8 @@ typedef struct {
     ASS_Hinting hinting;
     ASS_ShapingLevel shaper;
     int selective_style_overrides; // ASS_OVERRIDE_* flags
+    int wrap_cjk;               // 0 - don't allow word wrap between CJK characters
+    // 1 - prefer spaces for wrapping, but allow wrapping between CJK characters
 
     char *default_font;
     char *default_family;

--- a/libass/ass_render.h
+++ b/libass/ass_render.h
@@ -143,6 +143,7 @@ typedef struct glyph_info {
     ASS_Vector pos;
     ASS_Vector offset;
     char linebreak;             // the first (leading) glyph of some line ?
+    int allowbreak;             // break opportunity
     uint32_t c[4];              // colors
     ASS_Vector advance;         // 26.6
     ASS_Vector cluster_advance;

--- a/libass/ass_render.h
+++ b/libass/ass_render.h
@@ -74,8 +74,8 @@ typedef struct {
     ASS_Hinting hinting;
     ASS_ShapingLevel shaper;
     int selective_style_overrides; // ASS_OVERRIDE_* flags
-    int wrap_tr14;               // 0 - word wrap only from newlines or spaces
-    // 1 - word wrap according to https://unicode.org/reports/tr14/
+    int improve_rendering;         // 0 - maintain VSFilter compatibility
+    // 1 - enable improvements that can break VSFilter compatibility
 
     char *default_font;
     char *default_family;

--- a/libass/ass_render_api.c
+++ b/libass/ass_render_api.c
@@ -172,9 +172,9 @@ void ass_set_selective_style_override(ASS_Renderer *priv, ASS_Style *style)
     user_style->FontName = strdup(user_style->FontName);
 }
 
-void ass_set_wrap_tr14(ASS_Renderer *priv, int wrap)
+void ass_set_improve_rendering(ASS_Renderer *priv, int improve)
 {
-    priv->settings.wrap_tr14 = wrap;
+    priv->settings.improve_rendering = improve;
 }
 
 int ass_fonts_update(ASS_Renderer *render_priv)

--- a/libass/ass_render_api.c
+++ b/libass/ass_render_api.c
@@ -172,6 +172,11 @@ void ass_set_selective_style_override(ASS_Renderer *priv, ASS_Style *style)
     user_style->FontName = strdup(user_style->FontName);
 }
 
+void ass_set_wrap_cjk(ASS_Renderer *priv, int wrap)
+{
+    priv->settings.wrap_cjk = wrap;
+}
+
 int ass_fonts_update(ASS_Renderer *render_priv)
 {
     // This is just a stub now!

--- a/libass/ass_render_api.c
+++ b/libass/ass_render_api.c
@@ -172,9 +172,9 @@ void ass_set_selective_style_override(ASS_Renderer *priv, ASS_Style *style)
     user_style->FontName = strdup(user_style->FontName);
 }
 
-void ass_set_wrap_cjk(ASS_Renderer *priv, int wrap)
+void ass_set_wrap_tr14(ASS_Renderer *priv, int wrap)
 {
-    priv->settings.wrap_cjk = wrap;
+    priv->settings.wrap_tr14 = wrap;
 }
 
 int ass_fonts_update(ASS_Renderer *render_priv)


### PR DESCRIPTION
Demo in mpv:
![wrap-cjk-demo](https://user-images.githubusercontent.com/5602483/74581494-9fb16000-4fb8-11ea-8dda-1a37aadb45db.gif)

I'm opening this before adding any huge unicode range definitions to catch other issues early on. ~~I know that it isn't correct to break on the [Korean Unicode ranges](https://en.wikipedia.org/wiki/Korean_language_and_computers#Hangul_in_Unicode), for example.~~
Edit: it might be easier to treat all CJK the same way and [web browsers also do this](https://www.w3.org/TR/css-text-3/#line-breaking). Without any special handling for the Korean ranges the rules in [this post](https://nojeokhill.koreanconsulting.com/2013/05/korean-translation-tip-cardinal-rules-of-korean-language-layout.html) would be followed except when the words would otherwise overflow off screen because Korean text has spaces between words.

I'm planning to make the primary line break character [any space](http://jkorpela.fi/chars/spaces.html) (except the non-breaking ones maybe), secondary any punctuation and finally any Chinese or Japanese character.

Fixes https://github.com/libass/libass/issues/360