### PR TITLE
compare: Fix millisecond formatting

### DIFF
--- a/compare/README.md
+++ b/compare/README.md
@@ -55,11 +55,11 @@ Test program output can look like the following:
 Loading font 'font1.ttf'.
 Loading font 'font2.otf'.
 Processing 'sub1.ass':
-  Time 0:00:00.0500 - 2.464 BAD
-  Time 0:00:01.0500 - 1.412 OK
-  Time 0:00:02.0500 - 4.919 FAIL
+  Time 0:00:00.500 - 2.464 BAD
+  Time 0:00:01.500 - 1.412 OK
+  Time 0:00:02.500 - 4.919 FAIL
 Processing 'sub2.ass':
-  Time 0:02:33.0000 - 0.728 OK
+  Time 0:02:33.000 - 0.728 OK
 Only 3 of 4 images have passed test
 ```
 For each target image file the program reports a maximal ratio of the per pixel comparison error to the baseline error scale.

--- a/compare/compare.c
+++ b/compare/compare.c
@@ -304,7 +304,7 @@ static bool process_image(ASS_Renderer *renderer, ASS_Track *track,
     unsigned msec = tm % 1000;  tm /= 1000;
     unsigned sec  = tm %   60;  tm /=   60;
     unsigned min  = tm %   60;  tm /=   60;
-    printf("  Time %u:%02u:%02u.%04u - ", (unsigned) tm, min, sec, msec);
+    printf("  Time %u:%02u:%02u.%03u - ", (unsigned) tm, min, sec, msec);
 
     char path[4096];
     snprintf(path, sizeof(path), "%s/%s", input, file);


### PR DESCRIPTION
Padding should be 3 digits not 4, otherwise a time of eg `2252ms` is displayed as
`0:00:02.0252` instead of `0:00:02.252`.

Also updated `compare/README.md` accordingly.