### PR TITLE
Fix margin bugs and confusion

### DIFF
--- a/libass/ass.h
+++ b/libass/ass.h
@@ -170,6 +170,12 @@ typedef enum {
      * On dialogue events override: Justify
      */
     ASS_OVERRIDE_BIT_JUSTIFY = 1 << 10,
+    /**
+     * Change behavior if ass_set_margins() with non-0 values is called: do not
+     * attempt to apply scaling to normal dialogue text based on the margins,
+     * and use the screen size instead.
+     */
+    ASS_OVERRIDE_BIT_SANE_MARGINS = 1 << 11,
 } ASS_OverrideBits;
 
 /**

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -2714,6 +2714,12 @@ ass_render_event(ASS_Renderer *render_priv, ASS_Event *event,
         render_priv->state.clip_y0 = render_priv->state.clip_y0 < zy ? zy : render_priv->state.clip_y0;
         render_priv->state.clip_x1 = render_priv->state.clip_x1 > sx ? sx : render_priv->state.clip_x1;
         render_priv->state.clip_y1 = render_priv->state.clip_y1 > sy ? sy : render_priv->state.clip_y1;
+    } else if (render_priv->settings.use_margins) {
+        // no \clip (explicit==0) and use_margins => only clip to screen with margins
+        render_priv->state.clip_x0 = 0;
+        render_priv->state.clip_y0 = 0;
+        render_priv->state.clip_x1 = render_priv->settings.frame_width;
+        render_priv->state.clip_y1 = render_priv->settings.frame_height;
     }
 
     calculate_rotation_params(render_priv, &bbox, device_x, device_y);


### PR DESCRIPTION
This affects various cases. The first commit fixes https://github.com/mpv-player/mpv/issues/7557.

The second commit fixes problems that become visible especially when zooming and panning the video. This tends to trigger all sorts of corner cases. Unfortunately, the change is incompatible, which is why I had to gate it behind a flag (NB: would prefer using ASS_Feature for this). A mpv branch which uses this is at: https://github.com/mpv-player/mpv/compare/ass_shit