### PR TITLE
Ass compliance field

### DIFF
--- a/libass/Makefile.am
+++ b/libass/Makefile.am
@@ -5,7 +5,7 @@ AM_CFLAGS = -std=gnu99 -Wall -Wextra -Wno-sign-compare -Wno-unused-parameter \
 
 LIBASS_LT_CURRENT = 9
 LIBASS_LT_REVISION = 2
-LIBASS_LT_AGE = 0
+LIBASS_LT_AGE = 1
 
 nasm_verbose = $(nasm_verbose_$(V))
 nasm_verbose_ = $(nasm_verbose_$(AM_DEFAULT_VERBOSITY))

--- a/libass/ass.c
+++ b/libass/ass.c
@@ -58,6 +58,8 @@ struct parser_priv {
     uint32_t *read_order_bitmap;
     int read_order_elems; // size in uint32_t units of read_order_bitmap
     int check_readorder;
+
+    int enable_extensions;
 };
 
 #define ASS_STYLES_ALLOC 20
@@ -1325,6 +1327,17 @@ ASS_Track *ass_new_track(ASS_Library *library)
     }
     track->parser_priv->check_readorder = 1;
     return track;
+}
+
+int ass_track_set_feature(ASS_Track *track, ASS_Feature feature, int enable)
+{
+    switch (feature) {
+    case ASS_FEATURE_INCOMPATIBLE_EXTENSIONS:
+        track->parser_priv->enable_extensions = !!enable;
+        return 0;
+    default:
+        return -1;
+    }
 }
 
 /**

--- a/libass/ass.h
+++ b/libass/ass.h
@@ -24,7 +24,7 @@
 #include <stdarg.h>
 #include "ass_types.h"
 
-#define LIBASS_VERSION 0x01400000
+#define LIBASS_VERSION 0x01400001
 
 #ifdef __cplusplus
 extern "C" {
@@ -198,6 +198,19 @@ typedef enum {
     ASS_FONTPROVIDER_FONTCONFIG,
     ASS_FONTPROVIDER_DIRECTWRITE,
 } ASS_DefaultFontProvider;
+
+typedef enum {
+    /**
+     * Enable libass extensions that would display ASS subtitles incorrectly.
+     * These may be useful for applications, which use libass as renderer for
+     * subtitles converted from another format, or which use libass for other
+     * purposes that do not involve actual ASS subtitles authored for
+     * distribution.
+     */
+    ASS_FEATURE_INCOMPATIBLE_EXTENSIONS,
+
+    // New enum values can be added here in new ABI-compatible library releases.
+} ASS_Feature;
 
 /**
  * \brief Initialize the library.
@@ -511,6 +524,23 @@ ASS_Image *ass_render_frame(ASS_Renderer *priv, ASS_Track *track,
  * \return pointer to empty track
  */
 ASS_Track *ass_new_track(ASS_Library *);
+
+/**
+ * \brief Enable or disable certain features
+ * This manages flags that control the behavior of the renderer and how certain
+ * tags etc. within the track are interpreted. The defaults on a newly created
+ * ASS_Track are such that rendering is compatible with traditional renderers
+ * like VSFilter, and/or old versions of libass. Calling ass_process_data() or
+ * ass_process_codec_private() may change some of these flags according to file
+ * headers. (ass_process_chunk() will not change any of the flags.)
+ * Additions to ASS_Feature are backward compatible to old libass releases (ABI
+ * compatibility).
+ * \param track track
+ * \param feature the specific feature to enable or disable
+ * \param enable 0 for disable, any non-0 value for enable
+ * \return 0 if feature set, -1 if feature is unknown
+ */
+int ass_track_set_feature(ASS_Track *track, ASS_Feature feature, int enable);
 
 /**
  * \brief Deallocate track and all its child objects (styles and events).

--- a/libass/ass.h
+++ b/libass/ass.h
@@ -56,6 +56,7 @@ typedef struct ass_image {
         IMAGE_TYPE_SHADOW
     } type;
 
+    // New fields can be added here in new ABI-compatible library releases.
 } ASS_Image;
 
 /*
@@ -170,6 +171,7 @@ typedef enum {
      * On dialogue events override: Justify
      */
     ASS_OVERRIDE_BIT_JUSTIFY = 1 << 10,
+    // New enum values can be added here in new ABI-compatible library releases.
 } ASS_OverrideBits;
 
 /**

--- a/libass/ass_types.h
+++ b/libass/ass_types.h
@@ -166,6 +166,7 @@ typedef enum ASS_YCbCrMatrix {
     YCBCR_SMPTE240M_PC,
     YCBCR_FCC_TV,
     YCBCR_FCC_PC
+    // New enum values can be added here in new ABI-compatible library releases.
 } ASS_YCbCrMatrix;
 
 /*
@@ -205,6 +206,8 @@ typedef struct ass_track {
 
     ASS_Library *library;
     ASS_ParserPriv *parser_priv;
+
+    // New fields can be added here in new ABI-compatible library releases.
 } ASS_Track;
 
 #endif /* LIBASS_TYPES_H */

--- a/libass/libass.sym
+++ b/libass/libass.sym
@@ -43,3 +43,4 @@ ass_set_pixel_aspect
 ass_set_selective_style_override_enabled
 ass_set_selective_style_override
 ass_set_check_readorder
+ass_track_set_feature


### PR DESCRIPTION
This is a much discussed thing, that is supposed to enable us to disable
weird VSFilter compatibility hacks. Currently it obviously does nothing.

If we ever extend the libass format, the plan is that we may add a new
header to the ASS [Script Info] section, which causes the compliance
field set to a new (to be added) enum value.

In theory, we could reuse the track_type field for this purpose, but
that seems questionable. Better not touch anything related to SSA
compatibility.