### PR TITLE
Allocation failure logging, error reporting

### DIFF
--- a/libass/Makefile.am
+++ b/libass/Makefile.am
@@ -31,7 +31,8 @@ libass_la_SOURCES = ass.h ass.c ass_types.h ass_utils.h ass_utils.c \
                     ass_parse.h ass_parse.c ass_priv.h ass_shaper.h ass_shaper.c \
                     ass_outline.h ass_outline.c ass_drawing.h ass_drawing.c \
                     ass_rasterizer.h ass_rasterizer.c ass_rasterizer_c.c \
-                    ass_bitmap.h ass_bitmap.c ass_blur.c ass_func_template.h
+                    ass_bitmap.h ass_bitmap.c ass_blur.c ass_func_template.h \
+                    ass_alloc.h ass_alloc.c
 
 libass_la_LDFLAGS = -no-undefined -version-info $(LIBASS_LT_CURRENT):$(LIBASS_LT_REVISION):$(LIBASS_LT_AGE)
 libass_la_LDFLAGS += -export-symbols $(srcdir)/libass.sym

--- a/libass/ass_alloc.c
+++ b/libass/ass_alloc.c
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2020 libass contributors
+ *
+ * This file is part of libass.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "config.h"
+#include "ass_compat.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "ass_alloc.h"
+#include "ass_utils.h"
+
+// strdup and strndup are only part of ISO C since C2x; libass only requires C99
+#ifndef HAVE_STRDUP
+char *ass_strdup_replacement(const char *str)
+{
+    size_t len    = strlen(s) + 1;
+    char *new_str = malloc(len);
+    if (new_str)
+        memcpy(new_str, str, len);
+    return new_str;
+}
+#define strdup ass_strdup_replacement
+#endif
+
+#ifndef HAVE_STRNDUP
+char *ass_strndup_replacement(const char *s, size_t n)
+{
+    char *end = memchr(s, 0, n);
+    size_t len = end ? end - s : n;
+    char *new = len < SIZE_MAX ? malloc(len + 1) : NULL;
+    if (new) {
+        memcpy(new, s, len);
+        new[len] = 0;
+    }
+    return new;
+}
+#define strndup ass_strndup_replacement
+#endif
+
+
+// Following macros expect fail_msg and lib to be defined and initialised
+#ifndef NDEBUG
+    #define ASS_ALLOC_TEST(ptr) \
+        if (!ptr) \
+            ass_msg(lib, MSGL_ERR, fail_msg)
+#else
+    #define ASS_ALLOC_TEST(ptr) do { } while (0)
+#endif
+
+#define ASS_RELAY_ALLOC(fun, ...)       \
+    void *new_ptr = (fun)(__VA_ARGS__); \
+    ASS_ALLOC_TEST(new_ptr);            \
+    return new_ptr
+
+void *ass_malloc_fun(const char *fail_msg, ASS_Library *lib,
+                     size_t size)
+{
+    ASS_RELAY_ALLOC(malloc, size);
+}
+
+void *ass_calloc_fun(const char *fail_msg, ASS_Library *lib,
+                     size_t n, size_t memb_s)
+{
+    ASS_RELAY_ALLOC(calloc, n, memb_s);
+}
+void *ass_realloc_fun(const char *fail_msg, ASS_Library *lib,
+                      void *prev, size_t new_size)
+{
+    ASS_RELAY_ALLOC(realloc, prev, new_size);
+}
+
+char *ass_strdup_fun(const char *fail_msg, ASS_Library *lib,
+                     const char *str)
+{
+    ASS_RELAY_ALLOC(strdup, str);
+}
+
+char *ass_strndup_fun(const char *fail_msg, ASS_Library *lib,
+                      const char *str, size_t size)
+{
+    ASS_RELAY_ALLOC(strndup, str, size);
+}
+
+void ass_free(void *ptr)
+{
+    free(ptr);
+}

--- a/libass/ass_alloc.h
+++ b/libass/ass_alloc.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2020 libass contributors
+ *
+ * This file is part of libass.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef LIBASS_ALLOC_H
+#define LIBASS_ALLOC_H
+
+#include "ass_types.h"
+
+void *ass_malloc_fun(const char *fail_msg, ASS_Library *lib, size_t size);
+void *ass_calloc_fun(const char *fail_msg, ASS_Library *lib, size_t nmemb, size_t smemb);
+void *ass_realloc_fun(const char *fail_msg, ASS_Library *lib, void *ptr, size_t new_size);
+char *ass_strdup_fun(const char *fail_msg, ASS_Library *lib, const char *str);
+char *ass_strndup_fun(const char *fail_msg, ASS_Library *lib, const char *str, size_t size);
+
+#define TO_STRING_(str) #str
+#define TO_STRING(str)  TO_STRING_(str)
+#define OOM_MESSAGE     "Allocation failed at " __FILE__ ":" TO_STRING(__LINE__)
+
+#define ASS_MALLOC(l, s)     ass_malloc_fun (OOM_MESSAGE, l, s)
+#define ASS_CALLOC(l, n, s)  ass_calloc_fun (OOM_MESSAGE, l, n, s)
+#define ASS_REALLOC(l, p, s) ass_realloc_fun(OOM_MESSAGE, l, p, s)
+#define ASS_STRDUP(l, s)     ass_strdup_fun (OOM_MESSAGE, l, s)
+#define ASS_STRNDUP(l, s, n) ass_strndup_fun(OOM_MESSAGE, l, s, n)
+
+void ass_free(void *ptr);
+
+#endif /* LIBASS_ALLOC_H */

--- a/libass/ass_utils.c
+++ b/libass/ass_utils.c
@@ -66,20 +66,6 @@ int has_avx2(void)
 
 #endif // ASM
 
-#ifndef HAVE_STRNDUP
-char *ass_strndup(const char *s, size_t n)
-{
-    char *end = memchr(s, 0, n);
-    size_t len = end ? end - s : n;
-    char *new = len < SIZE_MAX ? malloc(len + 1) : NULL;
-    if (new) {
-        memcpy(new, s, len);
-        new[len] = 0;
-    }
-    return new;
-}
-#endif
-
 void *ass_aligned_alloc(size_t alignment, size_t size, bool zero)
 {
     assert(!(alignment & (alignment - 1))); // alignment must be power of 2

--- a/libass/ass_utils.h
+++ b/libass/ass_utils.h
@@ -52,11 +52,6 @@ int has_avx(void);
 int has_avx2(void);
 #endif
 
-#ifndef HAVE_STRNDUP
-char *ass_strndup(const char *s, size_t n);
-#define strndup ass_strndup
-#endif
-
 void *ass_aligned_alloc(size_t alignment, size_t size, bool zero);
 void ass_aligned_free(void *ptr);
 


### PR DESCRIPTION
strdups can fail, but they are not always checked for failure in libass. This pr tries to change that.
To (hopefully) make review easier the strdup-commits are split into several with additional explanation in the commit message.

Also passing NULL as an `%s` to any printf function is undefined behaviour. gcc+glibc handles that forgiving in *most* instances, but this should not be relied upon.