### PR TITLE
Ignore leading space of lines in parsing

### DIFF
--- a/libass/ass.c
+++ b/libass/ass.c
@@ -940,6 +940,7 @@ static int process_fonts_line(ASS_Track *track, char *str)
 */
 static int process_line(ASS_Track *track, char *str)
 {
+    skip_spaces(&str);
     if (!ass_strncasecmp(str, "[Script Info]", 13)) {
         track->parser_priv->state = PST_INFO;
     } else if (!ass_strncasecmp(str, "[V4 Styles]", 11)) {


### PR DESCRIPTION
Being lenient about leading spaces will make invalid files as in #117 work with libass. As pointed out in #19 VSFilter is still far more lenient, but this patch improves it and would be neccessary for full compat anyway. fixes #117 

This was supposed to be a quick and easy fix.
However, while from libass' side this will make files as in #117 worrk, mpv will still refuse 117's sample file [(mpv-player/mpv/2846)](https://github.com/mpv-player/mpv/issues/2846) and with my synthetic test-file, mpv (or at least version 0.29.1-1 as packaged in Debian Buster) does some reordering that results in the first Dialogue line being not displayed (but parsed). This **does not** happen with `compare` or Aegisub, so it's not an libass issue.
*I can't test current git HEAD mpv right now, as it requires newer library version than I have easily available.*

Sample file:
```
﻿[Script Info]
ScriptType: v4.00+
WrapStyle: 0
 ScaledBorderAndShadow: yes
YCbCr Matrix: TV.709
PlayResX: 1920
PlayResY: 1080

 [V4+ Styles]
Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
Style: Oogaki,Rosario,72,&H00FFFFFF,&H000000FF,&H005C4143,&H00000000,-1,0,0,0,100,100,0,0,1,4.2,1.5,2,255,255,63,1
Style: Inuyama,Rosario,72,&H00FFFFFF,&HFF0000FF,&H001A6277,&H00000000,-1,0,0,0,100,100,0,0,1,4.2,1.5,2,255,255,63,1
Style: Kagamihara,Rosario,72,&H00FFFFFF,&HFF0000FF,&H00796D97,&H00000000,-1,0,0,0,100,100,0,0,1,4.2,1.5,2,255,255,63,1
Style: Type: Titel,Ubuntu Titling,82,&H008B7CEB,&H00CDB85F,&H004041C5,&H00000000,-1,0,0,0,100,100,5,0,1,0,0,5,10,10,10,1
Style: Type: Folgentitel,Ubuntu Titling,80,&H00FFFFFF,&H00FFFFFF,&H00FFFFFF,&H00000000,-1,0,0,0,100,100,0,0,1,1,0,5,10,10,10,1
Style: Type: Klubschild,Kalam,210,&H00000000,&H000000FF,&H00D0D0D0,&H00000000,-1,0,0,0,100,100,0,0,3,0,0,4,10,10,10,1


[Events]
Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
Dialogue: 0,0:00:00.00,0:00:01.76,Type: Titel,,0,0,0,,{\t(1460,1750,\fsp-49)}{\pos(960,350)}{\fade(0,0,255,0,1460,1490,1660)}ZI{\fscy0}MM{\fscy100}ER{\fscy0}C{\1a&HFF&\fscy130\fscx120\fnDejaVu Sans}▴{\fnUbuntu Titling\1a&H00&\fscy100\fscx100}MP
Dialogue: 0,0:00:00.00,0:00:01.76,Type: Titel,,0,0,0,,{\t(1460,1750,\fsp-49)}{\pos(960,350)\k200}{\k10}{\fade(0,0,255,0,1460,1586,1665)}{\fscy0}ZI{\fscy100}MM{\fscy0}ER{\fscy100}C{\1a&HFF&\fscy130\fscx120\fnDejaVu Sans}▴{\fnUbuntu Titling\fscx100}{\fscy0}MP
Dialogue: 0,0:00:00.00,0:00:01.76,Type: Titel,,0,0,0,,{\t(1460,1751,\fsp-49)}{\pos(960,350)\k200}{\k10}{\fscy0}ZIMMERC{\fscy100}{\fscy130\fscx120\fnDejaVu Sans}▴{\fnUbuntu Titling\fscx100}{\fscy0}MP
Dialogue: 0,0:00:01.87,0:00:03.48,Type: Folgentitel,,0,0,0,,{\pos(960,338.667)}Geschichte 1
Dialogue: 0,0:00:01.87,0:00:03.48,Type: Folgentitel,,0,0,0,,{\pos(960,733.333)}Rätsel der Thunfischdose
Dialogue: 0,0:00:05.48,0:00:07.24,Type: Klubschild,,0,0,0,,{\1c&HC9C9C9&\move(393,244,488,242,0,1735)}{\an7\move(393,244,460,284)\fscx100\fscy100\p1}m -48 -160 l -50 132 1035 524 1036 282
Dialogue: 1,0:00:05.48,0:00:07.24,Type: Klubschild,,0,0,0,,{\fry3}{\frz-21\move(393,244,488,242,0,1735)}Klub für Naturausflüge
Dialogue: 0,0:00:07.33,0:00:10.46,Kagamihara,Kagamihara,0,0,0,,Dieser Duft ...
Dialogue: 0,0:00:10.46,0:00:15.35,Kagamihara,Kagamihara,0,0,0,,macht einem doch direkt wieder Lust auf's Campen, nicht wahr?
 Dialogue: 0,0:00:16.76,0:00:19.91,Oogaki,Oogaki,0,0,0,,Brr, schon wieder voll kalt!
 Dialogue: 0,0:00:19.91,0:00:22.60,Inuyama,Inuyama,0,0,0,,Stell dich nicht so an …
 Dialogue: 0,0:00:22.91,0:00:24.95,Oogaki,Oogaki,0,0,0,,Jo, hast Recht
Dialogue: 0,0:00:25.12,0:00:28.05,Kagamihara,Kagamihara,0,0,0,,Ob hier sonst noch was rumliegt ?
Dialogue: 0,0:00:28.05,0:00:30.37,Kagamihara,Kagamihara,0,0,0,,Die Thunfischdosen sind immer noch da?
```