### PR TITLE
Fix overflows in outline processing

### DIFF
--- a/libass/ass_outline.h
+++ b/libass/ass_outline.h
@@ -83,8 +83,9 @@ typedef struct {
     char *segments;
 } ASS_Outline;
 
-#define OUTLINE_MIN  (-((int32_t) 1 << 28))
+// ouline point coordinates should always be in [-OUTLINE_MAX, +OUTLINE_MAX] range
 #define OUTLINE_MAX  (((int32_t) 1 << 28) - 1)
+// cubic spline splitting requires 8 * OUTLINE_MAX + 4 <= INT32_MAX
 
 bool outline_alloc(ASS_Outline *outline, size_t n_points, size_t n_segments);
 bool outline_convert(ASS_Outline *outline, const FT_Outline *source);

--- a/libass/ass_rasterizer.c
+++ b/libass/ass_rasterizer.c
@@ -269,12 +269,10 @@ bool rasterizer_set_outline(RasterizerData *rst,
     }
     rst->size[0] = rst->n_first;
 
-    for (size_t i = 0; i < path->n_points; i++) {
-        if (path->points[i].x < OUTLINE_MIN || path->points[i].x > OUTLINE_MAX)
-            return false;
-        if (path->points[i].y < OUTLINE_MIN || path->points[i].y > OUTLINE_MAX)
-            return false;
-    }
+#ifndef NDEBUG
+    for (size_t i = 0; i < path->n_points; i++)
+        assert(abs(path->points[i].x) <= OUTLINE_MAX && abs(path->points[i].y) <= OUTLINE_MAX);
+#endif
 
     ASS_Vector *start = path->points, *cur = start;
     for (size_t i = 0; i < path->n_segments; i++) {

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -1438,8 +1438,12 @@ get_bitmap_glyph(ASS_Renderer *render_priv, GlyphInfo *info,
         w *= STROKER_PRECISION / POSITION_PRECISION;
         frexp(w * (FFMAX(mxx, myx) + mzx * rz), &k->scale_ord_x);
         frexp(w * (FFMAX(mxy, myy) + mzy * rz), &k->scale_ord_y);
-        k->border.x = lrint(ldexp(bord_x, k->scale_ord_x) / STROKER_PRECISION);
-        k->border.y = lrint(ldexp(bord_y, k->scale_ord_y) / STROKER_PRECISION);
+        bord_x = ldexp(bord_x, k->scale_ord_x);
+        bord_y = ldexp(bord_y, k->scale_ord_y);
+        if (!(bord_x < OUTLINE_MAX && bord_y < OUTLINE_MAX))
+            return;
+        k->border.x = lrint(bord_x / STROKER_PRECISION);
+        k->border.y = lrint(bord_y / STROKER_PRECISION);
         if (!k->border.x && !k->border.y) {
             ass_cache_inc_ref(info->bm);
             info->bm_o = info->bm;


### PR DESCRIPTION
I've added a couple of checks for overflows in outline pipeline. Should fix #431, but I'm not familiar with that fuzzing business so I can't ascertain it for now.