### PR TITLE
Add checkasm and arm64/aarch64 assembly

### DIFF
--- a/.github/workflows/ghci.yml
+++ b/.github/workflows/ghci.yml
@@ -124,11 +124,11 @@ jobs:
 
       - name: compile
         if: matrix.do_distc != 'yes'
-        run: make -j 2
+        run: make -j 2 V=1
 
       - name: distcheck
         if: matrix.do_distc == 'yes'
-        run: make -j 2 distcheck
+        run: make -j 2 distcheck V=1
 
       - name: Coverity scan
         if: >

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ Makefile.in
 /test/test*
 /compare/compare*
 /profile/profile*
+/checkasm/checkasm*
 
 # pkgconfig
 /libass.pc
@@ -37,3 +38,4 @@ Makefile.in
 /ltmain.sh
 /missing
 /m4
+/test-driver

--- a/.gitignore
+++ b/.gitignore
@@ -19,9 +19,14 @@ Makefile.in
 
 # Test programs
 /test/test*
+!/test/test.c
 /compare/compare*
+!/test/compare/compare.c
 /profile/profile*
+!/profile/profile.c
 /checkasm/checkasm*
+!/checkasm/checkasm.c
+!/checkasm/checkasm.h
 
 # pkgconfig
 /libass.pc

--- a/Makefile.am
+++ b/Makefile.am
@@ -16,5 +16,8 @@ if ENABLE_PROFILE
     profile = profile
 endif
 
-SUBDIRS = libass $(test) $(compare) $(profile)
+if ASM
+    checkasm = checkasm
+endif
 
+SUBDIRS = libass $(test) $(compare) $(profile) $(checkasm)

--- a/checkasm/Makefile.am
+++ b/checkasm/Makefile.am
@@ -1,0 +1,28 @@
+AM_CFLAGS = -Wall
+
+check_PROGRAMS = checkasm
+checkasm_SOURCES = checkasm.h checkasm.c blend_bitmaps.c be_blur.c
+checkasm_CPPFLAGS = -I$(top_srcdir)/libass
+checkasm_LDADD = $(top_builddir)/libass/.libs/libass.a
+checkasm_LDFLAGS = $(AM_LDFLAGS) -static
+
+nasm_verbose = $(nasm_verbose_$(V))
+nasm_verbose_ = $(nasm_verbose_$(AM_DEFAULT_VERBOSITY))
+nasm_verbose_0 = @echo "  NASM    " $@;
+
+.asm.o:
+	$(nasm_verbose)$(AS) $(ASFLAGS) -I$(top_srcdir)/libass/ -o $@ $<
+
+if INTEL
+checkasm_SOURCES += x86/checkasm.asm
+endif
+
+run-checkasm: checkasm$(EXEEXT)
+	./checkasm$(EXEEXT)
+
+run-checkasm-bench: checkasm$(EXEEXT)
+	./checkasm$(EXEEXT) --bench
+
+TESTS = checkasm$(EXEEXT)
+
+bench: run-checkasm-bench

--- a/checkasm/be_blur.c
+++ b/checkasm/be_blur.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2020 rcombs <rcombs@rcombs.me>
+ *
+ * This file is part of libass.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "checkasm.h"
+
+#include "ass_bitmap.h"
+
+#define HEIGHT 8
+#define STRIDE 64
+#define MIN_WIDTH 2
+
+static void check_be_blur(BeBlurFunc func)
+{
+    if (check_func(func, "be_blur")) {
+        ALIGN(uint8_t buf_ref[STRIDE * HEIGHT], 32);
+        ALIGN(uint8_t buf_new[STRIDE * HEIGHT], 32);
+        ALIGN(uint16_t tmp[STRIDE * 2], 32);
+        declare_func(void,
+                     uint8_t *buf, intptr_t stride,
+                     intptr_t width, intptr_t height, uint16_t *tmp);
+
+        for (int w = MIN_WIDTH; w <= STRIDE; w++) {
+            memset(buf_ref, 0, sizeof(buf_ref));
+            memset(buf_new, 0, sizeof(buf_new));
+            for (int y = 0; y < HEIGHT; y++) {
+                for (int x = 0; x < w; x++)
+                    buf_ref[y * STRIDE + x] = buf_new[y * STRIDE + x] = rnd();
+            }
+
+            memset(tmp, 0, sizeof(tmp));
+            call_ref(buf_ref, STRIDE,
+                     w, HEIGHT, tmp);
+            memset(tmp, 0, sizeof(tmp));
+            call_new(buf_new, STRIDE,
+                     w, HEIGHT, tmp);
+
+            for (int i = 0; i < HEIGHT; i++) {
+                if (memcmp(buf_ref + STRIDE * i,
+                           buf_new + STRIDE * i,
+                           w)) {
+                    fail();
+                    goto fail;
+                }
+            }
+        }
+
+        fail:
+        bench_new(buf_new, STRIDE, STRIDE, HEIGHT, tmp);
+    }
+
+    report("be_blur");
+}
+
+void checkasm_check_be_blur(const BitmapEngine *engine)
+{
+    check_be_blur(engine->be_blur);
+}

--- a/checkasm/blend_bitmaps.c
+++ b/checkasm/blend_bitmaps.c
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2020 rcombs <rcombs@rcombs.me>
+ *
+ * This file is part of libass.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "checkasm.h"
+
+#define HEIGHT 8
+#define DST_STRIDE 64
+#define MIN_WIDTH  1
+#define SRC1_STRIDE 96
+#define SRC2_STRIDE 128
+
+static void check_blend_bitmaps(BitmapBlendFunc func, const char *name)
+{
+    if (check_func(func, name)) {
+        ALIGN(uint8_t src[SRC1_STRIDE * HEIGHT], 32);
+        ALIGN(uint8_t dst_ref[DST_STRIDE * HEIGHT], 32);
+        ALIGN(uint8_t dst_new[DST_STRIDE * HEIGHT], 32);
+        declare_func(void,
+                     uint8_t *dst, intptr_t dst_stride,
+                     uint8_t *src, intptr_t src_stride,
+                     intptr_t width, intptr_t height);
+
+        for (int w = MIN_WIDTH; w <= DST_STRIDE; w++) {
+            for (int i = 0; i < sizeof(src); i++)
+                src[i] = rnd();
+
+            for (int i = 0; i < sizeof(dst_ref); i++)
+                dst_ref[i] = dst_new[i] = rnd();
+
+            call_ref(dst_ref, DST_STRIDE,
+                     src, SRC1_STRIDE,
+                     w, HEIGHT);
+            call_new(dst_new, DST_STRIDE,
+                     src, SRC1_STRIDE,
+                     w, HEIGHT);
+
+            for (int i = 0; i < HEIGHT; i++) {
+                if (memcmp(dst_ref + DST_STRIDE * i,
+                           dst_new + DST_STRIDE * i,
+                           w)) {
+                    fail();
+                    goto fail;
+                }
+            }
+        }
+
+        fail:
+        bench_new(dst_new, DST_STRIDE, src, SRC1_STRIDE, DST_STRIDE, HEIGHT);
+    }
+
+    report(name);
+}
+
+static void check_mul_bitmaps(BitmapMulFunc func)
+{
+    if (check_func(func, "mul_bitmaps")) {
+        ALIGN(uint8_t src1[SRC1_STRIDE * HEIGHT], 32);
+        ALIGN(uint8_t src2[SRC2_STRIDE * HEIGHT], 32);
+        ALIGN(uint8_t dst_ref[DST_STRIDE * HEIGHT], 32);
+        ALIGN(uint8_t dst_new[DST_STRIDE * HEIGHT], 32);
+        declare_func(void,
+                     uint8_t *dst, intptr_t dst_stride,
+                     uint8_t *src1, intptr_t src1_stride,
+                     uint8_t *src2, intptr_t src2_stride,
+                     intptr_t width, intptr_t height);
+
+        for (int w = MIN_WIDTH; w < DST_STRIDE; w++) {
+            for (int i = 0; i < sizeof(src1); i++)
+                src1[i] = rnd();
+
+            for (int i = 0; i < sizeof(src2); i++)
+                src2[i] = rnd();
+
+            call_ref(dst_ref, DST_STRIDE,
+                     src1, SRC1_STRIDE,
+                     src2, SRC2_STRIDE,
+                     w, HEIGHT);
+            call_new(dst_new, DST_STRIDE,
+                     src1, SRC1_STRIDE,
+                     src2, SRC2_STRIDE,
+                     w, HEIGHT);
+
+            for (int i = 0; i < HEIGHT; i++) {
+                if (memcmp(dst_ref + DST_STRIDE * i,
+                           dst_new + DST_STRIDE * i,
+                           w)) {
+                    fail();
+                    goto fail;
+                }
+            }
+        }
+
+        fail:
+        bench_new(dst_new, DST_STRIDE, src1, SRC1_STRIDE, src2, SRC2_STRIDE, DST_STRIDE, HEIGHT);
+    }
+
+    report("mul_bitmaps");
+}
+
+void checkasm_check_blend_bitmaps(const BitmapEngine *engine)
+{
+    check_blend_bitmaps(engine->add_bitmaps, "add_bitmaps");
+    check_blend_bitmaps(engine->imul_bitmaps, "imul_bitmaps");
+    check_mul_bitmaps(engine->mul_bitmaps);
+}

