### PR TITLE
Disable bidi bracket matching unless enabled via ASS_Feature

### DIFF
--- a/libass/ass.c
+++ b/libass/ass.c
@@ -35,49 +35,10 @@
 #include "ass.h"
 #include "ass_utils.h"
 #include "ass_library.h"
+#include "ass_priv.h"
 #include "ass_string.h"
 
 #define ass_atof(STR) (ass_strtod((STR),NULL))
-
-typedef enum {
-    PST_UNKNOWN = 0,
-    PST_INFO,
-    PST_STYLES,
-    PST_EVENTS,
-    PST_FONTS
-} ParserState;
-
-typedef enum {
-    SINFO_LANGUAGE     = 1 << 0,
-    SINFO_PLAYRESX     = 1 << 1,
-    SINFO_PLAYRESY     = 1 << 2,
-    SINFO_TIMER        = 1 << 3,
-    SINFO_WRAPSTYLE    = 1 << 4,
-    SINFO_SCALEDBORDER = 1 << 5,
-    SINFO_COLOURMATRIX = 1 << 6,
-    SINFO_KERNING      = 1 << 7,
-    // for legacy detection
-    GENBY_FFMPEG       = 1 << 8
-    // max 32 enumerators
-} ScriptInfo;
-
-struct parser_priv {
-    ParserState state;
-    char *fontname;
-    char *fontdata;
-    int fontdata_size;
-    int fontdata_used;
-
-    // contains bitmap of ReadOrder IDs of all read events
-    uint32_t *read_order_bitmap;
-    int read_order_elems; // size in uint32_t units of read_order_bitmap
-    int check_readorder;
-
-    int enable_extensions;
-
-    // tracks [Script Info] headers set by the script
-    uint32_t header_flags;
-};
 
 static const char *const ass_style_format =
         "Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, "

--- a/libass/ass.c
+++ b/libass/ass.c
@@ -36,6 +36,7 @@
 #include "ass_utils.h"
 #include "ass_library.h"
 #include "ass_priv.h"
+#include "ass_shaper.h"
 #include "ass_string.h"
 
 #define ass_atof(STR) (ass_strtod((STR),NULL))
