### PR TITLE
Static analysis warning fixes

### DIFF
--- a/libass/ass.c
+++ b/libass/ass.c
@@ -163,6 +163,7 @@ static int resize_read_order_bitmap(ASS_Track *track, int max_id)
     // Don't allow malicious files to OOM us easily. Also avoids int overflows.
     if (max_id < 0 || max_id >= 10 * 1024 * 1024 * 8)
         goto fail;
+    assert(track->parser_priv->read_order_bitmap || !track->parser_priv->read_order_elems);
     if (max_id >= track->parser_priv->read_order_elems * 32) {
         int oldelems = track->parser_priv->read_order_elems;
         int elems = ((max_id + 31) / 32 + 1) * 2;

--- a/libass/ass_coretext.c
+++ b/libass/ass_coretext.c
@@ -62,18 +62,19 @@ static void destroy_font(void *priv)
 
 static bool check_postscript(void *priv)
 {
+    bool ret = false;
     CTFontDescriptorRef fontd = priv;
     CFNumberRef cfformat =
         CTFontDescriptorCopyAttribute(fontd, kCTFontFormatAttribute);
     int format;
 
-    if (!CFNumberGetValue(cfformat, kCFNumberIntType, &format))
-        return false;
+    if (CFNumberGetValue(cfformat, kCFNumberIntType, &format)) {
+        ret = format == kCTFontFormatOpenTypePostScript ||
+              format == kCTFontFormatPostScript;
+    }
 
     SAFE_CFRelease(cfformat);
-
-    return format == kCTFontFormatOpenTypePostScript ||
-           format == kCTFontFormatPostScript;
+    return ret;
 }
 
 static bool check_glyph(void *priv, uint32_t code)

--- a/libass/ass_fontselect.c
+++ b/libass/ass_fontselect.c
@@ -968,6 +968,7 @@ static void process_fontdata(ASS_FontProvider *priv, ASS_Library *library,
         if (!ass_font_provider_add_font(priv, &info, NULL, face_index, ft)) {
             ass_msg(library, MSGL_WARN, "Failed to add embedded font '%s'",
                     name);
+            free(ft);
         }
 
         free_font_info(&info);

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -124,6 +124,9 @@ ASS_Renderer *ass_renderer_init(ASS_Library *library)
 
 void ass_renderer_done(ASS_Renderer *render_priv)
 {
+    if (!render_priv)
+        return;
+
     ass_frame_unref(render_priv->images_root);
     ass_frame_unref(render_priv->prev_images_root);
 

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -1990,10 +1990,10 @@ static void retrieve_glyphs(ASS_Renderer *render_priv)
 
     for (i = 0; i < render_priv->text_info.length; i++) {
         GlyphInfo *info = glyphs + i;
-        while (info) {
+        do {
             get_outline_glyph(render_priv, info);
             info = info->next;
-        }
+        } while (info);
         info = glyphs + i;
 
         // Add additional space after italic to non-italic style changes
@@ -2022,7 +2022,7 @@ static void preliminary_layout(ASS_Renderer *render_priv)
     for (int i = 0; i < render_priv->text_info.length; i++) {
         GlyphInfo *info = render_priv->text_info.glyphs + i;
         ASS_Vector cluster_pen = pen;
-        while (info) {
+        do {
             info->pos.x = cluster_pen.x;
             info->pos.y = cluster_pen.y;
 
@@ -2030,7 +2030,7 @@ static void preliminary_layout(ASS_Renderer *render_priv)
             cluster_pen.y += info->advance.y;
 
             info = info->next;
-        }
+        } while (info);
         info = render_priv->text_info.glyphs + i;
         pen.x += info->cluster_advance.x;
         pen.y += info->cluster_advance.y;

--- a/libass/ass_render.h
+++ b/libass/ass_render.h
@@ -201,42 +201,46 @@ typedef struct {
 typedef struct {
     ASS_Event *event;
     ASS_Style *style;
-    int parsed_tags;
 
     ASS_Font *font;
     double font_size;
+    int parsed_tags;
     int flags;                  // decoration flags (underline/strike-through)
 
     int alignment;              // alignment overrides go here; if zero, style value will be used
     int justify;                // justify instructions
     double frx, fry, frz;
     double fax, fay;            // text shearing
+    double pos_x, pos_y;        // position
+    double org_x, org_y;        // origin
+    double scale_x, scale_y;
+    double hspacing;            // distance between letters, in pixels
+    double border_x;            // outline width
+    double border_y;
     enum {
         EVENT_NORMAL,           // "normal" top-, sub- or mid- title
         EVENT_POSITIONED,       // happens after pos(,), margins are ignored
         EVENT_HSCROLL,          // "Banner" transition effect, text_width is unlimited
         EVENT_VSCROLL           // "Scroll up", "Scroll down" transition effects
     } evt_type;
-    double pos_x, pos_y;        // position
-    double org_x, org_y;        // origin
-    char have_origin;           // origin is explicitly defined; if 0, get_base_point() is used
-    double scale_x, scale_y;
-    double hspacing;            // distance between letters, in pixels
     int border_style;
-    double border_x;            // outline width
-    double border_y;
     uint32_t c[4];              // colors(Primary, Secondary, so on) in RGBA
     int clip_x0, clip_y0, clip_x1, clip_y1;
+    char have_origin;           // origin is explicitly defined; if 0, get_base_point() is used
     char clip_mode;             // 1 = iclip
     char detect_collisions;
-    int fade;                   // alpha from \fad
     char be;                    // blur edges
+    int fade;                   // alpha from \fad
     double blur;                // gaussian blur
     double shadow_x;
     double shadow_y;
-    int drawing_scale;          // currently reading: regular text if 0, drawing otherwise
     double pbo;                 // drawing baseline offset
     char *clip_drawing_text;
+
+    // used to store RenderContext.style when doing selective style overrides
+    ASS_Style override_style_temp_storage;
+
+    int drawing_scale;          // currently reading: regular text if 0, drawing otherwise
     int clip_drawing_scale;
     int clip_drawing_mode;      // 0 = regular clip, 1 = inverse clip
 
@@ -266,9 +270,6 @@ typedef struct {
     int apply_font_scale;
     // whether this is assumed to be explicitly positioned
     int explicit;
-
-    // used to store RenderContext.style when doing selective style overrides
-    ASS_Style override_style_temp_storage;
 } RenderContext;
 
 typedef struct {

--- a/libass/x86/cpuid.h
+++ b/libass/x86/cpuid.h
@@ -19,6 +19,8 @@
 #ifndef INTEL_CPUID_H
 #define INTEL_CPUID_H
 
+#include <stdint.h>
+
 void ass_get_cpuid( uint32_t *eax, uint32_t *ebx, uint32_t *ecx, uint32_t *edx);
 void ass_get_xgetbv( uint32_t op, uint32_t *eax, uint32_t *edx );
 


### PR DESCRIPTION
Ran scan-build while poking around at clang-tidy and clang-format, and turned up some warnings. Some were false positives (but could easily be silenced in ways that improved code clarity); some were legitimate bugs. In the process, I ran into a couple additional bugs and went ahead and fixed them as well.