### PR TITLE
Fix Banner/Scroll effects & simplify clip coordinate conversion

### DIFF
--- a/libass/ass_parse.c
+++ b/libass/ass_parse.c
@@ -908,6 +908,7 @@ void apply_transition_effects(ASS_Renderer *render_priv, ASS_Event *event)
         render_priv->state.scroll_shift =
             (render_priv->time - render_priv->state.event->Start) / delay;
         render_priv->state.evt_type |= EVENT_HSCROLL;
+        render_priv->state.detect_collisions = 0;
         render_priv->state.wrap_style = 2;
         return;
     }

--- a/libass/ass_parse.c
+++ b/libass/ass_parse.c
@@ -480,11 +480,11 @@ char *parse_tags(ASS_Renderer *render_priv, char *p, char *end, double pwr,
                 k = ((double) (int32_t) ((uint32_t) t - t1)) / delta_t;
             x = k * (x2 - x1) + x1;
             y = k * (y2 - y1) + y1;
-            if (render_priv->state.evt_type != EVENT_POSITIONED) {
+            if (!(render_priv->state.evt_type & EVENT_POSITIONED)) {
                 render_priv->state.pos_x = x;
                 render_priv->state.pos_y = y;
                 render_priv->state.detect_collisions = 0;
-                render_priv->state.evt_type = EVENT_POSITIONED;
+                render_priv->state.evt_type |= EVENT_POSITIONED;
             }
         } else if (tag("frx")) {
             double val;
@@ -571,11 +571,11 @@ char *parse_tags(ASS_Renderer *render_priv, char *p, char *end, double pwr,
                 v2 = argtod(args[1]);
             } else
                 continue;
-            if (render_priv->state.evt_type == EVENT_POSITIONED) {
+            if (render_priv->state.evt_type & EVENT_POSITIONED) {
                 ass_msg(render_priv->library, MSGL_V, "Subtitle has a new \\pos "
                        "after \\move or \\pos, ignoring");
             } else {
-                render_priv->state.evt_type = EVENT_POSITIONED;
+                render_priv->state.evt_type |= EVENT_POSITIONED;
                 render_priv->state.detect_collisions = 0;
                 render_priv->state.pos_x = v1;
                 render_priv->state.pos_y = v2;
@@ -907,7 +907,7 @@ void apply_transition_effects(ASS_Renderer *render_priv, ASS_Event *event)
             delay = 1;          // ?
         render_priv->state.scroll_shift =
             (render_priv->time - render_priv->state.event->Start) / delay;
-        render_priv->state.evt_type = EVENT_HSCROLL;
+        render_priv->state.evt_type |= EVENT_HSCROLL;
         render_priv->state.wrap_style = 2;
         return;
     }
@@ -946,7 +946,7 @@ void apply_transition_effects(ASS_Renderer *render_priv, ASS_Event *event)
             y1 = render_priv->track->PlayResY;  // y0=y1=0 means fullscreen scrolling
         render_priv->state.clip_y0 = y0;
         render_priv->state.clip_y1 = y1;
-        render_priv->state.evt_type = EVENT_VSCROLL;
+        render_priv->state.evt_type |= EVENT_VSCROLL;
         render_priv->state.detect_collisions = 0;
     }
 

--- a/libass/ass_parse.c
+++ b/libass/ass_parse.c
@@ -908,6 +908,7 @@ void apply_transition_effects(ASS_Renderer *render_priv, ASS_Event *event)
         render_priv->state.scroll_shift =
             (render_priv->time - render_priv->state.event->Start) / delay;
         render_priv->state.evt_type = EVENT_HSCROLL;
+        render_priv->state.wrap_style = 2;
         return;
     }
 

--- a/libass/ass_parse.c
+++ b/libass/ass_parse.c
@@ -943,8 +943,8 @@ void apply_transition_effects(ASS_Renderer *render_priv, ASS_Event *event)
             y0 = v[1];
             y1 = v[0];
         }
-        render_priv->state.clip_y0 = y0;
-        render_priv->state.clip_y1 = y1;
+        render_priv->state.scroll_y0 = y0;
+        render_priv->state.scroll_y1 = y1;
         render_priv->state.evt_type |= EVENT_VSCROLL;
         render_priv->state.detect_collisions = 0;
     }

--- a/libass/ass_parse.c
+++ b/libass/ass_parse.c
@@ -897,10 +897,10 @@ void apply_transition_effects(ASS_Renderer *render_priv, ASS_Event *event)
                     "Error parsing effect: '%s'", event->Effect);
             return;
         }
-        if (cnt >= 2 && v[1] == 0)      // right-to-left
-            render_priv->state.scroll_direction = SCROLL_RL;
-        else                    // left-to-right
+        if (cnt >= 2 && v[1])   // left-to-right
             render_priv->state.scroll_direction = SCROLL_LR;
+        else                    // right-to-left
+            render_priv->state.scroll_direction = SCROLL_RL;
 
         delay = v[0];
         if (delay == 0)

--- a/libass/ass_parse.c
+++ b/libass/ass_parse.c
@@ -942,8 +942,6 @@ void apply_transition_effects(ASS_Renderer *render_priv, ASS_Event *event)
             y0 = v[1];
             y1 = v[0];
         }
