### PR TITLE
Make harfbuzz a hard dependency

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -47,8 +47,6 @@ AC_ARG_ENABLE([coretext], AS_HELP_STRING([--disable-coretext],
     [disable CoreText support (OSX only) @<:@default=check@:>@]))
 AC_ARG_ENABLE([require-system-font-provider], AS_HELP_STRING([--disable-require-system-font-provider],
     [allow compilation even if no system font provider was found @<:@default=enabled:>@]))
-AC_ARG_ENABLE([harfbuzz], AS_HELP_STRING([--disable-harfbuzz],
-    [disable HarfBuzz support @<:@default=check@:>@]))
 AC_ARG_ENABLE([asm], AS_HELP_STRING([--disable-asm],
     [disable compiling with ASM @<:@default=check@:>@]))
 AC_ARG_ENABLE([large-tiles], AS_HELP_STRING([--enable-large-tiles],
@@ -210,14 +208,11 @@ AC_LINK_IFELSE([
 fi
 AM_CONDITIONAL([DIRECTWRITE], [test x$directwrite = xtrue])
 
-if test x$enable_harfbuzz != xno; then
 PKG_CHECK_MODULES([HARFBUZZ], harfbuzz >= 1.2.3, [
     CFLAGS="$CFLAGS $HARFBUZZ_CFLAGS"
     LIBS="$LIBS $HARFBUZZ_LIBS"
-    AC_DEFINE(CONFIG_HARFBUZZ, 1, [found harfbuzz-ng via pkg-config])
-	harfbuzz=true
-    ], [harfbuzz=false])
-fi
+    AC_DEFINE(CONFIG_HARFBUZZ, 1, [found harfbuzz via pkg-config])
+    ])
 
 libpng=false
 if test x$enable_test = xyes || test x$enable_compare = xyes; then
@@ -242,11 +237,9 @@ if test "$use_libiconv" = true; then
 fi
 pkg_requires="freetype2 >= 9.10.3"
 pkg_requires="fribidi >= 0.19.0, ${pkg_requires}"
+pkg_requires="harfbuzz >= 1.2.3, ${pkg_requires}"
 if test x$fontconfig = xtrue; then
     pkg_requires="fontconfig >= 2.10.92, ${pkg_requires}"
-fi
-if test x$harfbuzz = xtrue; then
-    pkg_requires="harfbuzz >= 1.2.3, ${pkg_requires}"
 fi
 
 if test x$enable_require_system_font_provider != xno &&

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -113,11 +113,7 @@ ASS_Renderer *ass_renderer_init(ASS_Library *library)
         goto fail;
 
     ass_shaper_info(library);
-#ifdef CONFIG_HARFBUZZ
     priv->settings.shaper = ASS_SHAPING_COMPLEX;
-#else
-    priv->settings.shaper = ASS_SHAPING_SIMPLE;
-#endif
 
     ass_msg(library, MSGL_V, "Initialized");
 

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -2613,7 +2613,7 @@ ass_render_event(ASS_Renderer *render_priv, ASS_Event *event,
             resolve_base_direction(render_priv->state.font_encoding));
     ass_shaper_find_runs(render_priv->shaper, render_priv, text_info->glyphs,
             text_info->length);
-    if (ass_shaper_shape(render_priv->shaper, text_info) < 0) {
+    if (!ass_shaper_shape(render_priv->shaper, text_info)) {
         ass_msg(render_priv->library, MSGL_ERR, "Failed to shape text");
         free_render_context(render_priv);
         return false;

--- a/libass/ass_render.h
+++ b/libass/ass_render.h
@@ -26,9 +26,7 @@
 #include FT_FREETYPE_H
 #include FT_GLYPH_H
 #include FT_SYNTHESIS_H
-#ifdef CONFIG_HARFBUZZ
 #include <hb.h>
-#endif
 
 #include "ass.h"
 #include "ass_font.h"
@@ -128,11 +126,7 @@ typedef struct glyph_info {
     ASS_Font *font;
     int face_index;
     int glyph_index;
-#ifdef CONFIG_HARFBUZZ
     hb_script_t script;
-#else
-    int script;
-#endif
     double font_size;
     char *drawing_text;
     int drawing_scale;

--- a/libass/ass_render_api.c
+++ b/libass/ass_render_api.c
@@ -70,13 +70,11 @@ void ass_set_storage_size(ASS_Renderer *priv, int w, int h)
 
 void ass_set_shaper(ASS_Renderer *priv, ASS_ShapingLevel level)
 {
-#ifdef CONFIG_HARFBUZZ
     // select the complex shaper for illegal values
     if (level == ASS_SHAPING_SIMPLE || level == ASS_SHAPING_COMPLEX)
         priv->settings.shaper = level;
     else
         priv->settings.shaper = ASS_SHAPING_COMPLEX;
-#endif
 }
 
 void ass_set_margins(ASS_Renderer *priv, int t, int b, int l, int r)

--- a/libass/ass_shaper.c
+++ b/libass/ass_shaper.c
@@ -849,14 +849,14 @@ static void ass_shaper_skip_characters(TextInfo *text_info)
  * \param text_info event's text
  * \return success, when 0
  */
-int ass_shaper_shape(ASS_Shaper *shaper, TextInfo *text_info)
+bool ass_shaper_shape(ASS_Shaper *shaper, TextInfo *text_info)
 {
     int i, ret, last_break;
     FriBidiParType dir;
     GlyphInfo *glyphs = text_info->glyphs;
 
     if (!check_allocations(shaper, text_info->length))
-        return -1;
+        return false;
 
     // Get bidi character types and embedding levels
     last_break = 0;
@@ -883,7 +883,7 @@ int ass_shaper_shape(ASS_Shaper *shaper, TextInfo *text_info)
                     i - last_break + 1, &dir, shaper->emblevels + last_break);
 #endif
             if (ret == 0)
-                return -1;
+                return false;
             last_break = i + 1;
         }
     }
@@ -898,7 +898,7 @@ int ass_shaper_shape(ASS_Shaper *shaper, TextInfo *text_info)
         break;
     }
 
-    return 0;
+    return true;
 }
 
 /**

--- a/libass/ass_shaper.h
+++ b/libass/ass_shaper.h
@@ -42,7 +42,7 @@ void ass_shaper_set_level(ASS_Shaper *shaper, ASS_ShapingLevel level);
 #ifdef USE_FRIBIDI_EX_API
 void ass_shaper_set_bidi_brackets(ASS_Shaper *shaper, bool match_brackets);
 #endif
-int ass_shaper_shape(ASS_Shaper *shaper, TextInfo *text_info);
+bool ass_shaper_shape(ASS_Shaper *shaper, TextInfo *text_info);
 void ass_shaper_cleanup(ASS_Shaper *shaper, TextInfo *text_info);
 FriBidiStrIndex *ass_shaper_reorder(ASS_Shaper *shaper, TextInfo *text_info);
 FriBidiParType resolve_base_direction(int font_encoding);


### PR DESCRIPTION
Closes #199.
The hb-ft commit means harfbuzz no longer needs to depend on freetype to work with libass.
Also adds some missing malloc error checking.