--- a/checkasm/checkasm.c
+++ b/checkasm/checkasm.c
@@ -1,0 +1,797 @@
+/*
+ * Copyright © 2018, VideoLAN and dav1d authors
+ * Copyright © 2018, Two Orioles, LLC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "tests/checkasm/checkasm.h"
+
+#include <math.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "src/cpu.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#define COLOR_RED    FOREGROUND_RED
+#define COLOR_GREEN  FOREGROUND_GREEN
+#define COLOR_YELLOW (FOREGROUND_RED|FOREGROUND_GREEN)
+
+static unsigned get_seed(void) {
+    return GetTickCount();
+}
+#else
+#include <unistd.h>
+#include <signal.h>
+#include <time.h>
+#ifdef __APPLE__
+#include <mach/mach_time.h>
+#endif
+#define COLOR_RED    1
+#define COLOR_GREEN  2
+#define COLOR_YELLOW 3
+
+static unsigned get_seed(void) {
+#ifdef __APPLE__
+    return (unsigned) mach_absolute_time();
+#elif defined(HAVE_CLOCK_GETTIME)
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (unsigned) (1000000000ULL * ts.tv_sec + ts.tv_nsec);
+#endif
+}
+#endif
+
+/* List of tests to invoke */
+static const struct {
+    const char *name;
+    void (*func)(void);
+} tests[] = {
+    { "msac", checkasm_check_msac },
+#if CONFIG_8BPC
+    { "cdef_8bpc", checkasm_check_cdef_8bpc },
+    { "filmgrain_8bpc", checkasm_check_filmgrain_8bpc },
+    { "ipred_8bpc", checkasm_check_ipred_8bpc },
+    { "itx_8bpc", checkasm_check_itx_8bpc },
+    { "loopfilter_8bpc", checkasm_check_loopfilter_8bpc },
+    { "looprestoration_8bpc", checkasm_check_looprestoration_8bpc },
+    { "mc_8bpc", checkasm_check_mc_8bpc },
+#endif
+#if CONFIG_16BPC
+    { "cdef_16bpc", checkasm_check_cdef_16bpc },
+    { "filmgrain_16bpc", checkasm_check_filmgrain_16bpc },
+    { "ipred_16bpc", checkasm_check_ipred_16bpc },
+    { "itx_16bpc", checkasm_check_itx_16bpc },
+    { "loopfilter_16bpc", checkasm_check_loopfilter_16bpc },
+    { "looprestoration_16bpc", checkasm_check_looprestoration_16bpc },
+    { "mc_16bpc", checkasm_check_mc_16bpc },
+#endif
+    { 0 }
+};
+
+/* List of cpu flags to check */
+static const struct {
+    const char *name;
+    const char *suffix;
+    unsigned flag;
+} cpus[] = {
+#if ARCH_X86
+    { "SSE2",               "sse2",      DAV1D_X86_CPU_FLAG_SSE2 },
+    { "SSSE3",              "ssse3",     DAV1D_X86_CPU_FLAG_SSSE3 },
+    { "SSE4.1",             "sse4",      DAV1D_X86_CPU_FLAG_SSE41 },
+    { "AVX2",               "avx2",      DAV1D_X86_CPU_FLAG_AVX2 },
+    { "AVX-512 (Ice Lake)", "avx512icl", DAV1D_X86_CPU_FLAG_AVX512ICL },
+#elif ARCH_AARCH64 || ARCH_ARM
+    { "NEON",               "neon",      DAV1D_ARM_CPU_FLAG_NEON },
+#elif ARCH_PPC64LE
+    { "VSX",                "vsx",       DAV1D_PPC_CPU_FLAG_VSX },
+#endif
+    { 0 }
+};
+
+typedef struct CheckasmFuncVersion {
+    struct CheckasmFuncVersion *next;
+    void *func;
+    int ok;
+    unsigned cpu;
+    int iterations;
+    uint64_t cycles;
+} CheckasmFuncVersion;
+
+/* Binary search tree node */
+typedef struct CheckasmFunc {
+    struct CheckasmFunc *child[2];
+    CheckasmFuncVersion versions;
+    uint8_t color; /* 0 = red, 1 = black */
+    char name[];
+} CheckasmFunc;
+
+/* Internal state */
+static struct {
+    CheckasmFunc *funcs;
+    CheckasmFunc *current_func;
+    CheckasmFuncVersion *current_func_ver;
+    const char *current_test_name;
+    const char *bench_pattern;
+    size_t bench_pattern_len;
+    int num_checked;
+    int num_failed;
+    int nop_time;
+    unsigned cpu_flag;
+    const char *cpu_flag_name;
+    const char *test_name;
+    unsigned seed;
+    int bench_c;
+    int verbose;
+    int function_listing;
+#if ARCH_X86_64
+    void (*simd_warmup)(void);
+#endif
+} state;
+
+/* float compare support code */
+typedef union {
+    float f;
+    uint32_t i;
+} intfloat;
+
+static uint32_t xs_state[4];
+
+static void xor128_srand(unsigned seed) {
+    xs_state[0] = seed;
+    xs_state[1] = ( seed & 0xffff0000) | (~seed & 0x0000ffff);
+    xs_state[2] = (~seed & 0xffff0000) | ( seed & 0x0000ffff);
+    xs_state[3] = ~seed;
+}
+
+// xor128 from Marsaglia, George (July 2003). "Xorshift RNGs".
+//             Journal of Statistical Software. 8 (14).
+//             doi:10.18637/jss.v008.i14.
+int xor128_rand(void) {
+    const uint32_t x = xs_state[0];
+    const uint32_t t = x ^ (x << 11);
+
+    xs_state[0] = xs_state[1];
+    xs_state[1] = xs_state[2];
+    xs_state[2] = xs_state[3];
+    uint32_t w = xs_state[3];
+
+    w = (w ^ (w >> 19)) ^ (t ^ (t >> 8));
+    xs_state[3] = w;
+
+    return w >> 1;
+}
+
+static int is_negative(const intfloat u) {
+    return u.i >> 31;
+}
+
+int float_near_ulp(const float a, const float b, const unsigned max_ulp) {
+    intfloat x, y;
+
+    x.f = a;
+    y.f = b;
+
+    if (is_negative(x) != is_negative(y)) {
+        // handle -0.0 == +0.0
+        return a == b;
+    }
+
+    if (llabs((int64_t)x.i - y.i) <= max_ulp)
+        return 1;
+
+    return 0;
+}
+
+int float_near_ulp_array(const float *const a, const float *const b,
+                         const unsigned max_ulp, const int len)
+{
+    for (int i = 0; i < len; i++)
+        if (!float_near_ulp(a[i], b[i], max_ulp))
+            return 0;
+
+    return 1;
+}
+
+int float_near_abs_eps(const float a, const float b, const float eps) {
+    return fabsf(a - b) < eps;
+}
+
+int float_near_abs_eps_array(const float *const a, const float *const b,
+                             const float eps, const int len)
+{
+    for (int i = 0; i < len; i++)
+        if (!float_near_abs_eps(a[i], b[i], eps))
+            return 0;
+
+    return 1;
+}
+
+int float_near_abs_eps_ulp(const float a, const float b, const float eps,
+                           const unsigned max_ulp)
+{
+    return float_near_ulp(a, b, max_ulp) || float_near_abs_eps(a, b, eps);
+}
+
+int float_near_abs_eps_array_ulp(const float *const a, const float *const b,
+                                 const float eps, const unsigned max_ulp,
+                                 const int len)
+{
+    for (int i = 0; i < len; i++)
+        if (!float_near_abs_eps_ulp(a[i], b[i], eps, max_ulp))
+            return 0;
+
+    return 1;
+}
+
+/* Print colored text to stderr if the terminal supports it */
+static void color_printf(const int color, const char *const fmt, ...) {
+    static int8_t use_color = -1;
+    va_list arg;
+
+#ifdef _WIN32
+    static HANDLE con;
+    static WORD org_attributes;
+
+    if (use_color < 0) {
+        CONSOLE_SCREEN_BUFFER_INFO con_info;
+        con = GetStdHandle(STD_ERROR_HANDLE);
+        if (con && con != INVALID_HANDLE_VALUE &&
+            GetConsoleScreenBufferInfo(con, &con_info))
+        {
+            org_attributes = con_info.wAttributes;
+            use_color = 1;
+        } else
+            use_color = 0;
+    }
+    if (use_color)
+        SetConsoleTextAttribute(con, (org_attributes & 0xfff0) |
+                                (color & 0x0f));
+#else
+    if (use_color < 0) {
+        const char *const term = getenv("TERM");
+        use_color = term && strcmp(term, "dumb") && isatty(2);
+    }
+    if (use_color)
+        fprintf(stderr, "\x1b[%d;3%dm", (color & 0x08) >> 3, color & 0x07);
+#endif
+
+    va_start(arg, fmt);
+    vfprintf(stderr, fmt, arg);
+    va_end(arg);
+
+    if (use_color) {
+#ifdef _WIN32
+        SetConsoleTextAttribute(con, org_attributes);
+#else
+        fprintf(stderr, "\x1b[0m");
+#endif
+    }
+}
+
+/* Deallocate a tree */
+static void destroy_func_tree(CheckasmFunc *const f) {
+    if (f) {
+        CheckasmFuncVersion *v = f->versions.next;
+        while (v) {
+            CheckasmFuncVersion *next = v->next;
+            free(v);
+            v = next;
+        }
+
+        destroy_func_tree(f->child[0]);
+        destroy_func_tree(f->child[1]);
+        free(f);
+    }
+}
+
+/* Allocate a zero-initialized block, clean up and exit on failure */
+static void *checkasm_malloc(const size_t size) {
+    void *const ptr = calloc(1, size);
+    if (!ptr) {
+        fprintf(stderr, "checkasm: malloc failed\n");
+        destroy_func_tree(state.funcs);
+        exit(1);
+    }
+    return ptr;
+}
+
+/* Get the suffix of the specified cpu flag */
+static const char *cpu_suffix(const unsigned cpu) {
+    for (int i = (int)(sizeof(cpus) / sizeof(*cpus)) - 2; i >= 0; i--)
+        if (cpu & cpus[i].flag)
+            return cpus[i].suffix;
+
+    return "c";
+}
+
+#ifdef readtime
+static int cmp_nop(const void *a, const void *b) {
+    return *(const uint16_t*)a - *(const uint16_t*)b;
+}
+
+/* Measure the overhead of the timing code (in decicycles) */
+static int measure_nop_time(void) {
+    uint16_t nops[10000];
+    int nop_sum = 0;
+
+    for (int i = 0; i < 10000; i++) {
+        uint64_t t = readtime();
+        nops[i] = (uint16_t) (readtime() - t);
+    }
+
+    qsort(nops, 10000, sizeof(uint16_t), cmp_nop);
+    for (int i = 2500; i < 7500; i++)
+        nop_sum += nops[i];
+
+    return nop_sum / 500;
+}
+
+/* Print benchmark results */
+static void print_benchs(const CheckasmFunc *const f) {
+    if (f) {
+        print_benchs(f->child[0]);
+
+        /* Only print functions with at least one assembly version */
+        if (state.bench_c || f->versions.cpu || f->versions.next) {
+            const CheckasmFuncVersion *v = &f->versions;
+            do {
+                if (v->iterations) {
+                    const int decicycles = (int) (10*v->cycles/v->iterations -
+                                                  state.nop_time) / 4;
+                    printf("%s_%s: %d.%d\n", f->name, cpu_suffix(v->cpu),
+                           decicycles/10, decicycles%10);
+                }
+            } while ((v = v->next));
+        }
+
+        print_benchs(f->child[1]);
+    }
+}
+#endif
+
+static void print_functions(const CheckasmFunc *const f) {
+    if (f) {
+        print_functions(f->child[0]);
+        printf("%s\n", f->name);
+        print_functions(f->child[1]);
+    }
+}
+
+#define is_digit(x) ((x) >= '0' && (x) <= '9')
+
+/* ASCIIbetical sort except preserving natural order for numbers */
+static int cmp_func_names(const char *a, const char *b) {
+    const char *const start = a;
+    int ascii_diff, digit_diff;
+
+    for (; !(ascii_diff = *(const unsigned char*)a -
+                          *(const unsigned char*)b) && *a; a++, b++);
+    for (; is_digit(*a) && is_digit(*b); a++, b++);
+
+    if (a > start && is_digit(a[-1]) &&
+        (digit_diff = is_digit(*a) - is_digit(*b)))
+    {
+        return digit_diff;
+    }
+
+    return ascii_diff;
+}
+
+/* Perform a tree rotation in the specified direction and return the new root */
+static CheckasmFunc *rotate_tree(CheckasmFunc *const f, const int dir) {
+    CheckasmFunc *const r = f->child[dir^1];
+    f->child[dir^1] = r->child[dir];
+    r->child[dir] = f;
+    r->color = f->color;
+    f->color = 0;
+    return r;
+}
+
+#define is_red(f) ((f) && !(f)->color)
+
+/* Balance a left-leaning red-black tree at the specified node */
+static void balance_tree(CheckasmFunc **const root) {
+    CheckasmFunc *const f = *root;
+
+    if (is_red(f->child[0]) && is_red(f->child[1])) {
+        f->color ^= 1;
+        f->child[0]->color = f->child[1]->color = 1;
+    }
+    else if (!is_red(f->child[0]) && is_red(f->child[1]))
+        *root = rotate_tree(f, 0); /* Rotate left */
+    else if (is_red(f->child[0]) && is_red(f->child[0]->child[0]))
+        *root = rotate_tree(f, 1); /* Rotate right */
+}
+
+/* Get a node with the specified name, creating it if it doesn't exist */
+static CheckasmFunc *get_func(CheckasmFunc **const root, const char *const name) {
+    CheckasmFunc *f = *root;
+
+    if (f) {
+        /* Search the tree for a matching node */
+        const int cmp = cmp_func_names(name, f->name);
+        if (cmp) {
+            f = get_func(&f->child[cmp > 0], name);
+
+            /* Rebalance the tree on the way up if a new node was inserted */
+            if (!f->versions.func)
+                balance_tree(root);
+        }
+    } else {
+        /* Allocate and insert a new node into the tree */
+        const size_t name_length = strlen(name) + 1;
+        f = *root = checkasm_malloc(offsetof(CheckasmFunc, name) + name_length);
+        memcpy(f->name, name, name_length);
+    }
+
+    return f;
+}
+
+checkasm_context checkasm_context_buf;
+
+/* Crash handling: attempt to catch crashes and handle them
+ * gracefully instead of just aborting abruptly. */
+#ifdef _WIN32
+static LONG NTAPI signal_handler(EXCEPTION_POINTERS *const e) {
+    switch (e->ExceptionRecord->ExceptionCode) {
+    case EXCEPTION_FLT_DIVIDE_BY_ZERO:
+    case EXCEPTION_INT_DIVIDE_BY_ZERO:
+        checkasm_fail_func("fatal arithmetic error");
+        break;
+    case EXCEPTION_ILLEGAL_INSTRUCTION:
+    case EXCEPTION_PRIV_INSTRUCTION:
+        checkasm_fail_func("illegal instruction");
+        break;
+    case EXCEPTION_ACCESS_VIOLATION:
+    case EXCEPTION_ARRAY_BOUNDS_EXCEEDED:
+    case EXCEPTION_DATATYPE_MISALIGNMENT:
+    case EXCEPTION_IN_PAGE_ERROR:
+    case EXCEPTION_STACK_OVERFLOW:
+        checkasm_fail_func("segmentation fault");
+        break;
+    default:
+        return EXCEPTION_CONTINUE_SEARCH;
+    }
+    checkasm_load_context();
+    return EXCEPTION_CONTINUE_EXECUTION; /* never reached, but shuts up gcc */
+}
+#else
+static void signal_handler(const int s) {
+    checkasm_set_signal_handler_state(0);
+    checkasm_fail_func(s == SIGFPE ? "fatal arithmetic error" :
+                       s == SIGILL ? "illegal instruction" :
+                                     "segmentation fault");
+    checkasm_load_context();
+}
+#endif
+
+/* Perform tests and benchmarks for the specified
+ * cpu flag if supported by the host */
+static void check_cpu_flag(const char *const name, unsigned flag) {
+    const unsigned old_cpu_flag = state.cpu_flag;
+
+    flag |= old_cpu_flag;
+    dav1d_set_cpu_flags_mask(flag);
+    state.cpu_flag = dav1d_get_cpu_flags();
+
+    if (!flag || state.cpu_flag != old_cpu_flag) {
+        state.cpu_flag_name = name;
+        for (int i = 0; tests[i].func; i++) {
+            if (state.test_name && strcmp(tests[i].name, state.test_name))
+                continue;
+            xor128_srand(state.seed);
+            state.current_test_name = tests[i].name;
+            tests[i].func();
+        }
+    }
+}
+
+/* Print the name of the current CPU flag, but only do it once */
+static void print_cpu_name(void) {
+    if (state.cpu_flag_name) {
+        color_printf(COLOR_YELLOW, "%s:\n", state.cpu_flag_name);
+        state.cpu_flag_name = NULL;
+    }
+}
+
+int main(int argc, char *argv[]) {
+    (void)func_new, (void)func_ref;
+    state.seed = get_seed();
+    int ret = 0;
+
+    while (argc > 1) {
+        if (!strncmp(argv[1], "--help", 6)) {
+            fprintf(stdout,
+                    "checkasm [options] <random seed>\n"
+                    "    <random seed>       Numeric value to seed the rng\n"
+                    "Options:\n"
+                    "    --test=<test_name>  Test only <test_name>\n"
+                    "    --bench=<pattern>   Test and benchmark the functions matching <pattern>\n"
+                    "    --list-functions    List available functions\n"
+                    "    --list-tests        List available tests\n"
+                    "    --bench-c           Benchmark the C-only functions\n"
+                    "    --verbose -v        Print failures verbosely\n");
+            return 0;
+        } else if (!strncmp(argv[1], "--bench-c", 9)) {
+            state.bench_c = 1;
+        } else if (!strncmp(argv[1], "--bench", 7)) {
+#ifndef readtime
+            fprintf(stderr,
+                    "checkasm: --bench is not supported on your system\n");
+            return 1;
+#endif
+            if (argv[1][7] == '=') {
+                state.bench_pattern = argv[1] + 8;
+                state.bench_pattern_len = strlen(state.bench_pattern);
+            } else
+                state.bench_pattern = "";
+        } else if (!strncmp(argv[1], "--test=", 7)) {
+            state.test_name = argv[1] + 7;
+        } else if (!strcmp(argv[1], "--list-functions")) {
+            state.function_listing = 1;
+        } else if (!strcmp(argv[1], "--list-tests")) {
+            for (int i = 0; tests[i].name; i++)
+                printf("%s\n", tests[i].name);
+            return 0;
+        } else if (!strcmp(argv[1], "--verbose") || !strcmp(argv[1], "-v")) {
+            state.verbose = 1;
+        } else {
+            state.seed = (unsigned) strtoul(argv[1], NULL, 10);
+        }
+
+        argc--;
+        argv++;
+    }
+
+    dav1d_init_cpu();
+
+    if (!state.function_listing) {
+        fprintf(stderr, "checkasm: using random seed %u\n", state.seed);
+#if ARCH_X86_64
+        void checkasm_warmup_avx2(void);
+        void checkasm_warmup_avx512(void);
+        const unsigned cpu_flags = dav1d_get_cpu_flags();
+        if (cpu_flags & DAV1D_X86_CPU_FLAG_AVX512ICL)
+            state.simd_warmup = checkasm_warmup_avx512;
+        else if (cpu_flags & DAV1D_X86_CPU_FLAG_AVX2)
+            state.simd_warmup = checkasm_warmup_avx2;
+        checkasm_simd_warmup();
+#endif
+    }
+
+    check_cpu_flag(NULL, 0);
+
+    if (state.function_listing) {
+        print_functions(state.funcs);
+    } else {
+        for (int i = 0; cpus[i].flag; i++)
+            check_cpu_flag(cpus[i].name, cpus[i].flag);
+        if (!state.num_checked) {
+            fprintf(stderr, "checkasm: no tests to perform\n");
+        } else if (state.num_failed) {
+            fprintf(stderr, "checkasm: %d of %d tests have failed\n",
+                    state.num_failed, state.num_checked);
+            ret = 1;
+        } else {
+            fprintf(stderr, "checkasm: all %d tests passed\n", state.num_checked);
+#ifdef readtime
+            if (state.bench_pattern) {
+                state.nop_time = measure_nop_time();
+                printf("nop: %d.%d\n", state.nop_time/10, state.nop_time%10);
+                print_benchs(state.funcs);
+            }
+#endif
+        }
+    }
+
+    destroy_func_tree(state.funcs);
+    return ret;
+}
+
+/* Decide whether or not the specified function needs to be tested and
+ * allocate/initialize data structures if needed. Returns a pointer to a
+ * reference function if the function should be tested, otherwise NULL */
+void *checkasm_check_func(void *const func, const char *const name, ...) {
+    char name_buf[256];
+    va_list arg;
+
+    va_start(arg, name);
+    const int name_length = vsnprintf(name_buf, sizeof(name_buf), name, arg);
+    va_end(arg);
+
+    if (!func || name_length <= 0 || (size_t)name_length >= sizeof(name_buf))
+        return NULL;
+
+    state.current_func = get_func(&state.funcs, name_buf);
+
+    if (state.function_listing) /* Save function names without running tests */
+        return NULL;
+
+    state.funcs->color = 1;
+    CheckasmFuncVersion *v = &state.current_func->versions;
+    void *ref = func;
+
+    if (v->func) {
+        CheckasmFuncVersion *prev;
+        do {
+            /* Only test functions that haven't already been tested */
+            if (v->func == func)
+                return NULL;
+
+            if (v->ok)
+                ref = v->func;
+
+            prev = v;
+        } while ((v = v->next));
+
+        v = prev->next = checkasm_malloc(sizeof(CheckasmFuncVersion));
+    }
+
+    v->func = func;
+    v->ok = 1;
+    v->cpu = state.cpu_flag;
+    state.current_func_ver = v;
+    xor128_srand(state.seed);
+
+    if (state.cpu_flag || state.bench_c)
+        state.num_checked++;
+
+    return ref;
+}
+
+/* Decide whether or not the current function needs to be benchmarked */
+int checkasm_bench_func(void) {
+    return !state.num_failed && state.bench_pattern &&
+           !strncmp(state.current_func->name, state.bench_pattern,
+                    state.bench_pattern_len);
+}
+
+/* Indicate that the current test has failed, return whether verbose printing
+ * is requested. */
+int checkasm_fail_func(const char *const msg, ...) {
+    if (state.current_func_ver->cpu && state.current_func_ver->ok) {
+        va_list arg;
+
+        print_cpu_name();
+        fprintf(stderr, "   %s_%s (", state.current_func->name,
+                cpu_suffix(state.current_func_ver->cpu));
+        va_start(arg, msg);
+        vfprintf(stderr, msg, arg);
+        va_end(arg);
+        fprintf(stderr, ")\n");
+
+        state.current_func_ver->ok = 0;
+        state.num_failed++;
+    }
+    return state.verbose;
+}
+
+/* Update benchmark results of the current function */
+void checkasm_update_bench(const int iterations, const uint64_t cycles) {
+    state.current_func_ver->iterations += iterations;
+    state.current_func_ver->cycles += cycles;
+}
+
+/* Print the outcome of all tests performed since
+ * the last time this function was called */
+void checkasm_report(const char *const name, ...) {
+    static int prev_checked, prev_failed;
+    static size_t max_length;
+
+    if (state.num_checked > prev_checked) {
+        int pad_length = (int) max_length + 4;
+        va_list arg;
+
+        print_cpu_name();
+        pad_length -= fprintf(stderr, " - %s.", state.current_test_name);
+        va_start(arg, name);
+        pad_length -= vfprintf(stderr, name, arg);
+        va_end(arg);
+        fprintf(stderr, "%*c", imax(pad_length, 0) + 2, '[');
+
+        if (state.num_failed == prev_failed)
+            color_printf(COLOR_GREEN, "OK");
+        else
+            color_printf(COLOR_RED, "FAILED");
+        fprintf(stderr, "]\n");
+
+        prev_checked = state.num_checked;
+        prev_failed  = state.num_failed;
+    } else if (!state.cpu_flag) {
+        /* Calculate the amount of padding required
+         * to make the output vertically aligned */
+        size_t length = strlen(state.current_test_name);
+        va_list arg;
+
+        va_start(arg, name);
+        length += vsnprintf(NULL, 0, name, arg);
+        va_end(arg);
+
+        if (length > max_length)
+            max_length = length;
+    }
+}
+
+void checkasm_set_signal_handler_state(const int enabled) {
+#ifdef _WIN32
+    if (enabled)
+        AddVectoredExceptionHandler(0, signal_handler);
+    else
+        RemoveVectoredExceptionHandler(signal_handler);
+#else
+    void (*const handler)(int) = enabled ? signal_handler : SIG_DFL;
+    signal(SIGBUS,  handler);
+    signal(SIGFPE,  handler);
+    signal(SIGILL,  handler);
+    signal(SIGSEGV, handler);
+#endif
+}
+
+#define DEF_CHECKASM_CHECK_FUNC(type, fmt) \
+int checkasm_check_##type(const char *const file, const int line, \
+                          const type *buf1, ptrdiff_t stride1, \
+                          const type *buf2, ptrdiff_t stride2, \
+                          const int w, int h, const char *const name) \
+{ \
+    stride1 /= sizeof(*buf1); \
+    stride2 /= sizeof(*buf2); \
+    int y = 0; \
+    for (y = 0; y < h; y++) \
+        if (memcmp(&buf1[y*stride1], &buf2[y*stride2], w*sizeof(*buf1))) \
+            break; \
+    if (y == h) \
+        return 0; \
+    if (!checkasm_fail_func("%s:%d", file, line)) \
+        return 1; \
+    fprintf(stderr, "%s:\n", name); \
+    while (h--) { \
+        for (int x = 0; x < w; x++) \
+            fprintf(stderr, " " fmt, buf1[x]); \
+        fprintf(stderr, "    "); \
+        for (int x = 0; x < w; x++) \
+            fprintf(stderr, " " fmt, buf2[x]); \
+        fprintf(stderr, "    "); \
+        for (int x = 0; x < w; x++) \
+            fprintf(stderr, "%c", buf1[x] != buf2[x] ? 'x' : '.'); \
+        buf1 += stride1; \
+        buf2 += stride2; \
+        fprintf(stderr, "\n"); \
+    } \
+    return 1; \
+}
+
+DEF_CHECKASM_CHECK_FUNC(uint8_t,  "%02x")
+DEF_CHECKASM_CHECK_FUNC(uint16_t, "%04x")
+DEF_CHECKASM_CHECK_FUNC(int16_t,  "%6d")
+DEF_CHECKASM_CHECK_FUNC(int32_t,  "%9d")
+
+#if ARCH_X86_64
+void checkasm_simd_warmup(void)
+{
+    if (state.simd_warmup)
+        state.simd_warmup();
+}
+#endif

