### PR TITLE
Fix & rework margins (black bars)

### DIFF
--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -2795,13 +2795,13 @@ ass_start_frame(ASS_Renderer *render_priv, ASS_Track *track,
     // PAR correction
     double par = render_priv->settings.par;
     if (par == 0.) {
-        if (settings_priv->frame_width && settings_priv->frame_height &&
+        if (render_priv->orig_width && render_priv->orig_height &&
             settings_priv->storage_width && settings_priv->storage_height) {
-            double dar = ((double) settings_priv->frame_width) /
-                         settings_priv->frame_height;
+            double dar = ((double) render_priv->orig_width) /
+                         render_priv->orig_height;
             double sar = ((double) settings_priv->storage_width) /
                          settings_priv->storage_height;
-            par = sar / dar;
+            par = dar / sar;
         } else
             par = 1.0;
     }

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -2734,7 +2734,7 @@ ass_render_event(ASS_Renderer *render_priv, ASS_Event *event,
     event_images->top = device_y - text_info->lines[0].asc;
     event_images->height = text_info->height;
     event_images->left =
-        (device_x + bbox.x_min * render_priv->font_scale_x) + 0.5;
+        (device_x + bbox.x_min) * render_priv->font_scale_x + 0.5;
     event_images->width =
         (bbox.x_max - bbox.x_min) * render_priv->font_scale_x + 0.5;
     event_images->detect_collisions = render_priv->state.detect_collisions;

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -2714,6 +2714,12 @@ ass_render_event(ASS_Renderer *render_priv, ASS_Event *event,
         render_priv->state.clip_y0 = render_priv->state.clip_y0 < zy ? zy : render_priv->state.clip_y0;
         render_priv->state.clip_x1 = render_priv->state.clip_x1 > sx ? sx : render_priv->state.clip_x1;
         render_priv->state.clip_y1 = render_priv->state.clip_y1 > sy ? sy : render_priv->state.clip_y1;
+    } else if (render_priv->settings.use_margins) {
+        // no \clip (explicit==0) and use_margins => only clip to screen with margins
+        render_priv->state.clip_x0 = 0;
+        render_priv->state.clip_y0 = 0;
+        render_priv->state.clip_x1 = render_priv->settings.frame_width;
+        render_priv->state.clip_y1 = render_priv->settings.frame_height;
     }
 
     calculate_rotation_params(render_priv, &bbox, device_x, device_y);

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -193,26 +193,40 @@ static double x2scr_pos(ASS_Renderer *render_priv, double x)
     return x * render_priv->orig_width / render_priv->font_scale_x / render_priv->track->PlayResX +
         render_priv->settings.left_margin;
 }
-static double x2scr(ASS_Renderer *render_priv, double x)
+static double x2scr_left(ASS_Renderer *render_priv, double x)
 {
-    if (render_priv->state.explicit)
+    if (render_priv->state.explicit || !render_priv->settings.use_margins)
         return x2scr_pos(render_priv, x);
-    return x * render_priv->orig_width_nocrop / render_priv->font_scale_x /
+    return x * render_priv->fit_width / render_priv->font_scale_x /
+        render_priv->track->PlayResX;
+}
+static double x2scr_right(ASS_Renderer *render_priv, double x)
+{
+    if (render_priv->state.explicit || !render_priv->settings.use_margins)
+        return x2scr_pos(render_priv, x);
+    return x * render_priv->fit_width / render_priv->font_scale_x /
         render_priv->track->PlayResX +
-        FFMAX(render_priv->settings.left_margin, 0);
+        (render_priv->width - render_priv->fit_width);
 }
 static double x2scr_pos_scaled(ASS_Renderer *render_priv, double x)
 {
     return x * render_priv->orig_width / render_priv->track->PlayResX +
         render_priv->settings.left_margin;
 }
-static double x2scr_scaled(ASS_Renderer *render_priv, double x)
+static double x2scr_left_scaled(ASS_Renderer *render_priv, double x)
 {
-    if (render_priv->state.explicit)
+    if (render_priv->state.explicit || !render_priv->settings.use_margins)
         return x2scr_pos_scaled(render_priv, x);
-    return x * render_priv->orig_width_nocrop /
+    return x * render_priv->fit_width /
+        render_priv->track->PlayResX;
+}
+static double x2scr_right_scaled(ASS_Renderer *render_priv, double x)
+{
+    if (render_priv->state.explicit || !render_priv->settings.use_margins)
+        return x2scr_pos_scaled(render_priv, x);
+    return x * render_priv->fit_width /
         render_priv->track->PlayResX +
-        FFMAX(render_priv->settings.left_margin, 0);
+        (render_priv->width - render_priv->fit_width);
 }
 /**
  * \brief Mapping between script and screen coordinates
@@ -224,40 +238,29 @@ static double y2scr_pos(ASS_Renderer *render_priv, double y)
 }
 static double y2scr(ASS_Renderer *render_priv, double y)
 {
-    if (render_priv->state.explicit)
+    if (render_priv->state.explicit || !render_priv->settings.use_margins)
         return y2scr_pos(render_priv, y);
-    return y * render_priv->orig_height_nocrop /
+    return y * render_priv->fit_height /
         render_priv->track->PlayResY +
-        FFMAX(render_priv->settings.top_margin, 0);
+        (render_priv->height - render_priv->fit_height) * 0.5;
 }
 
 // the same for toptitles
 static double y2scr_top(ASS_Renderer *render_priv, double y)
 {
-    if (render_priv->state.explicit)
+    if (render_priv->state.explicit || !render_priv->settings.use_margins)
         return y2scr_pos(render_priv, y);
-    if (render_priv->settings.use_margins)
-        return y * render_priv->orig_height_nocrop /
-            render_priv->track->PlayResY;
-    else
-        return y * render_priv->orig_height_nocrop /
-            render_priv->track->PlayResY +
-            FFMAX(render_priv->settings.top_margin, 0);
+    return y * render_priv->fit_height /
+        render_priv->track->PlayResY;
 }
 // the same for subtitles
 static double y2scr_sub(ASS_Renderer *render_priv, double y)
 {
-    if (render_priv->state.explicit)
+    if (render_priv->state.explicit || !render_priv->settings.use_margins)
         return y2scr_pos(render_priv, y);
-    if (render_priv->settings.use_margins)
-        return y * render_priv->orig_height_nocrop /
-            render_priv->track->PlayResY +
-            FFMAX(render_priv->settings.top_margin, 0)
-            + FFMAX(render_priv->settings.bottom_margin, 0);
-    else
-        return y * render_priv->orig_height_nocrop /
-            render_priv->track->PlayResY +
-            FFMAX(render_priv->settings.top_margin, 0);
+    return y * render_priv->fit_height /
+        render_priv->track->PlayResY +
+        (render_priv->height - render_priv->fit_height);
 }
 
 /*
@@ -961,17 +964,18 @@ static void init_font_scale(ASS_Renderer *render_priv)
 {
     ASS_Settings *settings_priv = &render_priv->settings;
 
-    render_priv->font_scale = ((double) render_priv->orig_height) /
-                              render_priv->track->PlayResY;
+    double font_scr_h = render_priv->orig_height;
+    if (!render_priv->state.explicit && render_priv->settings.use_margins)
+        font_scr_h = render_priv->fit_height;
+
+    render_priv->font_scale = font_scr_h / render_priv->track->PlayResY;
     if (settings_priv->storage_height)
-        render_priv->blur_scale = ((double) render_priv->orig_height) /
-            settings_priv->storage_height;
+        render_priv->blur_scale = font_scr_h / settings_priv->storage_height;
     else
         render_priv->blur_scale = 1.;
     if (render_priv->track->ScaledBorderAndShadow)
         render_priv->border_scale =
-            ((double) render_priv->orig_height) /
-            render_priv->track->PlayResY;
+            font_scr_h / render_priv->track->PlayResY;
     else
         render_priv->border_scale = render_priv->blur_scale;
     if (!settings_priv->storage_height)
@@ -2144,8 +2148,8 @@ static void calculate_rotation_params(ASS_Renderer *render_priv, ASS_DRect *bbox
 {
     ASS_DVector center;
     if (render_priv->state.have_origin) {
-        center.x = x2scr(render_priv, render_priv->state.org_x);
-        center.y = y2scr(render_priv, render_priv->state.org_y);
+        center.x = x2scr_pos(render_priv, render_priv->state.org_x);
+        center.y = y2scr_pos(render_priv, render_priv->state.org_y);
     } else {
         double bx = 0., by = 0.;
         get_base_point(bbox, render_priv->state.alignment, &bx, &by);
@@ -2567,8 +2571,8 @@ ass_render_event(ASS_Renderer *render_priv, ASS_Event *event,
 
     // calculate max length of a line
     double max_text_width =
-        x2scr(render_priv, render_priv->track->PlayResX - MarginR) -
-        x2scr(render_priv, MarginL);
+        x2scr_right(render_priv, render_priv->track->PlayResX - MarginR) -
+        x2scr_left(render_priv, MarginL);
 
     // wrap lines
     if (render_priv->state.evt_type != EVENT_HSCROLL) {
@@ -2596,16 +2600,16 @@ ass_render_event(ASS_Renderer *render_priv, ASS_Event *event,
     double device_x = 0;
     if (render_priv->state.evt_type == EVENT_NORMAL ||
         render_priv->state.evt_type == EVENT_VSCROLL) {
-        device_x = x2scr(render_priv, MarginL);
+        device_x = x2scr_left(render_priv, MarginL);
     } else if (render_priv->state.evt_type == EVENT_HSCROLL) {
         if (render_priv->state.scroll_direction == SCROLL_RL)
             device_x =
-                x2scr(render_priv,
+                x2scr_pos(render_priv,
                       render_priv->track->PlayResX -
                       render_priv->state.scroll_shift);
         else if (render_priv->state.scroll_direction == SCROLL_LR)
             device_x =
-                x2scr(render_priv, render_priv->state.scroll_shift) -
+                x2scr_pos(render_priv, render_priv->state.scroll_shift) -
                 (bbox.x_max - bbox.x_min);
     }
 
@@ -2673,9 +2677,9 @@ ass_render_event(ASS_Renderer *render_priv, ASS_Event *event,
         render_priv->state.evt_type == EVENT_HSCROLL ||
         render_priv->state.evt_type == EVENT_VSCROLL) {
         render_priv->state.clip_x0 =
-            x2scr_scaled(render_priv, render_priv->state.clip_x0);
+            x2scr_left_scaled(render_priv, render_priv->state.clip_x0);
         render_priv->state.clip_x1 =
-            x2scr_scaled(render_priv, render_priv->state.clip_x1);
+            x2scr_right_scaled(render_priv, render_priv->state.clip_x1);
         if (valign == VALIGN_TOP) {
             render_priv->state.clip_y0 =
                 y2scr_top(render_priv, render_priv->state.clip_y0);

--- a/libass/ass_render.h
+++ b/libass/ass_render.h
@@ -64,12 +64,12 @@ typedef struct {
     double font_size_coeff;     // font size multiplier
     double line_spacing;        // additional line spacing (in frame pixels)
     double line_position;       // vertical position for subtitles, 0-100 (0 = no change)
-    int top_margin;             // height of top margin. Everything except toptitles is shifted down by top_margin.
+    int top_margin;             // height of top margin. Video frame is shifted down by top_margin.
     int bottom_margin;          // height of bottom margin. (frame_height - top_margin - bottom_margin) is original video height.
     int left_margin;
     int right_margin;
     int use_margins;            // 0 - place all subtitles inside original frame
-    // 1 - use margins for placing toptitles and subtitles
+    // 1 - place subtitles (incl. toptitles) in full display frame incl. margins
     double par;                 // user defined pixel aspect ratio (0 = unset)
     ASS_Hinting hinting;
     ASS_ShapingLevel shaper;
@@ -301,8 +301,8 @@ struct ass_renderer {
     int width, height;          // screen dimensions
     int orig_height;            // frame height ( = screen height - margins )
     int orig_width;             // frame width ( = screen width - margins )
-    int orig_height_nocrop;     // frame height ( = screen height - margins + cropheight)
-    int orig_width_nocrop;      // frame width ( = screen width - margins + cropwidth)
+    double fit_height;          // frame height without zoom & pan (fit to screen & letterboxed)
+    double fit_width;           // frame width without zoom & pan (fit to screen & letterboxed)
     ASS_Track *track;
     long long time;             // frame's timestamp, ms
     double font_scale;

--- a/libass/ass_render_api.c
+++ b/libass/ass_render_api.c
@@ -37,12 +37,16 @@ static void ass_reconfigure(ASS_Renderer *priv)
         settings->right_margin;
     priv->orig_height = settings->frame_height - settings->top_margin -
         settings->bottom_margin;
-    priv->orig_width_nocrop =
-        settings->frame_width - FFMAX(settings->left_margin, 0) -
-        FFMAX(settings->right_margin, 0);
-    priv->orig_height_nocrop =
-        settings->frame_height - FFMAX(settings->top_margin, 0) -
-        FFMAX(settings->bottom_margin, 0);
+    priv->fit_width =
+        (long long) priv->orig_width * priv->height >=
+        (long long) priv->orig_height * priv->width ?
+            priv->width :
+            (double) priv->orig_width * priv->height / priv->orig_height;
+    priv->fit_height =
+        (long long) priv->orig_width * priv->height <=
+        (long long) priv->orig_height * priv->width ?
+            priv->height :
+            (double) priv->orig_height * priv->width / priv->orig_width;
 }
 
 void ass_set_frame_size(ASS_Renderer *priv, int w, int h)


### PR DESCRIPTION
Follow-up to #384 as discussed on IRC.

Like #384, this makes all affected subtitles fixed within the screen/window frame and unaffected by any further pan & zoom in the media player, and disables all of this entirely when `!use_margins`.

The difference is that elements are scaled to the same sizes they would be if the screen/window was displaying a fit-to-screen letterboxed video at 100% zoom & no pan, sans the black bars from letterboxing. For example, opening a 1920×720 video on a 1920×1200 screen and then going full screen keeps element sizes unchanged (except very slightly to adjust for the disappearing menu bars etc.). _(In mpv, element sizes are enlarged because it explicitly does this with its `--sub-scale-with-video` option. Use `--sub-ass-force-margins` and play ASS to see it in action.)_

This is desirable especially for ASS or other styled subtitles where the font size is explicitly set in the subtitles and lines are manually broken to ensure a nice amount of text on screen. This also preserves the scaling mpv experiences currently, so user-configured font sizes stay the same and mpv’s sub scaling options keep working.

I also fixed a couple aspect ratio bugs that I found while figuring out the difference between `x2scr` and `x2scr_scaled`.