@@ -1468,7 +1469,11 @@ int ass_track_set_feature(ASS_Track *track, ASS_Feature feature, int enable)
 {
     switch (feature) {
     case ASS_FEATURE_INCOMPATIBLE_EXTENSIONS:
-        track->parser_priv->enable_extensions = !!enable;
+        //-fallthrough
+#ifdef USE_FRIBIDI_EX_API
+    case ASS_FEATURE_BIDI_BRACKETS:
+        track->parser_priv->bidi_brackets = !!enable;
+#endif
         return 0;
     default:
         return -1;

--- a/libass/ass.h
+++ b/libass/ass.h
@@ -24,7 +24,7 @@
 #include <stdarg.h>
 #include "ass_types.h"
 
-#define LIBASS_VERSION 0x01400001
+#define LIBASS_VERSION 0x01400002
 
 #ifdef __cplusplus
 extern "C" {
@@ -208,6 +208,19 @@ typedef enum {
      * distribution.
      */
     ASS_FEATURE_INCOMPATIBLE_EXTENSIONS,
+
+    /**
+     * Match bracket pairs in bidirectional text according to the revised
+     * Unicode Bidirectional Algorithm introduced in Unicode 6.3.
+     * This is incompatible with VSFilter and disabled by default.
+     *
+     * (Directional isolates, also introduced in Unicode 6.3,
+     * are unconditionally processed when FriBidi is new enough.)
+     *
+     * This feature may be unavailable at runtime (ass_track_set_feature
+     * may return -1) if libass was compiled against old FriBidi.
+     */
+    ASS_FEATURE_BIDI_BRACKETS,
 
     // New enum values can be added here in new ABI-compatible library releases.
 } ASS_Feature;

--- a/libass/ass_priv.h
+++ b/libass/ass_priv.h
@@ -19,7 +19,10 @@
 #ifndef LIBASS_PRIV_H
 #define LIBASS_PRIV_H
 
+#include <stdbool.h>
 #include <stdint.h>
+
+#include "ass_shaper.h"
 
 typedef enum {
     PST_UNKNOWN = 0,
@@ -55,10 +58,12 @@ struct parser_priv {
     int read_order_elems; // size in uint32_t units of read_order_bitmap
     int check_readorder;
 
-    int enable_extensions;
-
     // tracks [Script Info] headers set by the script
     uint32_t header_flags;
+
+#ifdef USE_FRIBIDI_EX_API
+    bool bidi_brackets;
+#endif
 };
 
 #endif /* LIBASS_PRIV_H */

--- a/libass/ass_priv.h
+++ b/libass/ass_priv.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2006 Evgeniy Stepanov <eugeni.stepanov@gmail.com>
+ *
+ * This file is part of libass.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef LIBASS_PRIV_H
+#define LIBASS_PRIV_H
+
+#include <stdint.h>
+
+typedef enum {
+    PST_UNKNOWN = 0,
+    PST_INFO,
+    PST_STYLES,
+    PST_EVENTS,
+    PST_FONTS
+} ParserState;
+
+typedef enum {
+    SINFO_LANGUAGE     = 1 << 0,
+    SINFO_PLAYRESX     = 1 << 1,
+    SINFO_PLAYRESY     = 1 << 2,
+    SINFO_TIMER        = 1 << 3,
+    SINFO_WRAPSTYLE    = 1 << 4,
+    SINFO_SCALEDBORDER = 1 << 5,
+    SINFO_COLOURMATRIX = 1 << 6,
+    SINFO_KERNING      = 1 << 7,
+    // for legacy detection
+    GENBY_FFMPEG       = 1 << 8
+    // max 32 enumerators
+} ScriptInfo;
+
+struct parser_priv {
+    ParserState state;
+    char *fontname;
+    char *fontdata;
+    int fontdata_size;
+    int fontdata_used;
+
+    // contains bitmap of ReadOrder IDs of all read events
+    uint32_t *read_order_bitmap;
+    int read_order_elems; // size in uint32_t units of read_order_bitmap
+    int check_readorder;
+
+    int enable_extensions;
+
+    // tracks [Script Info] headers set by the script
+    uint32_t header_flags;
+};
+
+#endif /* LIBASS_PRIV_H */

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -27,6 +27,7 @@
 #include "ass_outline.h"
 #include "ass_render.h"
 #include "ass_parse.h"
+#include "ass_priv.h"
 #include "ass_shaper.h"
 
 #define MAX_GLYPHS_INITIAL 1024
@@ -2833,6 +2834,10 @@ ass_start_frame(ASS_Renderer *render_priv, ASS_Track *track,
     ass_shaper_set_kerning(render_priv->shaper, track->Kerning);
     ass_shaper_set_language(render_priv->shaper, track->Language);
     ass_shaper_set_level(render_priv->shaper, render_priv->settings.shaper);
+#ifdef USE_FRIBIDI_EX_API
+    ass_shaper_set_bidi_brackets(render_priv->shaper,
+            track->parser_priv->bidi_brackets);
+#endif
 
     // PAR correction
     double par = render_priv->settings.par;

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -108,7 +108,7 @@ ASS_Renderer *ass_renderer_init(ASS_Library *library)
     priv->settings.font_size_coeff = 1.;
     priv->settings.selective_style_overrides = ASS_OVERRIDE_BIT_SELECTIVE_FONT_SCALE;
 
-    if (!(priv->shaper = ass_shaper_new(0)))
+    if (!(priv->shaper = ass_shaper_new()))
         goto fail;
 
     ass_shaper_info(library);

--- a/libass/ass_shaper.c
+++ b/libass/ass_shaper.c
@@ -758,10 +758,10 @@ static void shape_fribidi(ASS_Shaper *shaper, GlyphInfo *glyphs, size_t len)
  * \param shaper shaper instance
  * \param kern toggle kerning
  */
-void ass_shaper_set_kerning(ASS_Shaper *shaper, int kern)
+void ass_shaper_set_kerning(ASS_Shaper *shaper, bool kern)
 {
 #ifdef CONFIG_HARFBUZZ
-    shaper->features[KERN].value = !!kern;
+    shaper->features[KERN].value = kern;
 #endif
 }
 

--- a/libass/ass_shaper.c
+++ b/libass/ass_shaper.c
@@ -947,18 +947,15 @@ int ass_shaper_shape(ASS_Shaper *shaper, TextInfo *text_info)
 }
 
 /**
- * \brief Create a new shaper instance and preallocate data structures
- * \param prealloc preallocation size
+ * \brief Create a new shaper instance
  */
-ASS_Shaper *ass_shaper_new(size_t prealloc)
+ASS_Shaper *ass_shaper_new(void)
 {
     ASS_Shaper *shaper = calloc(sizeof(*shaper), 1);
     if (!shaper)
         return NULL;
 
     shaper->base_direction = FRIBIDI_PAR_ON;
-    if (!check_allocations(shaper, prealloc))
-        goto error;
 
 #ifdef CONFIG_HARFBUZZ
     if (!init_features(shaper))

--- a/libass/ass_shaper.h
+++ b/libass/ass_shaper.h
@@ -25,7 +25,7 @@ typedef struct ass_shaper ASS_Shaper;
 #include "ass_render.h"
 
 void ass_shaper_info(ASS_Library *lib);
-ASS_Shaper *ass_shaper_new(size_t prealloc);
+ASS_Shaper *ass_shaper_new(void);
 void ass_shaper_free(ASS_Shaper *shaper);
 void ass_shaper_empty_cache(ASS_Shaper *shaper);
 void ass_shaper_set_kerning(ASS_Shaper *shaper, int kern);

--- a/libass/ass_shaper.h
+++ b/libass/ass_shaper.h
@@ -22,13 +22,14 @@
 typedef struct ass_shaper ASS_Shaper;
 
 #include <fribidi.h>
+#include <stdbool.h>
 #include "ass_render.h"
 
 void ass_shaper_info(ASS_Library *lib);
 ASS_Shaper *ass_shaper_new(void);
 void ass_shaper_free(ASS_Shaper *shaper);
 void ass_shaper_empty_cache(ASS_Shaper *shaper);
-void ass_shaper_set_kerning(ASS_Shaper *shaper, int kern);
+void ass_shaper_set_kerning(ASS_Shaper *shaper, bool kern);
 void ass_shaper_find_runs(ASS_Shaper *shaper, ASS_Renderer *render_priv,
                           GlyphInfo *glyphs, size_t len);
 void ass_shaper_set_base_direction(ASS_Shaper *shaper, FriBidiParType dir);

--- a/libass/ass_shaper.h
+++ b/libass/ass_shaper.h
@@ -25,6 +25,10 @@ typedef struct ass_shaper ASS_Shaper;
 #include <stdbool.h>
 #include "ass_render.h"
 
+#if FRIBIDI_MAJOR_VERSION >= 1
+#define USE_FRIBIDI_EX_API
+#endif
+
 void ass_shaper_info(ASS_Library *lib);
 ASS_Shaper *ass_shaper_new(void);
 void ass_shaper_free(ASS_Shaper *shaper);
@@ -35,6 +39,9 @@ void ass_shaper_find_runs(ASS_Shaper *shaper, ASS_Renderer *render_priv,
 void ass_shaper_set_base_direction(ASS_Shaper *shaper, FriBidiParType dir);
 void ass_shaper_set_language(ASS_Shaper *shaper, const char *code);
 void ass_shaper_set_level(ASS_Shaper *shaper, ASS_ShapingLevel level);
+#ifdef USE_FRIBIDI_EX_API
+void ass_shaper_set_bidi_brackets(ASS_Shaper *shaper, bool match_brackets);
+#endif
 int ass_shaper_shape(ASS_Shaper *shaper, TextInfo *text_info);
 void ass_shaper_cleanup(ASS_Shaper *shaper, TextInfo *text_info);
 FriBidiStrIndex *ass_shaper_reorder(ASS_Shaper *shaper, TextInfo *text_info);


### PR DESCRIPTION
As shown in #374, bracket matching (introduced in commit df7c00c95ec6e526bf85e6bc8296eaca66f5db8d of #298, but not yet part of any release) is incompatible with VSFilter (even on modern Windows).

As decided in #374, disable it by default. But as bracket matching is generally a good thing (and simply more standards-compliant), keep it available as an ASS_Feature that can be enabled for things like media player UIs.

The new feature can be toggled individually or enabled as part of the catch-all `ASS_FEATURE_INCOMPATIBLE_EXTENSIONS`. I’ve removed the placeholder `enable_extensions` flag and instead directly toggle the new feature’s underlying flag when the catch-all is toggled.

### Fallback

If libass is compiled against FriBidi older than 1.0, bracket matching is impossible. Signal this at runtime by failing to recognize the `ASS_FEATURE_BIDI_BRACKETS` feature. This way, clients who want to use bracket matching can set the feature without any compile-time checks for FriBidi and can be freely linked against libass that is itself compiled against any version of FriBidi; and yet they can detect at runtime whether the feature is actually enabled.

Bump `LIBASS_VERSION` so that the presence of `ASS_FEATURE_BIDI_BRACKETS` enum constant can be detected at compile-time. As per above, the enum constant is available at compile-time regardless of FriBidi version.

### Small conflicts

It’s nothing to worry about, but FYI, this conflicts with a commit from #399 that changes the signature of `ass_shaper_shape`.

### Naming of `ASS_ParserPriv`

The new field has nothing to do with the high-level ASS & Matroska packet parsing in ass.c that the rest of `ASS_ParserPriv` is used for. Or with any kind of ASS parsing for that matter. This disturbs me, but I’m (currently) making no attempt to solve this in this PR.