--- a/checkasm/checkasm.c
+++ b/checkasm/checkasm.c
@@ -87,6 +87,9 @@ static const struct {
     { "SSE2",               "sse2",      ASS_CPU_FLAG_X86_SSE2 },
     { "AVX2",               "avx2",      ASS_CPU_FLAG_X86_AVX2 },
 #endif
+#if defined(__aarch64__)
+    { "NEON",               "neon",      ASS_CPU_FLAG_ARM_NEON },
+#endif
     { 0 }
 };
 

--- a/checkasm/checkasm.h
+++ b/checkasm/checkasm.h
@@ -1,0 +1,330 @@
+/*
+ * Copyright © 2018, VideoLAN and dav1d authors
+ * Copyright © 2018, Two Orioles, LLC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DAV1D_TESTS_CHECKASM_CHECKASM_H
+#define DAV1D_TESTS_CHECKASM_CHECKASM_H
+
+#include "config.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#if ARCH_X86_64 && defined(_WIN32)
+/* setjmp/longjmp on 64-bit Windows will try to use SEH to unwind the stack,
+ * which doesn't work for assembly functions without unwind information. */
+#include <windows.h>
+#define checkasm_context CONTEXT
+#define checkasm_save_context() RtlCaptureContext(&checkasm_context_buf)
+#define checkasm_load_context() RtlRestoreContext(&checkasm_context_buf, NULL)
+#else
+#include <setjmp.h>
+#define checkasm_context jmp_buf
+#define checkasm_save_context() setjmp(checkasm_context_buf)
+#define checkasm_load_context() longjmp(checkasm_context_buf, 1)
+#endif
+
+#include "include/common/attributes.h"
+#include "include/common/bitdepth.h"
+#include "include/common/intops.h"
+
+int xor128_rand(void);
+#define rnd xor128_rand
+
+#define decl_check_bitfns(name) \
+name##_8bpc(void); \
+name##_16bpc(void)
+
+void checkasm_check_msac(void);
+decl_check_bitfns(void checkasm_check_cdef);
+decl_check_bitfns(void checkasm_check_filmgrain);
+decl_check_bitfns(void checkasm_check_ipred);
+decl_check_bitfns(void checkasm_check_itx);
+decl_check_bitfns(void checkasm_check_loopfilter);
+decl_check_bitfns(void checkasm_check_looprestoration);
+decl_check_bitfns(void checkasm_check_mc);
+
+void *checkasm_check_func(void *func, const char *name, ...);
+int checkasm_bench_func(void);
+int checkasm_fail_func(const char *msg, ...);
+void checkasm_update_bench(int iterations, uint64_t cycles);
+void checkasm_report(const char *name, ...);
+void checkasm_set_signal_handler_state(int enabled);
+extern checkasm_context checkasm_context_buf;
+
+/* float compare utilities */
+int float_near_ulp(float a, float b, unsigned max_ulp);
+int float_near_abs_eps(float a, float b, float eps);
+int float_near_abs_eps_ulp(float a, float b, float eps, unsigned max_ulp);
+int float_near_ulp_array(const float *a, const float *b, unsigned max_ulp,
+                         int len);
+int float_near_abs_eps_array(const float *a, const float *b, float eps,
+                             int len);
+int float_near_abs_eps_array_ulp(const float *a, const float *b, float eps,
+                                 unsigned max_ulp, int len);
+
+static void *func_ref, *func_new;
+
+#define BENCH_RUNS (1 << 12) /* Trade-off between accuracy and speed */
+
+/* Decide whether or not the specified function needs to be tested */
+#define check_func(func, ...)\
+    (func_ref = checkasm_check_func((func_new = func), __VA_ARGS__))
+
+/* Declare the function prototype. The first argument is the return value,
+ * the remaining arguments are the function parameters. Naming parameters
+ * is optional. */
+#define declare_func(ret, ...)\
+    declare_new(ret, __VA_ARGS__)\
+    typedef ret func_type(__VA_ARGS__);\
+    checkasm_save_context()
+
+/* Indicate that the current test has failed */
+#define fail() checkasm_fail_func("%s:%d", __FILE__, __LINE__)
+
+/* Print the test outcome */
+#define report checkasm_report
+
+/* Call the reference function */
+#define call_ref(...)\
+    (checkasm_set_signal_handler_state(1),\
+     ((func_type *)func_ref)(__VA_ARGS__));\
+    checkasm_set_signal_handler_state(0)
+
+#if HAVE_ASM
+#if ARCH_X86
+#ifdef _MSC_VER
+#include <intrin.h>
+#define readtime() (_mm_lfence(), __rdtsc())
+#else
+static inline uint64_t readtime(void) {
+    uint32_t eax, edx;
+    __asm__ __volatile__("lfence\nrdtsc" : "=a"(eax), "=d"(edx));
+    return (((uint64_t)edx) << 32) | eax;
+}
+#define readtime readtime
+#endif
+#elif ARCH_AARCH64
+#ifdef _MSC_VER
+#include <windows.h>
+#define readtime() (_InstructionSynchronizationBarrier(), ReadTimeStampCounter())
+#else
+static inline uint64_t readtime(void) {
+    uint64_t cycle_counter;
+    /* This requires enabling user mode access to the cycle counter (which
+     * can only be done from kernel space).
+     * This could also read cntvct_el0 instead of pmccntr_el0; that register
+     * might also be readable (depending on kernel version), but it has much
+     * worse precision (it's a fixed 50 MHz timer). */
+    __asm__ __volatile__("isb\nmrs %0, pmccntr_el0"
+                         : "=r"(cycle_counter)
+                         :: "memory");
+    return cycle_counter;
+}
+#define readtime readtime
+#endif
+#elif ARCH_ARM && !defined(_MSC_VER) && __ARM_ARCH >= 7
+static inline uint64_t readtime(void) {
+    uint32_t cycle_counter;
+    /* This requires enabling user mode access to the cycle counter (which
+     * can only be done from kernel space). */
+    __asm__ __volatile__("isb\nmrc p15, 0, %0, c9, c13, 0"
+                         : "=r"(cycle_counter)
+                         :: "memory");
+    return cycle_counter;
+}
+#define readtime readtime
+#elif ARCH_PPC64LE
+static inline uint64_t readtime(void) {
+    uint32_t tbu, tbl, temp;
+
+    __asm__ __volatile__(
+        "1:\n"
+        "mfspr %2,269\n"
+        "mfspr %0,268\n"
+        "mfspr %1,269\n"
+        "cmpw   %2,%1\n"
+        "bne    1b\n"
+    : "=r"(tbl), "=r"(tbu), "=r"(temp)
+    :
+    : "cc");
+
+    return (((uint64_t)tbu) << 32) | (uint64_t)tbl;
+}
+#define readtime readtime
+#endif
+
+/* Verifies that clobbered callee-saved registers
+ * are properly saved and restored */
+void checkasm_checked_call(void *func, ...);
+
+#if ARCH_X86_64
+/* Evil hack: detect incorrect assumptions that 32-bit ints are zero-extended
+ * to 64-bit. This is done by clobbering the stack with junk around the stack
+ * pointer and calling the assembly function through checked_call() with added
+ * dummy arguments which forces all real arguments to be passed on the stack
+ * and not in registers. For 32-bit arguments the upper half of the 64-bit
+ * register locations on the stack will now contain junk which will cause
+ * misbehaving functions to either produce incorrect output or segfault. Note
+ * that even though this works extremely well in practice, it's technically
+ * not guaranteed and false negatives is theoretically possible, but there
+ * can never be any false positives. */
+void checkasm_stack_clobber(uint64_t clobber, ...);
+/* YMM and ZMM registers on x86 are turned off to save power when they haven't
+ * been used for some period of time. When they are used there will be a
+ * "warmup" period during which performance will be reduced and inconsistent
+ * which is problematic when trying to benchmark individual functions. We can
+ * work around this by periodically issuing "dummy" instructions that uses
+ * those registers to keep them powered on. */
+void checkasm_simd_warmup(void);
+#define declare_new(ret, ...)\
+    ret (*checked_call)(void *, int, int, int, int, int, __VA_ARGS__,\
+                        int, int, int, int, int, int, int, int,\
+                        int, int, int, int, int, int, int) =\
+    (void *)checkasm_checked_call;
+#define CLOB (UINT64_C(0xdeadbeefdeadbeef))
+#ifdef _WIN32
+#define STACKARGS 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0
+#else
+#define STACKARGS 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0
+#endif
+#define call_new(...)\
+    (checkasm_set_signal_handler_state(1),\
+     checkasm_simd_warmup(),\
+     checkasm_stack_clobber(CLOB, CLOB, CLOB, CLOB, CLOB, CLOB, CLOB,\
+                            CLOB, CLOB, CLOB, CLOB, CLOB, CLOB, CLOB,\
+                            CLOB, CLOB, CLOB, CLOB, CLOB, CLOB, CLOB),\
+     checked_call(func_new, 0, 0, 0, 0, 0, __VA_ARGS__, STACKARGS));\
+    checkasm_set_signal_handler_state(0)
+#elif ARCH_X86_32
+#define declare_new(ret, ...)\
+    ret (*checked_call)(void *, __VA_ARGS__, int, int, int, int, int, int,\
+                        int, int, int, int, int, int, int, int, int) =\
+        (void *)checkasm_checked_call;
+#define call_new(...)\
+    (checkasm_set_signal_handler_state(1),\
+     checked_call(func_new, __VA_ARGS__, 15, 14, 13, 12,\
+                  11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1));\
+    checkasm_set_signal_handler_state(0)
+#elif ARCH_ARM
+/* Use a dummy argument, to offset the real parameters by 2, not only 1.
+ * This makes sure that potential 8-byte-alignment of parameters is kept
+ * the same even when the extra parameters have been removed. */
+void checkasm_checked_call_vfp(void *func, int dummy, ...);
+#define declare_new(ret, ...)\
+    ret (*checked_call)(void *, int dummy, __VA_ARGS__,\
+                        int, int, int, int, int, int, int, int,\
+                        int, int, int, int, int, int, int) =\
+    (void *)checkasm_checked_call_vfp;
+#define call_new(...)\
+    (checkasm_set_signal_handler_state(1),\
+     checked_call(func_new, 0, __VA_ARGS__, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0));\
+    checkasm_set_signal_handler_state(0)
+#elif ARCH_AARCH64 && !defined(__APPLE__)
+void checkasm_stack_clobber(uint64_t clobber, ...);
+#define declare_new(ret, ...)\
+    ret (*checked_call)(void *, int, int, int, int, int, int, int,\
+                        __VA_ARGS__, int, int, int, int, int, int, int, int,\
+                        int, int, int, int, int, int, int) =\
+    (void *)checkasm_checked_call;
+#define CLOB (UINT64_C(0xdeadbeefdeadbeef))
+#define call_new(...)\
+    (checkasm_set_signal_handler_state(1),\
+     checkasm_stack_clobber(CLOB, CLOB, CLOB, CLOB, CLOB, CLOB,\
+                            CLOB, CLOB, CLOB, CLOB, CLOB, CLOB,\
+                            CLOB, CLOB, CLOB, CLOB, CLOB, CLOB,\
+                            CLOB, CLOB, CLOB, CLOB, CLOB),\
+     checked_call(func_new, 0, 0, 0, 0, 0, 0, 0, __VA_ARGS__,\
+                  7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0));\
+    checkasm_set_signal_handler_state(0)
+#else
+#define declare_new(ret, ...)
+#define call_new(...)\
+    (checkasm_set_signal_handler_state(1),\
+     ((func_type *)func_new)(__VA_ARGS__));\
+    checkasm_set_signal_handler_state(0)
+#endif
+#else /* HAVE_ASM */
+#define declare_new(ret, ...)
+/* Call the function */
+#define call_new(...)\
+    (checkasm_set_signal_handler_state(1),\
+     ((func_type *)func_new)(__VA_ARGS__));\
+    checkasm_set_signal_handler_state(0)
+#endif /* HAVE_ASM */
+
+/* Benchmark the function */
+#ifdef readtime
+#define bench_new(...)\
+    do {\
+        if (checkasm_bench_func()) {\
+            checkasm_set_signal_handler_state(1);\
+            func_type *tfunc = func_new;\
+            uint64_t tsum = 0;\
+            int tcount = 0;\
+            for (int ti = 0; ti < BENCH_RUNS; ti++) {\
+                uint64_t t = readtime();\
+                tfunc(__VA_ARGS__);\
+                tfunc(__VA_ARGS__);\
+                tfunc(__VA_ARGS__);\
+                tfunc(__VA_ARGS__);\
+                t = readtime() - t;\
+                if (t*tcount <= tsum*4 && ti > 0) {\
+                    tsum += t;\
+                    tcount++;\
+                }\
+            }\
+            checkasm_set_signal_handler_state(0);\
+            checkasm_update_bench(tcount, tsum);\
+        }\
+    } while (0)
+#else
+#define bench_new(...) do {} while (0)
+#endif
+
+#define DECL_CHECKASM_CHECK_FUNC(type) \
+int checkasm_check_##type(const char *const file, const int line, \
+                          const type *const buf1, const ptrdiff_t stride1, \
+                          const type *const buf2, const ptrdiff_t stride2, \
+                          const int w, const int h, const char *const name)
+
+DECL_CHECKASM_CHECK_FUNC(uint8_t);
+DECL_CHECKASM_CHECK_FUNC(uint16_t);
+DECL_CHECKASM_CHECK_FUNC(int16_t);
+DECL_CHECKASM_CHECK_FUNC(int32_t);
+
+
+#define PASTE(a,b) a ## b
+#define CONCAT(a,b) PASTE(a,b)
+
+#define checkasm_check(prefix, ...) CONCAT(checkasm_check_, prefix)(__FILE__, __LINE__, __VA_ARGS__)
+
+#ifdef BITDEPTH
+#define checkasm_check_pixel(...) checkasm_check(PIXEL_TYPE, __VA_ARGS__)
+#define checkasm_check_coef(...)  checkasm_check(COEF_TYPE,  __VA_ARGS__)
+#endif
+
+#endif /* DAV1D_TESTS_CHECKASM_CHECKASM_H */

