### PR TITLE
Line height fixes

### DIFF
--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -1566,7 +1566,7 @@ static void trim_whitespace(ASS_Renderer *render_priv)
     i = ti->length - 1;
     cur = ti->glyphs + i;
     while (i && IS_WHITESPACE(cur)) {
-        cur->skip++;
+        cur->skip = true;
         cur = ti->glyphs + --i;
     }
 
@@ -1574,7 +1574,7 @@ static void trim_whitespace(ASS_Renderer *render_priv)
     i = 0;
     cur = ti->glyphs;
     while (i < ti->length && IS_WHITESPACE(cur)) {
-        cur->skip++;
+        cur->skip = true;
         cur = ti->glyphs + ++i;
     }
 
@@ -1586,18 +1586,18 @@ static void trim_whitespace(ASS_Renderer *render_priv)
             j = i - 1;
             cur = ti->glyphs + j;
             while (j && IS_WHITESPACE(cur)) {
-                cur->skip++;
+                cur->skip = true;
                 cur = ti->glyphs + --j;
             }
             // A break itself can contain a whitespace, too
             cur = ti->glyphs + i;
             if (cur->symbol == ' ' || cur->symbol == '\n') {
-                cur->skip++;
+                cur->skip = true;
                 // Mark whitespace after
                 j = i + 1;
                 cur = ti->glyphs + j;
                 while (j < ti->length && IS_WHITESPACE(cur)) {
-                    cur->skip++;
+                    cur->skip = true;
                     cur = ti->glyphs + ++j;
                 }
                 i = j - 1;

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -1540,7 +1540,7 @@ static void measure_text(ASS_Renderer *render_priv)
         max_desc = FFMAX(max_desc, cur->desc);
         max_border_y = FFMAX(max_border_y, cur->border_y);
         max_border_x = FFMAX(max_border_x, cur->border_x);
-        if (cur->symbol != '\n' && cur->symbol != 0)
+        if (cur->symbol != '\n')
             scale = 1.0 / 64;
     }
     assert(cur_line == text_info->n_lines - 1);

--- a/libass/ass_render.h
+++ b/libass/ass_render.h
@@ -21,6 +21,7 @@
 #define LIBASS_RENDER_H
 
 #include <inttypes.h>
+#include <stdbool.h>
 #include <ft2build.h>
 #include FT_FREETYPE_H
 #include FT_GLYPH_H
@@ -122,7 +123,7 @@ typedef struct {
 // GlyphInfo and TextInfo are used for text centering and word-wrapping operations
 typedef struct glyph_info {
     unsigned symbol;
-    unsigned skip;              // skip glyph when layouting text
+    bool skip;                  // skip glyph when layouting text
     ASS_Font *font;
     int face_index;
     int glyph_index;

--- a/libass/ass_render.h
+++ b/libass/ass_render.h
@@ -124,6 +124,7 @@ typedef struct {
 typedef struct glyph_info {
     unsigned symbol;
     bool skip;                  // skip glyph when layouting text
+    bool is_trimmed_whitespace;
     ASS_Font *font;
     int face_index;
     int glyph_index;

--- a/libass/ass_shaper.c
+++ b/libass/ass_shaper.c
@@ -878,7 +878,11 @@ static void ass_shaper_skip_characters(TextInfo *text_info)
         // Skip direction override control characters
         if ((glyphs[i].symbol <= 0x202e && glyphs[i].symbol >= 0x202a)
                 || (glyphs[i].symbol <= 0x200f && glyphs[i].symbol >= 0x200b)
-                || (glyphs[i].symbol <= 0x2063 && glyphs[i].symbol >= 0x2060)
+                || (glyphs[i].symbol <= 0x206f && glyphs[i].symbol >= 0x2060)
+                || (glyphs[i].symbol <= 0xfe0f && glyphs[i].symbol >= 0xfe00)
+                || (glyphs[i].symbol <= 0xe01ef && glyphs[i].symbol >= 0xe0100)
+                || (glyphs[i].symbol <= 0x180f && glyphs[i].symbol >= 0x180b)
+                || glyphs[i].symbol == 0x061c
                 || glyphs[i].symbol == 0xfeff
                 || glyphs[i].symbol == 0x00ad
                 || glyphs[i].symbol == 0x034f) {

--- a/libass/ass_shaper.c
+++ b/libass/ass_shaper.c
@@ -595,7 +595,7 @@ shape_harfbuzz_process_run(GlyphInfo *glyphs, hb_buffer_t *buf, int offset)
 
         // if we have more than one glyph per cluster, allocate a new one
         // and attach to the root glyph
-        if (info->skip == 0) {
+        if (!info->skip) {
             while (info->next)
                 info = info->next;
             info->next = malloc(sizeof(GlyphInfo));
@@ -608,7 +608,7 @@ shape_harfbuzz_process_run(GlyphInfo *glyphs, hb_buffer_t *buf, int offset)
         }
 
         // set position and advance
-        info->skip = 0;
+        info->skip = false;
         info->glyph_index = glyph_info[j].codepoint;
         info->offset.x    = pos[j].x_offset * info->scale_x;
         info->offset.y    = -pos[j].y_offset * info->scale_y;
@@ -634,7 +634,7 @@ static void shape_harfbuzz(ASS_Shaper *shaper, GlyphInfo *glyphs, size_t len)
 
     // Initialize: skip all glyphs, this is undone later as needed
     for (i = 0; i < len; i++)
-        glyphs[i].skip = 1;
+        glyphs[i].skip = true;
 
     for (i = 0; i < len; i++) {
         int offset = i;
@@ -883,7 +883,7 @@ static void ass_shaper_skip_characters(TextInfo *text_info)
                 || glyphs[i].symbol == 0x00ad
                 || glyphs[i].symbol == 0x034f) {
             glyphs[i].symbol = 0;
-            glyphs[i].skip++;
+            glyphs[i].skip = true;
         }
     }
 }


### PR DESCRIPTION
This isn’t perfect: VSFilter knows nothing about “skippable”/invisible characters. It works with opaque UTF-16 code units and treats specially only U+0020 SPACE and line breaks. A line height gets halved if the line contains no code units between two line breaks. So our whole `skip` business should not apply to line height calculations. But of course, we use `skip` during shaping and we use shaping during line wrapping… So this is a bit complicated.

This works well as an approximation though.