### PR TITLE
[RFC] \box tag

### DIFF
--- a/libass/ass_parse.c
+++ b/libass/ass_parse.c
@@ -741,6 +741,16 @@ char *parse_tags(ASS_Renderer *render_priv, char *p, char *end, double pwr,
                 render_priv->state.be = val;
             } else
                 render_priv->state.be = 0;
+        } else if (complex_tag("box")) {
+            if (nargs == 4) {
+                render_priv->state.margin_x0 = argtoi(args[0]);
+                render_priv->state.margin_y0 = argtoi(args[1]);
+                render_priv->state.margin_x1 =
+                    render_priv->track->PlayResX - argtoi(args[2]);
+                render_priv->state.margin_y1 =
+                    render_priv->track->PlayResY - argtoi(args[3]);
+                render_priv->state.margin_set = 1;
+            }
         } else if (tag("b")) {
             int val = argtoi(*args);
             if (!nargs || !(val == 0 || val == 1 || val >= 100))

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -1057,6 +1057,11 @@ init_render_context(ASS_Renderer *render_priv, ASS_Event *event)
     render_priv->state.effect_type = EF_NONE;
     render_priv->state.effect_timing = 0;
     render_priv->state.effect_skip_timing = 0;
+    render_priv->state.margin_x0 = 0;
+    render_priv->state.margin_y0 = 0;
+    render_priv->state.margin_x1 = 0;
+    render_priv->state.margin_y1 = 0;
+    render_priv->state.margin_set = 0;
 
     apply_transition_effects(render_priv, event);
     render_priv->state.explicit = render_priv->state.evt_type != EVENT_NORMAL ||
@@ -2562,8 +2567,16 @@ ass_render_event(ASS_Renderer *render_priv, ASS_Event *event,
         (event->MarginL) ? event->MarginL : render_priv->state.style->MarginL;
     int MarginR =
         (event->MarginR) ? event->MarginR : render_priv->state.style->MarginR;
-    int MarginV =
+    int MarginT =
         (event->MarginV) ? event->MarginV : render_priv->state.style->MarginV;
+    int MarginB = MarginT;
+
+    if (render_priv->state.margin_set) {
+        MarginL = render_priv->state.margin_x0;
+        MarginR = render_priv->state.margin_x1;
+        MarginT = render_priv->state.margin_y0;
+        MarginB = render_priv->state.margin_y1;
+    }
 
     // calculate max length of a line
     double max_text_width =
@@ -2616,7 +2629,7 @@ ass_render_event(ASS_Renderer *render_priv, ASS_Event *event,
         if (valign == VALIGN_TOP) {     // toptitle
             device_y =
                 y2scr_top(render_priv,
-                          MarginV) + text_info->lines[0].asc;
+                          MarginT) + text_info->lines[0].asc;
         } else if (valign == VALIGN_CENTER) {   // midtitle
             double scr_y =
                 y2scr(render_priv, render_priv->track->PlayResY / 2.0);
@@ -2630,7 +2643,7 @@ ass_render_event(ASS_Renderer *render_priv, ASS_Event *event,
                        "Invalid valign, assuming 0 (subtitle)");
             scr_bottom =
                 y2scr_sub(render_priv,
-                          render_priv->track->PlayResY - MarginV);
+                          render_priv->track->PlayResY - MarginB);
             scr_top = y2scr_top(render_priv, 0); //xxx not always 0?
             device_y = scr_bottom + (scr_top - scr_bottom) * line_pos / 100.0;
             device_y -= text_info->height;

--- a/libass/ass_render.h
+++ b/libass/ass_render.h
@@ -228,6 +228,8 @@ typedef struct {
     uint32_t c[4];              // colors(Primary, Secondary, so on) in RGBA
     int clip_x0, clip_y0, clip_x1, clip_y1;
     char clip_mode;             // 1 = iclip
+    int margin_x0, margin_y0, margin_x1, margin_y1;
+    char margin_set;
     char detect_collisions;
     int fade;                   // alpha from \fad
     char be;                    // blur edges


### PR DESCRIPTION
This essentially sets the margins. But it allows you to set different
margins for top and bottom (instead of only a "MarginV"), and takes a
rectangle instead of right/bottom margin values. Rather similar to for
example \clip.

Example: \box(500,50,700,100)

For now, either the top or bottom margin is ignored, depending on
alignment. A future idea might be to cut off the text in a non-ugly way,
such as ellipsization. (This would be controlled by other tags.)

This tag should be a nice addition in contexts where setting the the
event or style margins is too bothersome.