--- a/checkasm/checkasm.h
+++ b/checkasm/checkasm.h
@@ -88,7 +88,7 @@ int float_near_abs_eps_array_ulp(const float *a, const float *b, float eps,
 
 static void *func_ref, *func_new;
 
-#define BENCH_RUNS (1 << 12) /* Trade-off between accuracy and speed */
+#define BENCH_RUNS (1 << 16) /* Trade-off between accuracy and speed */
 
 /* Decide whether or not the specified function needs to be tested */
 #define check_func(func, ...)\

--- a/checkasm/checkasm.h
+++ b/checkasm/checkasm.h
@@ -127,6 +127,9 @@ static inline uint64_t readtime(void) {
 }
 #define readtime readtime
 #endif
+#elif defined(__aarch64__) && defined(__APPLE__)
+#include <mach/mach_time.h>
+#define readtime() mach_absolute_time()
 #elif defined(__aarch64__)
 #ifdef _MSC_VER
 #include <windows.h>

--- a/checkasm/x86/checkasm.asm
+++ b/checkasm/x86/checkasm.asm
@@ -1,0 +1,286 @@
+; Copyright © 2018, VideoLAN and dav1d authors
+; Copyright © 2018, Two Orioles, LLC
+; All rights reserved.
+;
+; Redistribution and use in source and binary forms, with or without
+; modification, are permitted provided that the following conditions are met:
+;
+; 1. Redistributions of source code must retain the above copyright notice, this
+;    list of conditions and the following disclaimer.
+;
+; 2. Redistributions in binary form must reproduce the above copyright notice,
+;    this list of conditions and the following disclaimer in the documentation
+;    and/or other materials provided with the distribution.
+;
+; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+; ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+; WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+; DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+; ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+; (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+; ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+; (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+; SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+%define private_prefix checkasm
+%include "config.asm"
+%include "ext/x86/x86inc.asm"
+
+SECTION_RODATA 16
+
+%if ARCH_X86_64
+; just random numbers to reduce the chance of incidental match
+%if WIN64
+x6:  dq 0x1a1b2550a612b48c,0x79445c159ce79064
+x7:  dq 0x2eed899d5a28ddcd,0x86b2536fcd8cf636
+x8:  dq 0xb0856806085e7943,0x3f2bf84fc0fcca4e
+x9:  dq 0xacbd382dcf5b8de2,0xd229e1f5b281303f
+x10: dq 0x71aeaff20b095fd9,0xab63e2e11fa38ed9
+x11: dq 0x89b0c0765892729a,0x77d410d5c42c882d
+x12: dq 0xc45ea11a955d8dd5,0x24b3c1d2a024048b
+x13: dq 0x2e8ec680de14b47c,0xdd7b8919edd42786
+x14: dq 0x135ce6888fa02cbf,0x11e53e2b2ac655ef
+x15: dq 0x011ff554472a7a10,0x6de8f4c914c334d5
+n7:  dq 0x21f86d66c8ca00ce
+n8:  dq 0x75b6ba21077c48ad
+%endif
+n9:  dq 0xed56bb2dcb3c7736
+n10: dq 0x8bda43d3fd1a7e06
+n11: dq 0xb64a9c9e5d318408
+n12: dq 0xdf9a54b303f1d3a3
+n13: dq 0x4a75479abd64e097
+n14: dq 0x249214109d5d1c88
+%endif
+
+errmsg_reg:   db "failed to preserve register", 0
+errmsg_stack: db "stack corruption", 0
+
+SECTION .text
+
+cextern fail_func
+
+; max number of args used by any asm function.
+; (max_args % 4) must equal 3 for stack alignment
+%define max_args 15
+
+%if ARCH_X86_64
+
+;-----------------------------------------------------------------------------
+; int checkasm_stack_clobber(uint64_t clobber, ...)
+;-----------------------------------------------------------------------------
+cglobal stack_clobber, 1, 2
+    ; Clobber the stack with junk below the stack pointer
+    %define argsize (max_args+6)*8
+    SUB  rsp, argsize
+    mov   r1, argsize-8
+.loop:
+    mov [rsp+r1], r0
+    sub   r1, 8
+    jge .loop
+    ADD  rsp, argsize
+    RET
+
+%if WIN64
+    %assign free_regs 7
+    %define stack_param rsp+32 ; shadow space
+    %define num_stack_params rsp+stack_offset+22*8
+    DECLARE_REG_TMP 4
+%else
+    %assign free_regs 9
+    %define stack_param rsp
+    %define num_stack_params rsp+stack_offset+16*8
+    DECLARE_REG_TMP 7
+%endif
+
+;-----------------------------------------------------------------------------
+; void checkasm_checked_call(void *func, ...)
+;-----------------------------------------------------------------------------
+INIT_XMM
+cglobal checked_call, 2, 15, 16, max_args*8+64+8
+    mov  t0, r0
+
+    ; All arguments have been pushed on the stack instead of registers in
+    ; order to test for incorrect assumptions that 32-bit ints are
+    ; zero-extended to 64-bit.
+    mov  r0, r6mp
+    mov  r1, r7mp
+    mov  r2, r8mp
+    mov  r3, r9mp
+%if UNIX64
+    mov  r4, r10mp
+    mov  r5, r11mp
+%else ; WIN64
+    ; Move possible floating-point arguments to the correct registers
+    movq m0, r0
+    movq m1, r1
+    movq m2, r2
+    movq m3, r3
+
+    %assign i 6
+    %rep 16-6
+        mova m %+ i, [x %+ i]
+        %assign i i+1
+    %endrep
+%endif
+
+    ; write stack canaries to the area above parameters passed on the stack
+    mov r9d, [num_stack_params]
+    mov  r8, [rsp+stack_offset] ; return address
+    not  r8
+%assign i 0
+%rep 8 ; 64 bytes
+    mov [stack_param+(r9+i)*8], r8
+    %assign i i+1
+%endrep
+    dec r9d
+    jl .stack_setup_done ; no stack parameters
+.copy_stack_parameter:
+    mov  r8, [stack_param+stack_offset+7*8+r9*8]
+    mov [stack_param+r9*8], r8
+    dec r9d
+    jge .copy_stack_parameter
+.stack_setup_done:
+
+%assign i 14
+%rep 15-free_regs
+    mov r %+ i, [n %+ i]
+    %assign i i-1
+%endrep
+    call t0
+
+    ; check for failure to preserve registers
+    xor r14, [n14]
+    lea  r0, [errmsg_reg]
+%assign i 13
+%rep 14-free_regs
+    xor r %+ i, [n %+ i]
+    or  r14, r %+ i
+    %assign i i-1
+%endrep
+%if WIN64
+    pxor m6, [x6]
+    %assign i 7
+    %rep 16-7
+        pxor m %+ i, [x %+ i]
+        por  m6, m %+ i
+        %assign i i+1
+    %endrep
+    packsswb m6, m6
+    movq r5, m6
+    or  r14, r5
+%endif
+    jnz .fail
+
+    ; check for stack corruption
+    mov r9d, [num_stack_params]
+    mov  r8, [rsp+stack_offset]
+    mov  r4, [stack_param+r9*8]
+    not  r8
+    xor  r4, r8
+%assign i 1
+%rep 6
+    mov  r5, [stack_param+(r9+i)*8]
+    xor  r5, r8
+    or   r4, r5
+    %assign i i+1
+%endrep
+    xor  r8, [stack_param+(r9+7)*8]
+    or   r4, r8
+    jz .ok
+    add  r0, errmsg_stack-errmsg_reg
+.fail:
+    ; Call fail_func() with a descriptive message to mark it as a failure.
+    ; Save the return value located in rdx:rax first to prevent clobbering.
+    mov  r9, rax
+    mov r10, rdx
+    xor eax, eax
+    call fail_func
+    mov rdx, r10
+    mov rax, r9
+.ok:
+    RET
+
+; trigger a warmup of vector units
+%macro WARMUP 0
+cglobal warmup, 0, 0
+    xorps   m0, m0
+    mulps   m0, m0
+    RET
+%endmacro
+
+INIT_YMM avx2
+WARMUP
+INIT_ZMM avx512
+WARMUP
+
+%else
+
+; just random numbers to reduce the chance of incidental match
+%assign n3 0x6549315c
+%assign n4 0xe02f3e23
+%assign n5 0xb78d0d1d
+%assign n6 0x33627ba7
+
+;-----------------------------------------------------------------------------
+; void checkasm_checked_call(void *func, ...)
+;-----------------------------------------------------------------------------
+cglobal checked_call, 1, 7
+    mov  r3, [esp+stack_offset]      ; return address
+    mov  r1, [esp+stack_offset+17*4] ; num_stack_params
+    mov  r2, 27
+    not  r3
+    sub  r2, r1
+.push_canary:
+    push r3
+    dec  r2
+    jg .push_canary
+.push_parameter:
+    push dword [esp+32*4]
+    dec  r1
+    jg .push_parameter
+    mov  r3, n3
+    mov  r4, n4
+    mov  r5, n5
+    mov  r6, n6
+    call r0
+
+    ; check for failure to preserve registers
+    xor  r3, n3
+    xor  r4, n4
+    xor  r5, n5
+    xor  r6, n6
+    or   r3, r4
+    or   r5, r6
+    LEA  r1, errmsg_reg
+    or   r3, r5
+    jnz .fail
+
+    ; check for stack corruption
+    mov  r3, [esp+48*4] ; num_stack_params
+    mov  r6, [esp+31*4] ; return address
+    mov  r4, [esp+r3*4]
+    sub  r3, 26
+    not  r6
+    xor  r4, r6
+.check_canary:
+    mov  r5, [esp+(r3+27)*4]
+    xor  r5, r6
+    or   r4, r5
+    inc  r3
+    jl .check_canary
+    test r4, r4
+    jz .ok
+    add  r1, errmsg_stack-errmsg_reg
+.fail:
+    mov  r3, eax
+    mov  r4, edx
+    mov [esp], r1
+    call fail_func
+    mov edx, r4
+    mov eax, r3
+.ok:
+    add esp, 27*4
+    RET
+
+%endif ; ARCH_X86_64

--- a/checkasm/x86/checkasm.asm
+++ b/checkasm/x86/checkasm.asm
@@ -24,8 +24,7 @@
 ; SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 %define private_prefix checkasm
-%include "config.asm"
-%include "ext/x86/x86inc.asm"
+%include "x86/x86inc.asm"
 
 SECTION_RODATA 16
 

--- a/configure.ac
+++ b/configure.ac
@@ -215,6 +215,7 @@ extern_prefix=""
 
 # Locate and configure Assembler appropriately
 can_asm=false
+INTEL=false
 AS_IF([test "x$enable_asm" != xno], [
     AS_CASE([$host],
         [i?86-*], [
@@ -242,7 +243,6 @@ AS_IF([test "x$enable_asm" != xno], [
             ASFLAGS="$ASFLAGS -DARCH_X86_64=1"
         ],
         [ # default
-            INTEL=false
             AC_MSG_NOTICE([Assembly optimizations are not yet supported on $host; disabling.])
         ]
     )

--- a/configure.ac
+++ b/configure.ac
@@ -12,6 +12,7 @@ AC_CONFIG_HEADERS([config.h])
 # Checks for programs.
 AC_PROG_CC
 AM_PROG_CC_C_O
+AM_PROG_AS
 
 # Checks for header files.
 AC_CHECK_HEADERS_ONCE([iconv.h])
@@ -215,6 +216,7 @@ extern_prefix=""
 
 # Locate and configure Assembler appropriately
 can_asm=false
+AARCH64=false
 INTEL=false
 AS_IF([test "x$enable_asm" != xno], [
     AS_CASE([$host],
@@ -241,6 +243,11 @@ AS_IF([test "x$enable_asm" != xno], [
             BITS=64
             BITTYPE=64
             ASFLAGS="$ASFLAGS -DARCH_X86_64=1"
+        ],
+        [aarch64-*|arm64-*|armv8-*], [
+            AARCH64=true
+            BITS=64
+            BITTYPE=64
         ],
         [ # default
             AC_MSG_NOTICE([Assembly optimizations are not yet supported on $host; disabling.])
@@ -304,6 +311,17 @@ AS_IF([test "x$enable_asm" != xno], [
             rm conftest.asm conftest.o > /dev/null 2>&1
         ])
     ])
+    AS_IF([test "x$AARCH64" = xtrue], [
+        AS_CASE([$host],
+            [*darwin*], [
+                can_asm=true
+            ],
+            [ # default
+                AC_MSG_WARN(Please contact libass upstream to figure out if ASM)
+                AC_MSG_WARN(support for your platform can be added.)
+            ]
+        )
+    ])
 ])
 
 AS_IF([test x"$enable_asm" = xyes && test x"$can_asm" != xtrue], [
@@ -325,6 +343,7 @@ AM_CONDITIONAL([ASM], [test "x$can_asm" = xtrue])
 AM_CONDITIONAL([INTEL], [test "x$INTEL" = xtrue])
 AM_CONDITIONAL([X86], [test "x$X86" = xtrue])
 AM_CONDITIONAL([X64], [test "x$X64" = xtrue])
+AM_CONDITIONAL([AARCH64], [test "x$AARCH64" = xtrue])
 
 AM_CONDITIONAL([ENABLE_LARGE_TILES], [test "x$enable_large_tiles" = xyes])
 

--- a/configure.ac
+++ b/configure.ac
@@ -275,7 +275,6 @@ AS_IF([test "x$enable_asm" != xno], [
                     ))
                 ]
             )
-            ASFLAGS="$ASFLAGS -Dprivate_prefix=ass"
             AC_MSG_CHECKING([if $AS supports vpmovzxwd])
             echo "vpmovzxwd ymm0, xmm0" > conftest.asm
             AS_IF([$AS conftest.asm $ASFLAGS -o conftest.o >conftest.log 2>&1], [

--- a/configure.ac
+++ b/configure.ac
@@ -288,6 +288,9 @@ AS_IF([test "x$enable_asm" != xno], [
             ])
             rm conftest.asm conftest.o > /dev/null 2>&1
         ])
+    ], [
+        AC_MSG_NOTICE(Assembly optimizations are not yet supported on this architecture; disabling.)
+        enable_asm=no
     ])
 ])
 

--- a/configure.ac
+++ b/configure.ac
@@ -249,6 +249,7 @@ AS_IF([test "x$enable_asm" != xno], [
     AS_CASE([$host],
         [*darwin*], [
             extern_prefix="_"
+            AC_DEFINE(CONFIG_DARWIN, 1, [Darwin platform])
         ],
         [*cygwin*|*mingw*], [
             AS_IF([test "x$BITS" = x32], [

--- a/configure.ac
+++ b/configure.ac
@@ -210,6 +210,8 @@ AS_IF([test "x$enable_require_system_font_provider" != xno  dnl
     ))
 ])
 
+# Set prefix for external symbols
+extern_prefix=""
 
 # Locate and configure Assembler appropriately
 can_asm=false
@@ -244,6 +246,16 @@ AS_IF([test "x$enable_asm" != xno], [
             AC_MSG_NOTICE([Assembly optimizations are not yet supported on this architecture; disabling.])
         ]
     )
+    AS_CASE([$host],
+        [*darwin*], [
+            extern_prefix="_"
+        ],
+        [*cygwin*|*mingw*], [
+            AS_IF([test "x$BITS" = x32], [
+                extern_prefix="_"
+            ])
+        ]
+    )
     AS_IF([test "x$INTEL" = xtrue], [
         AC_CHECK_PROG([nasm_check], [$AS], [yes])
         AS_IF([test "x$nasm_check" != xyes], [
@@ -252,7 +264,7 @@ AS_IF([test "x$enable_asm" != xno], [
         ], [
             AS_CASE([$host],
                 [*darwin*], [
-                    ASFLAGS="$ASFLAGS -f macho$BITTYPE -DPREFIX -DSTACK_ALIGNMENT=16"
+                    ASFLAGS="$ASFLAGS -f macho$BITTYPE -DSTACK_ALIGNMENT=16"
                 ],
                 [*linux*|*solaris*|*haiku*], [
                     ASFLAGS="$ASFLAGS -f elf$BITTYPE -DSTACK_ALIGNMENT=16"
@@ -262,9 +274,6 @@ AS_IF([test "x$enable_asm" != xno], [
                 ],
                 [*cygwin*|*mingw*], [
                     ASFLAGS="$ASFLAGS -f win$BITTYPE"
-                    AS_IF([test "x$BITS" = x32], [
-                        ASFLAGS="$ASFLAGS -DPREFIX"
-                    ])
                 ],
                 [ # default
                     AC_MSG_ERROR(m4_text_wrap(m4_normalize([
@@ -277,6 +286,9 @@ AS_IF([test "x$enable_asm" != xno], [
                     ))
                 ]
             )
+            AS_IF([test "x$extern_prefix" == "x_"], [
+                ASFLAGS="$ASFLAGS -DPREFIX"
+            ])
             AC_MSG_CHECKING([if $AS supports vpmovzxwd])
             echo "vpmovzxwd ymm0, xmm0" > conftest.asm
             AS_IF([$AS conftest.asm $ASFLAGS -o conftest.o >conftest.log 2>&1], [
@@ -338,6 +350,8 @@ AM_COND_IF([ENABLE_LARGE_TILES], [
 ], [
     AC_DEFINE(CONFIG_LARGE_TILES, 0, [use small tiles])
 ])
+
+AC_DEFINE_UNQUOTED(EXTERN_PREFIX, $extern_prefix, [prefix for extern symbols])
 
 ## Make a guess about the source code version
 AS_IF([test -e "${srcdir}/.git"], [

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,7 @@
 AC_INIT(libass, 0.15.2)
 AM_INIT_AUTOMAKE([foreign])
+AM_EXTRA_RECURSIVE_TARGETS([bench])
+AM_EXTRA_RECURSIVE_TARGETS([run-checkasm])
 AC_CONFIG_MACRO_DIR([m4])
 # Disable Fortran checks
 define([AC_LIBTOOL_LANG_F77_CONFIG], [:])
@@ -15,7 +17,7 @@ AM_PROG_CC_C_O
 AC_CHECK_HEADERS_ONCE([iconv.h])
 
 # Checks for library functions.
-AC_CHECK_FUNCS([strdup strndup])
+AC_CHECK_FUNCS([strdup strndup clock_gettime])
 
 # Query configuration parameters and set their description
 AC_ARG_ENABLE([test], AS_HELP_STRING([--enable-test],
@@ -355,5 +357,5 @@ AC_DEFINE_UNQUOTED([CONFIG_SOURCEVERSION], ["$srcversion_string"],
 ## Setup output beautifier.
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
-AC_CONFIG_FILES([Makefile libass/Makefile test/Makefile compare/Makefile profile/Makefile libass.pc])
+AC_CONFIG_FILES([Makefile libass/Makefile test/Makefile compare/Makefile profile/Makefile checkasm/Makefile libass.pc])
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -302,9 +302,6 @@ AS_IF([test "x$enable_asm" != xno], [
             ])
             rm conftest.asm conftest.o > /dev/null 2>&1
         ])
-    ], [
-        AC_MSG_NOTICE(Assembly optimizations are not yet supported on this architecture; disabling.)
-        enable_asm=no
     ])
 ])
 

--- a/configure.ac
+++ b/configure.ac
@@ -243,7 +243,7 @@ AS_IF([test "x$enable_asm" != xno], [
         ],
         [ # default
             INTEL=false
-            AC_MSG_NOTICE([Assembly optimizations are not yet supported on this architecture; disabling.])
+            AC_MSG_NOTICE([Assembly optimizations are not yet supported on $host; disabling.])
         ]
     )
     AS_CASE([$host],

--- a/libass/Makefile.am
+++ b/libass/Makefile.am
@@ -15,7 +15,7 @@ nasm_verbose_0 = @echo "  NASM    " $@;
 	$(nasm_verbose)$(LIBTOOL) $(AM_V_lt) --tag=CC --mode=compile $(top_srcdir)/ltnasm.sh $(AS) $(ASFLAGS) -I$(srcdir)/ -Dprivate_prefix=ass -o $@ $<
 
 SRC_INTEL = x86/rasterizer.asm x86/blend_bitmaps.asm x86/be_blur.asm x86/blur.asm x86/cpuid.asm \
-            x86/cpuid.h
+            x86/cpuid.h x86/init.h
 
 SRC_FONTCONFIG = ass_fontconfig.c ass_fontconfig.h
 SRC_DIRECTWRITE = ass_directwrite.c ass_directwrite.h ass_directwrite_info_template.h dwrite_c.h
@@ -31,7 +31,7 @@ libass_la_SOURCES = ass.h ass.c ass_types.h ass_utils.h ass_utils.c \
                     ass_outline.h ass_outline.c ass_drawing.h ass_drawing.c \
                     ass_rasterizer.h ass_rasterizer.c ass_rasterizer_c.c \
                     ass_bitmap.h ass_bitmap.c ass_blur.c ass_func_template.h wyhash.h \
-                    ass_cpu.h ass_cpu.c
+                    ass_cpu.h ass_cpu.c ass_bitmap_engine.h ass_bitmap_engine.c
 
 libass_la_LDFLAGS = -no-undefined -version-info $(LIBASS_LT_CURRENT):$(LIBASS_LT_REVISION):$(LIBASS_LT_AGE)
 libass_la_LDFLAGS += -export-symbols $(srcdir)/libass.sym

--- a/libass/Makefile.am
+++ b/libass/Makefile.am
@@ -17,6 +17,8 @@ nasm_verbose_0 = @echo "  NASM    " $@;
 SRC_INTEL = x86/rasterizer.asm x86/blend_bitmaps.asm x86/be_blur.asm x86/blur.asm x86/cpuid.asm \
             x86/cpuid.h x86/init.h
 
+SRC_AARCH64 = aarch64/asm.S aarch64/be_blur.S aarch64/blend_bitmaps.S aarch64/init.h
+
 SRC_FONTCONFIG = ass_fontconfig.c ass_fontconfig.h
 SRC_DIRECTWRITE = ass_directwrite.c ass_directwrite.h ass_directwrite_info_template.h dwrite_c.h
 SRC_CORETEXT = ass_coretext.c ass_coretext.h
@@ -51,6 +53,9 @@ endif
 if ASM
 if INTEL
 libass_la_SOURCES += $(SRC_INTEL)
+endif
+if AARCH64
+libass_la_SOURCES += $(SRC_AARCH64)
 endif
 endif
 

--- a/libass/Makefile.am
+++ b/libass/Makefile.am
@@ -30,7 +30,8 @@ libass_la_SOURCES = ass.h ass.c ass_types.h ass_utils.h ass_utils.c \
                     ass_parse.h ass_parse.c ass_priv.h ass_shaper.h ass_shaper.c \
                     ass_outline.h ass_outline.c ass_drawing.h ass_drawing.c \
                     ass_rasterizer.h ass_rasterizer.c ass_rasterizer_c.c \
-                    ass_bitmap.h ass_bitmap.c ass_blur.c ass_func_template.h wyhash.h
+                    ass_bitmap.h ass_bitmap.c ass_blur.c ass_func_template.h wyhash.h \
+                    ass_cpu.h ass_cpu.c
 
 libass_la_LDFLAGS = -no-undefined -version-info $(LIBASS_LT_CURRENT):$(LIBASS_LT_REVISION):$(LIBASS_LT_AGE)
 libass_la_LDFLAGS += -export-symbols $(srcdir)/libass.sym

--- a/libass/Makefile.am
+++ b/libass/Makefile.am
@@ -12,7 +12,7 @@ nasm_verbose_ = $(nasm_verbose_$(AM_DEFAULT_VERBOSITY))
 nasm_verbose_0 = @echo "  NASM    " $@;
 
 .asm.lo:
-	$(nasm_verbose)$(LIBTOOL) $(AM_V_lt) --tag=CC --mode=compile $(top_srcdir)/ltnasm.sh $(AS) $(ASFLAGS) -I$(srcdir)/ -o $@ $<
+	$(nasm_verbose)$(LIBTOOL) $(AM_V_lt) --tag=CC --mode=compile $(top_srcdir)/ltnasm.sh $(AS) $(ASFLAGS) -I$(srcdir)/ -Dprivate_prefix=ass -o $@ $<
 
 SRC_INTEL = x86/rasterizer.asm x86/blend_bitmaps.asm x86/be_blur.asm x86/blur.asm x86/cpuid.asm \
             x86/cpuid.h

--- a/libass/aarch64/asm.S
+++ b/libass/aarch64/asm.S
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2021 rcombs
+ *
+ * This file is part of libass.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "config.h"
+
+.macro function name, export=1
+    .macro endfunc
+        .purgem endfunc
+    .endm
+    .text
+    .if \export
+        .global EXTERN_PREFIX\()ass_\name
+    .endif
+    .align 2
+    EXTERN_PREFIX\()ass_\name:
+.endmacro
+
+.macro const name, align=4
+    .macro endconst
+    .endm
+    .data
+    .align \align
+    \name:
+.endmacro
+
+.macro loadaddr reg, name
+#if CONFIG_DARWIN
+    adrp \reg, \name\()@PAGE
+    add \reg, \reg, #\name\()@PAGEOFF
+#elif !defined(PIC)
+    ldr \reg, =\name
+#else
+#error No support for PIC on this platform yet!
+#endif
+.endmacro

--- a/libass/aarch64/be_blur.S
+++ b/libass/aarch64/be_blur.S
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2021 rcombs
+ *
+ * This file is part of libass.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "asm.S"
+
+/*
+ * void be_blur(uint8_t *buf, intptr_t stride,
+ *              intptr_t width, intptr_t height, uint16_t *tmp);
+ */
+
+function be_blur_neon
+    sub x1, x1, x2
+    and x1, x1, ~15
+    mov x6, x0
+    mov x7, x4
+    movi v16.16b, 0
+    mov x9, x2
+
+    ld1 {v3.16b}, [x0], #16
+    ushll v4.8h, v3.8b, 0
+
+    ext v5.16b, v16.16b, v4.16b, 14
+    add v5.8h, v5.8h, v4.8h
+
+    ushll2 v0.8h, v3.16b, 0
+    b 1f
+
+0:
+    ld1 {v3.16b}, [x0], #16
+    ushll v4.8h, v3.8b, 0
+    ext v5.16b, v0.16b, v4.16b, 14
+    add v5.8h, v5.8h, v4.8h
+    ushll2 v0.8h, v3.16b, 0
+    ext v3.16b, v1.16b, v5.16b, 2
+    add v3.8h, v3.8h, v1.8h
+    mov v2.8h, v3.8h
+
+    st1 {v2.8h, v3.8h}, [x4], #32
+
+1:
+    ext v1.16b, v4.16b, v0.16b, 14
+    add v1.8h, v1.8h, v0.8h
+    ext v3.16b, v5.16b, v1.16b, 2
+    add v3.8h, v3.8h, v5.8h
+
+    mov v4.8h, v3.8h
+    st1 {v3.8h, v4.8h}, [x4], #32
+
+    subs x2, x2, 16
+    b.hi 0b
+
+    ext v0.16b, v0.16b, v16.16b, 14
+    ext v3.16b, v1.16b, v0.16b, 2
+    add v3.8h, v3.8h, v1.8h
+
+    mov v4.8h, v3.8h
+    st1 {v3.8h, v4.8h}, [x4], #32
+
+    add x0, x0, x1
+    subs x3, x3, 1
+    b.le 3f
+
+0:
+    mov x4, x7
+    mov x2, x9
+    ld1 {v2.16b}, [x0], #16
+    ushll v4.8h, v2.8b, 0
+    ext v5.16b, v16.16b, v4.16b, 14
+    add v5.8h, v5.8h, v4.8h
+    ushll2 v0.8h, v2.16b, 0
+
+    b 2f
+
+1:
+    ld1 {v2.16b}, [x0], #16
+    ushll v4.8h, v2.8b, 0
+    ext v5.16b, v0.16b, v4.16b, 14
+    add v5.8h, v5.8h, v4.8h
+    ushll2 v0.8h, v2.16b, 0
+    ext v2.16b, v1.16b, v5.16b, 2
+    add v6.8h, v2.8h, v1.8h
+
+    ld1 {v1.8h, v2.8h}, [x4]
+    add v7.8h, v1.8h, v6.8h
+    st1 {v6.8h, v7.8h}, [x4], #32
+    add v2.8h, v2.8h, v7.8h
+    uqshrn2 v3.16b, v2.8h, 4
+
+    st1 {v3.16b}, [x6], #16
+
+2:
+    ext v1.16b, v4.16b, v0.16b, 14
+    add v1.8h, v1.8h, v0.8h
+    ext v2.16b, v5.16b, v1.16b, 2
+    add v2.8h, v2.8h, v5.8h
+
+    ld1 {v3.8h, v4.8h}, [x4]
+    add v3.8h, v3.8h, v2.8h
+    st1 {v2.8h, v3.8h}, [x4], #32
+    add v4.8h, v4.8h, v3.8h
+    uqshrn v3.8b, v4.8h, 4
+
+    subs x2, x2, 16
+    b.hi 1b
+
+    ext v0.16b, v0.16b, v16.16b, 14
+    ext v2.16b, v1.16b, v0.16b, 2
+    add v4.8h, v2.8h, v1.8h
+
+    ld1 {v0.8h, v1.8h}, [x4]
+    add v5.8h, v0.8h, v4.8h
+    st1 {v4.8h, v5.8h}, [x4], #32
+    add v1.8h, v1.8h, v5.8h
+    uqshrn2 v3.16b, v1.8h, 4
+    st1 {v3.16b}, [x6], #16
+
+    add x0, x0, x1
+    add x6, x6, x1
+    subs x3, x3, 1
+    b.hi 0b
+
+3:
+    mov x2, x9
+    mov x4, x7
+0:
+    ld1 {v2.8h, v3.8h, v4.8h, v5.8h}, [x4], #64
+    add v2.8h, v2.8h, v3.8h
+    uqshrn v2.8b, v2.8h, 4
+    add v3.8h, v4.8h, v5.8h
+    uqshrn2 v2.16b, v3.8h, 4
+    st1 {v2.16b}, [x6], #16
+    subs x2, x2, 16
+    b.hi 0b
+    ret
+endfunc

--- a/libass/aarch64/blend_bitmaps.S
+++ b/libass/aarch64/blend_bitmaps.S
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2021 rcombs
+ *
+ * This file is part of libass.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "asm.S"
+
+/*
+ * load_edge_mask
+ * Set n first bytes of NEON register to 255 and other bytes to 0
+ */
+
+const edge_mask, align=16
+    .dcb.b 16, 0xFF
+edge_mask_zeroes:
+    .dcb.b 16, 0x00
+endconst
+
+.macro load_edge_mask dst, n, tmp
+    loadaddr \tmp, edge_mask_zeroes
+    sub \tmp, \tmp, \n
+    ld1 {\dst\().16B}, [\tmp]
+.endm
+
+/*
+ * void add_bitmaps(uint8_t *dst, intptr_t dst_stride,
+ *                  uint8_t *src, intptr_t src_stride,
+ *                  intptr_t width, intptr_t height);
+ */
+
+function add_bitmaps_neon
+    and x6, x4, 15
+    load_edge_mask v2, x6, x9
+    add x6, x4, 15
+    and x6, x6, ~15
+    sub x1, x1, x6
+    sub x3, x3, x6
+0:
+    mov x7, x4
+1:
+    ld1 {v0.16b}, [x0]
+    ld1 {v1.16b}, [x2], #16
+    subs x7, x7, 16
+    uqadd v0.16b, v0.16b, v1.16b
+    b.pl 2f
+    and v0.16b, v0.16b, v2.16b
+2:
+    st1 {v0.16b}, [x0], #16
+    b.hi 1b
+    add x0, x0, x1
+    add x2, x2, x3
+    subs x5, x5, #1
+    b.hi 0b
+    ret
+endfunc
+
+
+/*
+ * void imul_bitmaps(uint8_t *dst, intptr_t dst_stride,
+ *                   uint8_t *src, intptr_t src_stride,
+ *                   intptr_t width, intptr_t height);
+ */
+
+function imul_bitmaps_neon
+    and x6, x4, 15
+    load_edge_mask v4, x6, x9
+    add x6, x4, 15
+    and x6, x6, ~15
+    sub x1, x1, x6
+    sub x3, x3, x6
+
+0:
+    mov x7, x4
+1:
+    ld1 {v0.16b}, [x0]
+    ld1 {v1.16b}, [x2], #16
+    subs x7, x7, 16
+    b.pl 2f
+    and v1.16b, v1.16b, v4.16b
+2:
+    movi v2.8h, 255
+    movi v3.8h, 255
+    mvn v1.16b, v1.16b
+    umlal v2.8h, v0.8b, v1.8b
+    umlal2 v3.8h, v0.16b, v1.16b
+    uqshrn v0.8b, v2.8h, 8
+    uqshrn2 v0.16b, v3.8h, 8
+    st1 {v0.16b}, [x0], #16
+    b.hi 1b
+    add x0, x0, x1
+    add x2, x2, x3
+    subs x5, x5, #1
+    b.hi 0b
+    ret
+endfunc
+
+/*
+ * void mul_bitmaps(uint8_t *dst, intptr_t dst_stride,
+ *                  uint8_t *src1, intptr_t src1_stride,
+ *                  uint8_t *src2, intptr_t src2_stride,
+ *                  intptr_t width, intptr_t height);
+ */
+
+function mul_bitmaps_neon
+    and x8, x6, 15
+    load_edge_mask v4, x8, x9
+    add x8, x6, 15
+    and x8, x8, ~15
+    sub x1, x1, x8
+    sub x3, x3, x8
+    sub x5, x5, x8
+0:
+    mov x8, x6
+1:
+    ld1 {v0.16b}, [x2], #16
+    subs x8, x8, 16
+    ld1 {v1.16b}, [x4], #16
+    movi v2.8h, 255
+    movi v3.8h, 255
+    umlal v2.8h, v0.8b, v1.8b
+    umlal2 v3.8h, v0.16b, v1.16b
+    uqshrn v0.8b, v2.8h, 8
+    uqshrn2 v0.16b, v3.8h, 8
+    b.pl 2f
+    and v0.16b, v0.16b, v4.16b
+2:
+    st1 {v0.16b}, [x0], #16
+    b.hi 1b
+    add x0, x0, x1
+    add x2, x2, x3
+    add x4, x4, x5
+    subs x7, x7, #1
+    b.hi 0b
+    ret
+endfunc

--- a/libass/aarch64/init.h
+++ b/libass/aarch64/init.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2021 rcombs <rcombs@rcombs.me>
+ *
+ * This file is part of libass.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef X86_INIT_H
+#define X86_INIT_H
+
+#include "ass_bitmap_engine.h"
+#include "ass_cpu.h"
+
+#define ENGINE_SUFFIX   neon
+#include "ass_func_template.h"
+#undef ENGINE_SUFFIX
+
+void ass_bitmap_init_aarch64(BitmapEngine* engine, ASS_CPUFlags flags)
+{
+    if (flags & ASS_CPU_FLAG_ARM_NEON) {
+        engine->add_bitmaps = ass_add_bitmaps_neon;
+        engine->imul_bitmaps = ass_imul_bitmaps_neon;
+        engine->mul_bitmaps = ass_mul_bitmaps_neon;
+
+        engine->be_blur = ass_be_blur_neon;
+    }
+};
+
+#endif /* X86_INIT_H */

--- a/libass/ass_bitmap.h
+++ b/libass/ass_bitmap.h
@@ -24,71 +24,9 @@
 #include FT_GLYPH_H
 
 #include "ass.h"
+#include "ass_cpu.h"
 #include "ass_outline.h"
-
-
-struct segment;
-typedef void (*FillSolidTileFunc)(uint8_t *buf, ptrdiff_t stride, int set);
-typedef void (*FillHalfplaneTileFunc)(uint8_t *buf, ptrdiff_t stride,
-                                      int32_t a, int32_t b, int64_t c, int32_t scale);
-typedef void (*FillGenericTileFunc)(uint8_t *buf, ptrdiff_t stride,
-                                    const struct segment *line, size_t n_lines,
-                                    int winding);
-typedef void (*MergeTileFunc)(uint8_t *buf, ptrdiff_t stride, const uint8_t *tile);
-
-typedef void (*BitmapBlendFunc)(uint8_t *dst, intptr_t dst_stride,
-                                uint8_t *src, intptr_t src_stride,
-                                intptr_t width, intptr_t height);
-typedef void (*BitmapMulFunc)(uint8_t *dst, intptr_t dst_stride,
-                              uint8_t *src1, intptr_t src1_stride,
-                              uint8_t *src2, intptr_t src2_stride,
-                              intptr_t width, intptr_t height);
-
-typedef void (*BeBlurFunc)(uint8_t *buf, intptr_t stride,
-                           intptr_t width, intptr_t height, uint16_t *tmp);
-
-// intermediate bitmaps represented as sets of verical stripes of int16_t[alignment / 2]
-typedef void (*Convert8to16Func)(int16_t *dst, const uint8_t *src, ptrdiff_t src_stride,
-                                 uintptr_t width, uintptr_t height);
-typedef void (*Convert16to8Func)(uint8_t *dst, ptrdiff_t dst_stride, const int16_t *src,
-                                 uintptr_t width, uintptr_t height);
-typedef void (*FilterFunc)(int16_t *dst, const int16_t *src,
-                           uintptr_t src_width, uintptr_t src_height);
-typedef void (*ParamFilterFunc)(int16_t *dst, const int16_t *src,
-                                uintptr_t src_width, uintptr_t src_height,
-                                const int16_t *param);
-
-#define C_ALIGN_ORDER 5
-
-typedef struct {
-    int align_order;  // log2(alignment)
-
-    // rasterizer functions
-    int tile_order;  // log2(tile_size)
-    FillSolidTileFunc fill_solid;
-    FillHalfplaneTileFunc fill_halfplane;
-    FillGenericTileFunc fill_generic;
-    MergeTileFunc merge_tile;
-
-    // blend functions
-    BitmapBlendFunc add_bitmaps, imul_bitmaps;
-    BitmapMulFunc mul_bitmaps;
-
-    // be blur function
-    BeBlurFunc be_blur;
-
-    // gaussian blur functions
-    Convert8to16Func stripe_unpack;
-    Convert16to8Func stripe_pack;
-    FilterFunc shrink_horz, shrink_vert;
-    FilterFunc expand_horz, expand_vert;
-    ParamFilterFunc blur_horz[5], blur_vert[5];
-} BitmapEngine;
-
-extern const BitmapEngine ass_bitmap_engine_c;
-extern const BitmapEngine ass_bitmap_engine_sse2;
-extern const BitmapEngine ass_bitmap_engine_avx2;
-
+#include "ass_bitmap_engine.h"
 
 typedef struct {
     int32_t left, top;

--- a/libass/ass_bitmap_engine.c
+++ b/libass/ass_bitmap_engine.c
@@ -23,6 +23,9 @@
 #include "config.h"
 
 #if CONFIG_ASM
+#if (defined(__aarch64__))
+#include "aarch64/init.h"
+#endif
 #if (defined(__i386__) || defined(__x86_64__))
 #include "x86/init.h"
 #endif
@@ -75,6 +78,9 @@ void ass_bitmap_engine_init(BitmapEngine* engine, ASS_CPUFlags mask)
 
 #if CONFIG_ASM
     ASS_CPUFlags flags = ass_get_cpu_flags(mask);
+#if (defined(__aarch64__))
+    ass_bitmap_init_aarch64(engine, flags);
+#endif
 #if (defined(__i386__) || defined(__x86_64__))
     ass_bitmap_init_x86(engine, flags);
 #endif

--- a/libass/ass_bitmap_engine.c
+++ b/libass/ass_bitmap_engine.c
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2015 Vabishchevich Nikolay <vabnick@gmail.com>
+ *
+ * This file is part of libass.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <stdlib.h>
+
+#include "ass_bitmap_engine.h"
+
+#include "config.h"
+
+#if CONFIG_ASM
+#if (defined(__i386__) || defined(__x86_64__))
+#include "x86/init.h"
+#endif
+#endif
+
+#define ENGINE_SUFFIX   c
+#include "ass_func_template.h"
+#undef ENGINE_SUFFIX
+
+void ass_bitmap_engine_init(BitmapEngine* engine, ASS_CPUFlags mask)
+{
+#if CONFIG_LARGE_TILES
+    engine->tile_order = 5;
+    engine->fill_solid = fill_solid_tile32_c;
+    engine->fill_halfplane = ass_fill_halfplane_tile32_c;
+    engine->fill_generic = ass_fill_generic_tile32_c;
+    engine->merge_tile = ass_merge_tile32_c;
+#else
+    engine->tile_order = 4;
+    engine->fill_solid = ass_fill_solid_tile16_c;
+    engine->fill_halfplane = ass_fill_halfplane_tile16_c;
+    engine->fill_generic = ass_fill_generic_tile16_c;
+    engine->merge_tile = ass_merge_tile16_c;
+#endif
+
+    engine->add_bitmaps = ass_add_bitmaps_c;
+    engine->imul_bitmaps = ass_imul_bitmaps_c;
+    engine->mul_bitmaps = ass_mul_bitmaps_c;
+
+    engine->be_blur = ass_be_blur_c;
+
+    engine->stripe_unpack = ass_stripe_unpack_c;
+    engine->stripe_pack = ass_stripe_pack_c;
+    engine->shrink_horz = ass_shrink_horz_c;
+    engine->shrink_vert = ass_shrink_vert_c;
+    engine->expand_horz = ass_expand_horz_c;
+    engine->expand_vert = ass_expand_vert_c;
+
+    engine->blur_horz[0] = ass_blur4_horz_c;
+    engine->blur_horz[1] = ass_blur5_horz_c;
+    engine->blur_horz[2] = ass_blur6_horz_c;
+    engine->blur_horz[3] = ass_blur7_horz_c;
+    engine->blur_horz[4] = ass_blur8_horz_c;
+
+    engine->blur_vert[0] = ass_blur4_vert_c;
+    engine->blur_vert[1] = ass_blur5_vert_c;
+    engine->blur_vert[2] = ass_blur6_vert_c;
+    engine->blur_vert[3] = ass_blur7_vert_c;
+    engine->blur_vert[4] = ass_blur8_vert_c;
+
+#if CONFIG_ASM
+    ASS_CPUFlags flags = ass_get_cpu_flags(mask);
+#if (defined(__i386__) || defined(__x86_64__))
+    ass_bitmap_init_x86(engine, flags);
+#endif
+#endif
+}

--- a/libass/ass_bitmap_engine.h
+++ b/libass/ass_bitmap_engine.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2021 rcombs <rcombs@rcombs.me>
+ *
+ * This file is part of libass.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef LIBASS_BITMAP_ENGINE_H
+#define LIBASS_BITMAP_ENGINE_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "ass_cpu.h"
+
+struct segment;
+typedef void (*FillSolidTileFunc)(uint8_t *buf, ptrdiff_t stride, int set);
+typedef void (*FillHalfplaneTileFunc)(uint8_t *buf, ptrdiff_t stride,
+                                      int32_t a, int32_t b, int64_t c, int32_t scale);
+typedef void (*FillGenericTileFunc)(uint8_t *buf, ptrdiff_t stride,
+                                    const struct segment *line, size_t n_lines,
+                                    int winding);
+typedef void (*MergeTileFunc)(uint8_t *buf, ptrdiff_t stride, const uint8_t *tile);
+
+typedef void (*BitmapBlendFunc)(uint8_t *dst, intptr_t dst_stride,
+                                uint8_t *src, intptr_t src_stride,
+                                intptr_t width, intptr_t height);
+typedef void (*BitmapMulFunc)(uint8_t *dst, intptr_t dst_stride,
+                              uint8_t *src1, intptr_t src1_stride,
+                              uint8_t *src2, intptr_t src2_stride,
+                              intptr_t width, intptr_t height);
+
+typedef void (*BeBlurFunc)(uint8_t *buf, intptr_t stride,
+                           intptr_t width, intptr_t height, uint16_t *tmp);
+
+
+// intermediate bitmaps represented as sets of verical stripes of int16_t[alignment / 2]
+typedef void (*Convert8to16Func)(int16_t *dst, const uint8_t *src, ptrdiff_t src_stride,
+                                 uintptr_t width, uintptr_t height);
+typedef void (*Convert16to8Func)(uint8_t *dst, ptrdiff_t dst_stride, const int16_t *src,
+                                 uintptr_t width, uintptr_t height);
+typedef void (*FilterFunc)(int16_t *dst, const int16_t *src,
+                           uintptr_t src_width, uintptr_t src_height);
+typedef void (*ParamFilterFunc)(int16_t *dst, const int16_t *src,
+                                uintptr_t src_width, uintptr_t src_height,
+                                const int16_t *param);
+
+#if (defined(__i386__) || defined(__x86_64__))
+#define ASS_ALIGNMENT 32
+#else
+#define ASS_ALIGNMENT 16
+#endif
+
+typedef struct {
+    // rasterizer functions
+    int tile_order;  // log2(tile_size)
+    FillSolidTileFunc fill_solid;
+    FillHalfplaneTileFunc fill_halfplane;
+    FillGenericTileFunc fill_generic;
+    MergeTileFunc merge_tile;
+
+    // blend functions
+    BitmapBlendFunc add_bitmaps, imul_bitmaps;
+    BitmapMulFunc mul_bitmaps;
+
+    // be blur function
+    BeBlurFunc be_blur;
+
+    // gaussian blur functions
+    Convert8to16Func stripe_unpack;
+    Convert16to8Func stripe_pack;
+    FilterFunc shrink_horz, shrink_vert;
+    FilterFunc expand_horz, expand_vert;
+    ParamFilterFunc blur_horz[5], blur_vert[5];
+} BitmapEngine;
+
+void ass_bitmap_engine_init(BitmapEngine* engine, ASS_CPUFlags mask);
+
+#endif /* LIBASS_BITMAP_ENGINE_H */

--- a/libass/ass_blur.c
+++ b/libass/ass_blur.c
@@ -41,8 +41,11 @@
  * for the Fourier transform of the resulting kernel.
  */
 
-
-#define STRIPE_WIDTH  (1 << (C_ALIGN_ORDER - 1))
+#if ASS_ALIGNMENT <= 16
+#define STRIPE_WIDTH ASS_ALIGNMENT
+#else
+#define STRIPE_WIDTH 16
+#endif
 #define STRIPE_MASK   (STRIPE_WIDTH - 1)
 static int16_t zero_line[STRIPE_WIDTH];
 static int16_t dither_line[2 * STRIPE_WIDTH] = {
@@ -541,7 +544,7 @@ bool ass_gaussian_blur(const BitmapEngine *engine, Bitmap *bm, double r2)
     uint32_t end_w = ((w + offset) & ~((1 << blur.level) - 1)) - 4;
     uint32_t end_h = ((h + offset) & ~((1 << blur.level) - 1)) - 4;
 
-    const int stripe_width = 1 << (engine->align_order - 1);
+    const int stripe_width = ASS_ALIGNMENT;
     uint64_t size = (((uint64_t) end_w + stripe_width - 1) & ~(stripe_width - 1)) * end_h;
     if (size > INT_MAX / 4)
         return false;

--- a/libass/ass_cpu.c
+++ b/libass/ass_cpu.c
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2020 rcombs <rcombs@rcombs.me>
+ *
+ * This file is part of libass.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "config.h"
+
+#include "ass_cpu.h"
+#include "x86/cpuid.h"
+
+ASS_CPUFlags ass_get_cpu_flags(ASS_CPUFlags mask)
+{
+    ASS_CPUFlags flags = ASS_CPU_FLAG_NONE;
+
+#if (defined(__i386__) || defined(__x86_64__)) && CONFIG_ASM
+    uint32_t eax, ebx, ecx, edx;
+    uint32_t max_leaf = 0;
+
+    flags = ASS_CPU_FLAG_X86;
+
+    eax = 0;
+    ass_get_cpuid(&eax, &ebx, &ecx, &edx);
+    max_leaf = eax;
+
+    if (max_leaf >= 1) {
+        eax = 1;
+        ass_get_cpuid(&eax, &ebx, &ecx, &edx);
+        if (edx & (1 << 26)) // SSE2
+            flags |= ASS_CPU_FLAG_X86_SSE2;
+
+        if (ecx & (1 << 27) && // OSXSAVE
+            ecx & (1 << 28)) { // AVX
+            uint32_t xcr0l, xcr0h;
+            ass_get_xgetbv(0, &xcr0l, &xcr0h);
+            if (xcr0l & (1 << 1) && // XSAVE for XMM
+                xcr0l & (1 << 2))   // XSAVE for YMM
+                flags |= ASS_CPU_FLAG_X86_AVX;
+        }
+    }
+
+    if (max_leaf >= 7) {
+        eax = 7;
+        ass_get_cpuid(&eax, &ebx, &ecx, &edx);
+
+        if (flags & ASS_CPU_FLAG_X86_AVX &&
+            (ebx & (1 << 5))) // AVX2
+            flags |= ASS_CPU_FLAG_X86_AVX2;
+    }
+#endif
+
+    return flags & mask;
+}

--- a/libass/ass_cpu.c
+++ b/libass/ass_cpu.c
@@ -60,6 +60,9 @@ ASS_CPUFlags ass_get_cpu_flags(ASS_CPUFlags mask)
             flags |= ASS_CPU_FLAG_X86_AVX2;
     }
 #endif
+#if defined(__aarch64__)
+    flags = ASS_CPU_FLAG_ARM | ASS_CPU_FLAG_ARM_NEON;
+#endif
 
     return flags & mask;
 }

--- a/libass/ass_cpu.h
+++ b/libass/ass_cpu.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2020 rcombs <rcombs@rcombs.me>
+ *
+ * This file is part of libass.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef LIBASS_CPU_H
+#define LIBASS_CPU_H
+
+typedef enum ASS_CPUFlags {
+    ASS_CPU_FLAG_NONE          = 0x00,
+    ASS_CPU_FLAG_X86           = 0x01,
+    ASS_CPU_FLAG_X86_SSE2      = 0x02,
+    ASS_CPU_FLAG_X86_AVX       = 0x04,
+    ASS_CPU_FLAG_X86_AVX2      = 0x08,
+    ASS_CPU_FLAG_X86_AVX512ICL = 0x10, // Placeholder for checkasm
+    ASS_CPU_FLAG_MAX,
+    ASS_CPU_FLAG_ALL = ((ASS_CPU_FLAG_MAX & ~1ULL) << 1) - 1,
+} ASS_CPUFlags;
+
+ASS_CPUFlags ass_get_cpu_flags(ASS_CPUFlags mask);
+
+#endif

--- a/libass/ass_cpu.h
+++ b/libass/ass_cpu.h
@@ -21,11 +21,13 @@
 
 typedef enum ASS_CPUFlags {
     ASS_CPU_FLAG_NONE          = 0x00,
+#if (defined(__i386__) || defined(__x86_64__))
     ASS_CPU_FLAG_X86           = 0x01,
     ASS_CPU_FLAG_X86_SSE2      = 0x02,
     ASS_CPU_FLAG_X86_AVX       = 0x04,
     ASS_CPU_FLAG_X86_AVX2      = 0x08,
     ASS_CPU_FLAG_X86_AVX512ICL = 0x10, // Placeholder for checkasm
+#endif
     ASS_CPU_FLAG_MAX,
     ASS_CPU_FLAG_ALL = ((ASS_CPU_FLAG_MAX & ~1ULL) << 1) - 1,
 } ASS_CPUFlags;

--- a/libass/ass_cpu.h
+++ b/libass/ass_cpu.h
@@ -28,6 +28,10 @@ typedef enum ASS_CPUFlags {
     ASS_CPU_FLAG_X86_AVX2      = 0x08,
     ASS_CPU_FLAG_X86_AVX512ICL = 0x10, // Placeholder for checkasm
 #endif
+#if defined(__aarch64__)
+    ASS_CPU_FLAG_ARM           = 0x01,
+    ASS_CPU_FLAG_ARM_NEON      = 0x02,
+#endif
     ASS_CPU_FLAG_MAX,
     ASS_CPU_FLAG_ALL = ((ASS_CPU_FLAG_MAX & ~1ULL) << 1) - 1,
 } ASS_CPUFlags;

--- a/libass/ass_func_template.h
+++ b/libass/ass_func_template.h
@@ -16,7 +16,9 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-
+#define DECORATE_SUFFIX2(name, suffix) ass_##name##_##suffix
+#define DECORATE_SUFFIX(name, suffix) DECORATE_SUFFIX2(name, suffix)
+#define DECORATE(name) DECORATE_SUFFIX(name, ENGINE_SUFFIX)
 
 void DECORATE(fill_solid_tile16)(uint8_t *buf, ptrdiff_t stride, int set);
 void DECORATE(fill_solid_tile32)(uint8_t *buf, ptrdiff_t stride, int set);
@@ -90,36 +92,6 @@ void DECORATE(blur8_vert)(int16_t *dst, const int16_t *src,
                           uintptr_t src_width, uintptr_t src_height,
                           const int16_t *param);
 
-
-const BitmapEngine DECORATE(bitmap_engine) = {
-    .align_order = ALIGN,
-
-#if CONFIG_LARGE_TILES
-    .tile_order = 5,
-    .fill_solid = DECORATE(fill_solid_tile32),
-    .fill_halfplane = DECORATE(fill_halfplane_tile32),
-    .fill_generic = DECORATE(fill_generic_tile32),
-    .merge_tile = DECORATE(merge_tile32),
-#else
-    .tile_order = 4,
-    .fill_solid = DECORATE(fill_solid_tile16),
-    .fill_halfplane = DECORATE(fill_halfplane_tile16),
-    .fill_generic = DECORATE(fill_generic_tile16),
-    .merge_tile = DECORATE(merge_tile16),
-#endif
-
-    .add_bitmaps = DECORATE(add_bitmaps),
-    .imul_bitmaps = DECORATE(imul_bitmaps),
-    .mul_bitmaps = DECORATE(mul_bitmaps),
-
-    .be_blur = DECORATE(be_blur),
-
-    .stripe_unpack = DECORATE(stripe_unpack),
-    .stripe_pack = DECORATE(stripe_pack),
-    .shrink_horz = DECORATE(shrink_horz),
-    .shrink_vert = DECORATE(shrink_vert),
-    .expand_horz = DECORATE(expand_horz),
-    .expand_vert = DECORATE(expand_vert),
-    .blur_horz = { DECORATE(blur4_horz), DECORATE(blur5_horz), DECORATE(blur6_horz), DECORATE(blur7_horz), DECORATE(blur8_horz) },
-    .blur_vert = { DECORATE(blur4_vert), DECORATE(blur5_vert), DECORATE(blur6_vert), DECORATE(blur7_vert), DECORATE(blur8_vert) },
-};
+#undef DECORATE_SUFFIX2
+#undef DECORATE_SUFFIX
+#undef DECORATE

--- a/libass/ass_rasterizer.c
+++ b/libass/ass_rasterizer.c
@@ -59,7 +59,7 @@ bool rasterizer_init(const BitmapEngine *engine, RasterizerData *rst, int outlin
     rst->size[1] = rst->capacity[1] = 0;
     rst->n_first = 0;
 
-    unsigned align = 1 << engine->align_order;
+    unsigned align = 1 << ASS_ALIGNMENT;
     unsigned size = 1 << (2 * engine->tile_order);
     rst->tile = ass_aligned_alloc(align, size, false);
     return rst->tile;

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -25,6 +25,7 @@
 #include <stdbool.h>
 
 #include "ass.h"
+#include "ass_cpu.h"
 #include "ass_outline.h"
 #include "ass_render.h"
 #include "ass_parse.h"
@@ -74,16 +75,11 @@ ASS_Renderer *ass_renderer_init(ASS_Library *library)
     priv->ftlibrary = ft;
     // images_root and related stuff is zero-filled in calloc
 
-#if (defined(__i386__) || defined(__x86_64__)) && CONFIG_ASM
-    if (has_avx2())
-        priv->engine = &ass_bitmap_engine_avx2;
-    else if (has_sse2())
-        priv->engine = &ass_bitmap_engine_sse2;
-    else
-        priv->engine = &ass_bitmap_engine_c;
-#else
-    priv->engine = &ass_bitmap_engine_c;
-#endif
+    priv->engine = calloc(sizeof(BitmapEngine), 1);
+    if (!priv->engine)
+        goto fail;
+
+    ass_bitmap_engine_init(priv->engine, ASS_CPU_FLAG_ALL);
 
     if (!rasterizer_init(priv->engine, &priv->rasterizer, RASTERIZER_PRECISION))
         goto fail;
@@ -133,6 +129,8 @@ void ass_renderer_done(ASS_Renderer *render_priv)
 {
     if (!render_priv)
         return;
+
+    free(render_priv->engine);
 
     ass_frame_unref(render_priv->images_root);
     ass_frame_unref(render_priv->prev_images_root);
@@ -715,7 +713,7 @@ static void blend_vector_clip(ASS_Renderer *render_priv, ASS_Image *head)
         bleft = left - bx;
         btop = top - by;
 
-        unsigned align = 1 << render_priv->engine->align_order;
+        unsigned align = ASS_ALIGNMENT;
         if (render_priv->state.clip_drawing_mode) {
             // Inverse clip
             if (ax + aw < bx || ay + ah < by || ax > bx + bw ||

--- a/libass/ass_render.h
+++ b/libass/ass_render.h
@@ -321,7 +321,7 @@ struct ass_renderer {
     TextInfo text_info;
     CacheStore cache;
 
-    const BitmapEngine *engine;
+    BitmapEngine *engine;
     RasterizerData rasterizer;
 
     ASS_Style user_override_style;

--- a/libass/ass_utils.c
+++ b/libass/ass_utils.c
@@ -31,41 +31,6 @@
 #include "ass_utils.h"
 #include "ass_string.h"
 
-#if (defined(__i386__) || defined(__x86_64__)) && CONFIG_ASM
-
-#include "x86/cpuid.h"
-
-int has_sse2(void)
-{
-    uint32_t eax = 1, ebx, ecx, edx;
-    ass_get_cpuid(&eax, &ebx, &ecx, &edx);
-    return (edx >> 26) & 0x1;
-}
-
-int has_avx(void)
-{
-    uint32_t eax = 1, ebx, ecx, edx;
-    ass_get_cpuid(&eax, &ebx, &ecx, &edx);
-    if (!(ecx & (1 << 27))) // not OSXSAVE
-        return 0;
-    uint32_t misc = ecx;
-    ass_get_xgetbv(0, &eax, &edx);
-    if ((eax & 0x6) != 0x6)
-        return 0;
-    eax = 0;
-    ass_get_cpuid(&eax, &ebx, &ecx, &edx);
-    return (ecx & 0x6) == 0x6 ? (misc >> 28) & 0x1 : 0; // check high bits are relevant, then AVX support
-}
-
-int has_avx2(void)
-{
-    uint32_t eax = 7, ebx, ecx, edx;
-    ass_get_cpuid(&eax, &ebx, &ecx, &edx);
-    return (ebx >> 5) & has_avx();
-}
-
-#endif // ASM
-
 // Fallbacks
 #ifndef HAVE_STRDUP
 char *ass_strdup_fallback(const char *str)

--- a/libass/ass_utils.h
+++ b/libass/ass_utils.h
@@ -48,12 +48,6 @@
 
 #define ASS_PI 3.14159265358979323846
 
-#if (defined(__i386__) || defined(__x86_64__)) && CONFIG_ASM
-int has_sse2(void);
-int has_avx(void);
-int has_avx2(void);
-#endif
-
 typedef struct {
     const char *str;
     size_t len;

--- a/libass/x86/init.h
+++ b/libass/x86/init.h
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2021 rcombs <rcombs@rcombs.me>
+ *
+ * This file is part of libass.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef X86_INIT_H
+#define X86_INIT_H
+
+#include "ass_bitmap_engine.h"
+#include "ass_cpu.h"
+
+#define ENGINE_SUFFIX   sse2
+#include "ass_func_template.h"
+#undef ENGINE_SUFFIX
+
+#define ENGINE_SUFFIX   avx2
+#include "ass_func_template.h"
+#undef ENGINE_SUFFIX
+
+void ass_bitmap_init_x86(BitmapEngine* engine, ASS_CPUFlags flags)
+{
+    if (flags & ASS_CPU_FLAG_X86_SSE2) {
+#if CONFIG_LARGE_TILES
+        engine->fill_solid = ass_fill_solid_tile32_sse2;
+        engine->fill_halfplane = ass_fill_halfplane_tile32_sse2;
+        engine->fill_generic = ass_fill_generic_tile32_sse2;
+#else
+        engine->fill_solid = ass_fill_solid_tile16_sse2;
+        engine->fill_halfplane = ass_fill_halfplane_tile16_sse2;
+        engine->fill_generic = ass_fill_generic_tile16_sse2;
+#endif
+
+        engine->add_bitmaps = ass_add_bitmaps_sse2;
+        engine->imul_bitmaps = ass_imul_bitmaps_sse2;
+        engine->mul_bitmaps = ass_mul_bitmaps_sse2;
+
+        engine->be_blur = ass_be_blur_sse2;
+
+        engine->stripe_unpack = ass_stripe_unpack_sse2;
+        engine->stripe_pack = ass_stripe_pack_sse2;
+        engine->shrink_horz = ass_shrink_horz_sse2;
+        engine->shrink_vert = ass_shrink_vert_sse2;
+        engine->expand_horz = ass_expand_horz_sse2;
+        engine->expand_vert = ass_expand_vert_sse2;
+
+        engine->blur_horz[0] = ass_blur4_horz_sse2;
+        engine->blur_horz[1] = ass_blur5_horz_sse2;
+        engine->blur_horz[2] = ass_blur6_horz_sse2;
+        engine->blur_horz[3] = ass_blur7_horz_sse2;
+        engine->blur_horz[4] = ass_blur8_horz_sse2;
+
+        engine->blur_vert[0] = ass_blur4_vert_sse2;
+        engine->blur_vert[1] = ass_blur5_vert_sse2;
+        engine->blur_vert[2] = ass_blur6_vert_sse2;
+        engine->blur_vert[3] = ass_blur7_vert_sse2;
+        engine->blur_vert[4] = ass_blur8_vert_sse2;
+    }
+
+    if (flags & ASS_CPU_FLAG_X86_AVX2) {
+#if CONFIG_LARGE_TILES
+        engine->fill_solid = ass_fill_solid_tile32_avx2;
+        engine->fill_halfplane = ass_fill_halfplane_tile32_avx2;
+        engine->fill_generic = ass_fill_generic_tile32_avx2;
+#else
+        engine->fill_solid = ass_fill_solid_tile16_avx2;
+        engine->fill_halfplane = ass_fill_halfplane_tile16_avx2;
+        engine->fill_generic = ass_fill_generic_tile16_avx2;
+#endif
+
+        engine->add_bitmaps = ass_add_bitmaps_avx2;
+        engine->imul_bitmaps = ass_imul_bitmaps_avx2;
+        engine->mul_bitmaps = ass_mul_bitmaps_avx2;
+
+        engine->stripe_unpack = ass_stripe_unpack_avx2;
+        engine->stripe_pack = ass_stripe_pack_avx2;
+        engine->shrink_horz = ass_shrink_horz_avx2;
+        engine->shrink_vert = ass_shrink_vert_avx2;
+        engine->expand_horz = ass_expand_horz_avx2;
+        engine->expand_vert = ass_expand_vert_avx2;
+
+        engine->blur_horz[0] = ass_blur4_horz_avx2;
+        engine->blur_horz[1] = ass_blur5_horz_avx2;
+        engine->blur_horz[2] = ass_blur6_horz_avx2;
+        engine->blur_horz[3] = ass_blur7_horz_avx2;
+        engine->blur_horz[4] = ass_blur8_horz_avx2;
+
+        engine->blur_horz[0] = ass_blur4_vert_avx2;
+        engine->blur_horz[1] = ass_blur5_vert_avx2;
+        engine->blur_horz[2] = ass_blur6_vert_avx2;
+        engine->blur_horz[3] = ass_blur7_vert_avx2;
+        engine->blur_horz[4] = ass_blur8_vert_avx2;
+    }
+};
+
+#endif /* X86_INIT_H */


### PR DESCRIPTION
This comes from x264 -> ffmpeg -> dav1d, tweaked a little at each step along the way (and now tweaked a bit here). It has a few very useful applications:
- Testing existing functions to ensure they behave as expected for randomized input. From this testing I discovered that our be_blur ASM needed 1px more padding than we were giving it.
- Doing test-driven development of new ASM routines. No more just running code on some random test files and comparing PNG output.
- Benchmarking function variants (both during and after development) to see how their performance compares. While doing this, I discovered that a few of my old AVX2 routines are actually slower than the SSE2 versions, so I've disabled them until we can see if faster AVX2 versions are possible.
- Testing multiple variants of functions without screwing around with ifdefs in the source.

Run `make check` for the new tests, and `make bench` for the benchmarks.