-        if (y1 == 0)
-            y1 = render_priv->track->PlayResY;  // y0=y1=0 means fullscreen scrolling
         render_priv->state.clip_y0 = y0;
         render_priv->state.clip_y1 = y1;
         render_priv->state.evt_type |= EVENT_VSCROLL;

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -2687,13 +2687,13 @@ ass_render_event(ASS_Renderer *render_priv, ASS_Event *event,
         if (render_priv->state.scroll_direction == SCROLL_TB)
             device_y =
                 y2scr(render_priv,
-                      render_priv->state.clip_y0 +
+                      render_priv->state.scroll_y0 +
                       render_priv->state.scroll_shift) -
                 bbox.y_max;
         else if (render_priv->state.scroll_direction == SCROLL_BT)
             device_y =
                 y2scr(render_priv,
-                      render_priv->state.clip_y1 -
+                      render_priv->state.scroll_y1 -
                       render_priv->state.scroll_shift) -
                 bbox.y_min;
     } else if (!(render_priv->state.evt_type & EVENT_POSITIONED)) {
@@ -2758,6 +2758,14 @@ ass_render_event(ASS_Renderer *render_priv, ASS_Event *event,
         render_priv->state.clip_y0 = 0;
         render_priv->state.clip_x1 = render_priv->settings.frame_width;
         render_priv->state.clip_y1 = render_priv->settings.frame_height;
+    }
+
+    if (render_priv->state.evt_type & EVENT_VSCROLL) {
+        double y0 = y2scr_pos(render_priv, render_priv->state.scroll_y0);
+        double y1 = y2scr_pos(render_priv, render_priv->state.scroll_y1);
+
+        render_priv->state.clip_y0 = FFMAX(render_priv->state.clip_y0, y0);
+        render_priv->state.clip_y1 = FFMIN(render_priv->state.clip_y1, y1);
     }
 
     calculate_rotation_params(render_priv, &bbox, device_x, device_y);

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -2130,8 +2130,10 @@ static void align_lines(ASS_Renderer *render_priv, double max_text_width)
     int justify = render_priv->state.justify;
     double max_width = 0;
 
-    if (render_priv->state.evt_type == EVENT_HSCROLL)
-        return;
+    if (render_priv->state.evt_type == EVENT_HSCROLL) {
+        justify = halign;
+        halign = HALIGN_LEFT;
+    }
 
     for (i = 0; i <= text_info->length; ++i) {   // (text_info->length + 1) is the end of the last line
         if ((i == text_info->length) || glyphs[i].linebreak) {
@@ -2639,16 +2641,7 @@ ass_render_event(ASS_Renderer *render_priv, ASS_Event *event,
         x2scr_left(render_priv, MarginL);
 
     // wrap lines
-    if (render_priv->state.evt_type != EVENT_HSCROLL) {
-        // rearrange text in several lines
-        wrap_lines_smart(render_priv, max_text_width);
-    } else {
-        // no breaking or wrapping, everything in a single line
-        text_info->lines[0].offset = 0;
-        text_info->lines[0].len = text_info->length;
-        text_info->n_lines = 1;
-        measure_text(render_priv);
-    }
+    wrap_lines_smart(render_priv, max_text_width);
 
     reorder_text(render_priv);
 

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -2689,12 +2689,13 @@ ass_render_event(ASS_Renderer *render_priv, ASS_Event *event,
                 y2scr(render_priv,
                       render_priv->state.clip_y0 +
                       render_priv->state.scroll_shift) -
-                (bbox.y_max - bbox.y_min);
+                bbox.y_max;
         else if (render_priv->state.scroll_direction == SCROLL_BT)
             device_y =
                 y2scr(render_priv,
                       render_priv->state.clip_y1 -
-                      render_priv->state.scroll_shift);
+                      render_priv->state.scroll_shift) -
+                bbox.y_min;
     } else if (!(render_priv->state.evt_type & EVENT_POSITIONED)) {
         if (valign == VALIGN_TOP) {     // toptitle
             device_y =

--- a/libass/ass_render.h
+++ b/libass/ass_render.h
@@ -261,6 +261,7 @@ typedef struct {
         SCROLL_BT
     } scroll_direction;         // for EVENT_HSCROLL, EVENT_VSCROLL
     int scroll_shift;
+    int scroll_y0, scroll_y1;
 
     // face properties
     char *family;

--- a/libass/ass_render.h
+++ b/libass/ass_render.h
@@ -224,10 +224,10 @@ typedef struct {
     double border_x;            // outline width
     double border_y;
     enum {
-        EVENT_NORMAL,           // "normal" top-, sub- or mid- title
-        EVENT_POSITIONED,       // happens after pos(,), margins are ignored
-        EVENT_HSCROLL,          // "Banner" transition effect, text_width is unlimited
-        EVENT_VSCROLL           // "Scroll up", "Scroll down" transition effects
+        EVENT_NORMAL = 0,       // "normal" top-, sub- or mid- title
+        EVENT_POSITIONED = 1,   // happens after \pos or \move, margins are ignored
+        EVENT_HSCROLL = 2,      // "Banner" transition effect, text_width is unlimited
+        EVENT_VSCROLL = 4       // "Scroll up", "Scroll down" transition effects
     } evt_type;
     int border_style;
     uint32_t c[4];              // colors(Primary, Secondary, so on) in RGBA


### PR DESCRIPTION
Both in one PR because the “Support Banner/Scroll effects with \pos/\move” patch assumes the clip coordinate conversion patch has been applied first.

Labelling this “cosmetic” for the clip coordinate patch; “compatibility” for all the rest.

All banner/scroll changes have been tested and verified in practice against xy-VSFilter and MPC-HC.