### PR TITLE
Fix Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,7 @@ branches:
     - coverity_scan
 
 before_install:
-  - (sudo apt-get update || brew update)
-  - (sudo apt-get install -y libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev nasm || brew install freetype fribidi nasm) && ./autogen.sh && ./configure
+  - ./autogen.sh && ./configure
 script:
   - make -j4
 
@@ -42,6 +41,20 @@ notifications:
     on_failure: always
 
 addons:
+  apt:
+    update: true
+    packages:
+      - libfontconfig1-dev
+      - libfreetype6-dev
+      - libfribidi-dev
+      - libharfbuzz-dev
+      - nasm
+  homebrew:
+    update: true
+    packages:
+      - freetype
+      - fribidi
+      - nasm
   coverity_scan:
     project:
       name: "libass/libass"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
       compiler: gcc
 
 sudo: required
-dist: trusty
+dist: bionic
 
 branches:
   only:
@@ -55,6 +55,7 @@ addons:
       - freetype
       - fribidi
       - nasm
+      - harfbuzz
   coverity_scan:
     project:
       name: "libass/libass"


### PR DESCRIPTION
Travis builds are currently failing on MacOS due to `brew install` throwing an error on already installed but outdated packages (see eg [recent build failure](https://travis-ci.org/github/libass/libass/jobs/703007253) from #392 ). By delegating the brew and apt parts to addons, `brew install` or `brew upgrade` will be called as necessary.

While I was at it, I also added harfbuzz to macOS builds and bumped Ubuntu distro to bionic to make sure harfbuzz >= 1.2.3 will be present, which is needed for prs #398 and #399 . This is in a separate commit. Discard, copy over to relevant pr or apply as preferred.