### PR TITLE
Fix memory leak of font family string when error during add_face

### DIFF
--- a/libass/ass_font.c
+++ b/libass/ass_font.c
@@ -257,7 +257,7 @@ size_t ass_font_construct(void *key, void *value, void *priv)
         free(font->desc.family);
         font->desc.family = NULL;
     }
-    
+
     return 1;
 }
 

--- a/libass/ass_font.c
+++ b/libass/ass_font.c
@@ -253,8 +253,11 @@ size_t ass_font_construct(void *key, void *value, void *priv)
     font->size = 0.;
 
     int error = add_face(render_priv->fontselect, font, 0);
-    if (error == -1)
+    if (error == -1) {
+        free(font->desc.family);
         font->desc.family = NULL;
+    }
+    
     return 1;
 }
 


### PR DESCRIPTION
When using this library I consistently detected a memory leak tied to the family string.  It was set to NULL here without being freed.