### PR TITLE
ass.h: Mark deprecated declarations as deprecated

### DIFF
--- a/libass/ass.h
+++ b/libass/ass.h
@@ -30,6 +30,22 @@
 extern "C" {
 #endif
 
+#if (defined(__GNUC__) && ((__GNUC__ > 3) || (__GNUC__ == 3 && __GNUC_MINOR__ >= 1))) || defined(__clang__)
+    #define ASS_DEPRECATED(msg) __attribute__((deprecated(msg)))
+    #if __GNUC__ > 5 || defined(__clang__)
+        #define ASS_DEPRECATED_ENUM(msg) __attribute__((deprecated(msg)))
+    #else
+        #define ASS_DEPRECATED_ENUM(msg)
+    #endif
+#elif defined(_MSC_VER)
+    #define ASS_DEPRECATED(msg) __declspec(deprecated(msg))
+    #define ASS_DEPRECATED_ENUM(msg)
+#else
+    #define ASS_DEPRECATED(msg)
+    #define ASS_DEPRECATED_ENUM(msg)
+#endif
+
+
 /*
  * A linked list of images produced by an ass renderer.
  *
@@ -129,7 +145,7 @@ typedef enum {
     /**
      * Old alias for ASS_OVERRIDE_BIT_SELECTIVE_FONT_SCALE. Deprecated. Do not use.
      */
-    ASS_OVERRIDE_BIT_FONT_SIZE = 1 << 1,
+    ASS_OVERRIDE_BIT_FONT_SIZE ASS_DEPRECATED_ENUM("replaced by ASS_OVERRIDE_BIT_SELECTIVE_FONT_SCALE") = 1 << 1,
     /**
      * On dialogue events override: FontSize, Spacing, Blur, ScaleX, ScaleY
      */
@@ -402,7 +418,7 @@ void ass_set_pixel_aspect(ASS_Renderer *priv, double par);
  * \param dar display aspect ratio (DAR), prescaled for output PAR
  * \param sar storage aspect ratio (SAR)
  */
-void ass_set_aspect_ratio(ASS_Renderer *priv, double dar, double sar);
+ASS_DEPRECATED("use 'ass_set_pixel_aspect' instead") void ass_set_aspect_ratio(ASS_Renderer *priv, double dar, double sar);
 
 /**
  * \brief Set a fixed font scaling factor.
@@ -501,7 +517,7 @@ void ass_set_selective_style_override(ASS_Renderer *priv, ASS_Style *style);
  * \param priv renderer handle
  * \return success
  */
-int ass_fonts_update(ASS_Renderer *priv);
+ASS_DEPRECATED("it does nothing") int ass_fonts_update(ASS_Renderer *priv);
 
 /**
  * \brief Set hard cache limits.  Do not set, or set to zero, for reasonable


### PR DESCRIPTION
Some of the API is declared to be deprecated in source comments, but this is easy to miss. Now GCC, Clang and MSVC should issue a warning when deprecated API is used.
 
---

Version checks for GCC are a bit messy. If supporting deprecation-warnings on versions older than GCC 6 is not important this can be simplified. *(For reference: 6.1 released 27.04.2016; Debian Jessie (oldoldstable) shipped 4.9.2, but LTS support ended a month ago)*  
Since I could not find out when clang gained support for the deprecation attribute (for enums), I'm assuming it will always be supported.  

Tested with clang7 and gcc8

**Not tested with MSVC**.
It'd be good, if someone with an MSVC compiler could verify that deprecation warnings are working. Otherwise I'd prefer to drop the untested MSVC part.
Here's a test file: [depr_test.c.txt](https://github.com/libass/libass/files/5077892/depr_test.c.txt)


