### PR TITLE
Border collision and \an456 stacking

### DIFF
--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -1493,6 +1493,15 @@ size_t ass_bitmap_construct(void *key, void *value, void *priv)
     return sizeof(BitmapHashKey) + sizeof(Bitmap) + bitmap_size(bm);
 }
 
+static void measure_text_on_eol(ASS_Renderer *render_priv, double scale, int cur_line,
+                                int max_asc, int max_desc)
+{
+    render_priv->text_info.lines[cur_line].asc  = scale * max_asc;
+    render_priv->text_info.lines[cur_line].desc = scale * max_desc;
+    render_priv->text_info.height += scale * max_asc + scale * max_desc;
+}
+
+
 /**
  * This function goes through text_info and calculates text parameters.
  * The following text_info fields are filled:
@@ -1511,9 +1520,7 @@ static void measure_text(ASS_Renderer *render_priv)
     int max_asc = 0, max_desc = 0;
     for (int i = 0; i < text_info->length; i++) {
         if (text_info->glyphs[i].linebreak) {
-            text_info->lines[cur_line].asc  = scale * max_asc;
-            text_info->lines[cur_line].desc = scale * max_desc;
-            text_info->height += scale * max_asc + scale * max_desc;
+            measure_text_on_eol(render_priv, scale, cur_line, max_asc, max_desc);
             max_asc = max_desc = 0;
             scale = 0.5 / 64;
             cur_line++;
@@ -1525,9 +1532,7 @@ static void measure_text(ASS_Renderer *render_priv)
             scale = 1.0 / 64;
     }
     assert(cur_line == text_info->n_lines - 1);
-    text_info->lines[cur_line].asc  = scale * max_asc;
-    text_info->lines[cur_line].desc = scale * max_desc;
-    text_info->height += scale * max_asc + scale * max_desc;
+    measure_text_on_eol(render_priv, scale, cur_line, max_asc, max_desc);
     text_info->height += cur_line * render_priv->settings.line_spacing;
 }
 

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -2754,7 +2754,7 @@ ass_render_event(ASS_Renderer *render_priv, ASS_Event *event,
     event_images->width =
         (bbox.x_max - bbox.x_min) * render_priv->font_scale_x + 0.5;
     event_images->detect_collisions = render_priv->state.detect_collisions;
-    event_images->shift_direction = (valign == VALIGN_TOP) ? 1 : -1;
+    event_images->shift_direction = (valign == VALIGN_SUB) ? -1 : 1;
     event_images->event = event;
     event_images->imgs = render_text(render_priv);
 

--- a/libass/ass_render.h
+++ b/libass/ass_render.h
@@ -191,6 +191,9 @@ typedef struct {
     CombinedBitmapInfo *combined_bitmaps;
     unsigned n_bitmaps;
     double height;
+    int border_top;
+    int border_bottom;
+    int border_x;
     int max_glyphs;
     int max_lines;
     unsigned max_bitmaps;


### PR DESCRIPTION
This pr changes implicit positioning to take Borders into account (like *VSFilter) and also changes the shift direction for `\an4,5,6` lines to match *VSFilter.
closes #304 
closes #143 

~~This pr is as of now not yet ready for merge.
However I'd would be niceto get some feedback if the chosen approach seems sensible.~~

--snip-- *(Moved the originally present/unidentified issues down as they have been adressed)*

As I couldn't locate the relevant part of VSFilter code, I relied on the info from #154 and test ASS files. VSFilter seems to only care about the maximal x-border, even if it's far from the edge of a line.

To test this pr I used these two ASS-Files
[Bord-Coll-ASS.zip](https://github.com/libass/libass/files/4638387/Bord-Coll-ASS.zip)
and
[More-ASS-files.zip](https://github.com/libass/libass/files/4641184/More-ASS-files.zip)

, rendered on an 640×480 video: 
[test-video.zip](https://github.com/libass/libass/files/4638382/test-video.zip)

**Still needs to be addressed:**

- [x] ~~1px VSF-libass difference in the `bordy-var` sample for small borders.~~
- [x] Evaluate possible side effects of changing `event_image` size
      or if it is better to only change the `Segment`
- [x] If no one objects, this patch will also change to `BorderStyle=4`, update the docs
    in the wiki https://github.com/libass/libass/wiki/Libass'-ASS-Extensions#borderstyle4 *(made preliminary changes to doc)*

---

**Problems with patch v1:** (have been adressed)
While testing I found some issues that don't seem to be caused by this pr; thoughts on what t do with those would also be appreciated.

1) ~~x-VSF moves colliding \an6 down; libass up (`bordx-coll2.ass`)~~ ~~#143~~ **[Patch included]**

*Only with Border-Style=3:  (related to: https://code.google.com/archive/p/libass/wikis/IssuesAndDifferences.wiki ? )*

2) ~~x-VSF moves \an4 1px down if there's any \bord30 compared to only \bord1; libass does not (`bordx-coll2.ass`).  Idk why VSFilter does this. *(EDIT: with different values a shift >1px can be achieved)*~~ **#396 [xy-VSFilter bug]**
3) ~~In xy-VSF there's sometimes a thin 1px line visible between stacked bordstyl3 (`bordy-coll.ass`),
   but vertical text distance is identical to libass. Might not be positioning issue, but with how border-style3 is drawn~~ *[confirmed to also happen without patch and **out of scope**]*

`2.` and `3.` do not occur if using Borderstyle=1.