### PR TITLE
Karaoke fixes & improvements

### DIFF
--- a/libass/ass_outline.c
+++ b/libass/ass_outline.c
@@ -323,6 +323,20 @@ bool outline_transform_3d(ASS_Outline *outline, const ASS_Outline *source,
     return true;
 }
 
+void outline_update_min_transformed_x(const ASS_Outline *outline,
+                                      const double m[3][3],
+                                      int32_t *min_x) {
+    const ASS_Vector *pt = outline->points;
+    for (size_t i = 0; i < outline->n_points; i++) {
+        double z = m[2][0] * pt[i].x + m[2][1] * pt[i].y + m[2][2];
+        double x = (m[0][0] * pt[i].x + m[0][1] * pt[i].y + m[0][2]) / FFMAX(z, 0.1);
+        if (isnan(x))
+            continue;
+        int32_t ix = lrint(FFMINMAX(x, -OUTLINE_MAX, OUTLINE_MAX));
+        *min_x = FFMIN(*min_x, ix);
+    }
+}
+
 
 void outline_free(ASS_Outline *outline)
 {

--- a/libass/ass_outline.h
+++ b/libass/ass_outline.h
@@ -95,6 +95,9 @@ bool outline_transform_2d(ASS_Outline *outline, const ASS_Outline *source,
                           const double m[2][3]);
 bool outline_transform_3d(ASS_Outline *outline, const ASS_Outline *source,
                           const double m[3][3]);
+void outline_update_min_transformed_x(const ASS_Outline *outline,
+                                      const double m[3][3],
+                                      int32_t *min_x);
 void outline_free(ASS_Outline *outline);
 
 bool outline_add_point(ASS_Outline *outline, ASS_Vector pt, char segment);

--- a/libass/ass_parse.c
+++ b/libass/ass_parse.c
@@ -495,7 +495,6 @@ char *parse_tags(ASS_Renderer *render_priv, char *p, char *end, double pwr,
             double val;
             if (nargs) {
                 val = argtod(*args);
-                val *= M_PI / 180;
                 render_priv->state.frx =
                     val * pwr + render_priv->state.frx * (1 - pwr);
             } else
@@ -504,7 +503,6 @@ char *parse_tags(ASS_Renderer *render_priv, char *p, char *end, double pwr,
             double val;
             if (nargs) {
                 val = argtod(*args);
-                val *= M_PI / 180;
                 render_priv->state.fry =
                     val * pwr + render_priv->state.fry * (1 - pwr);
             } else
@@ -513,12 +511,11 @@ char *parse_tags(ASS_Renderer *render_priv, char *p, char *end, double pwr,
             double val;
             if (nargs) {
                 val = argtod(*args);
-                val *= M_PI / 180;
                 render_priv->state.frz =
                     val * pwr + render_priv->state.frz * (1 - pwr);
             } else
                 render_priv->state.frz =
-                    M_PI * render_priv->state.style->Angle / 180.;
+                    render_priv->state.style->Angle;
         } else if (tag("fn")) {
             char *family;
             char *start = args->start;

--- a/libass/ass_parse.c
+++ b/libass/ass_parse.c
@@ -972,59 +972,47 @@ void apply_transition_effects(ASS_Renderer *render_priv, ASS_Event *event)
  */
 void process_karaoke_effects(ASS_Renderer *render_priv)
 {
-    GlyphInfo *cur, *cur2;
-    GlyphInfo *s1, *e1;      // start and end of the current word
-    GlyphInfo *s2;           // start of the next word
-    int i;
-    int timing;                 // current timing
-    int tm_start, tm_end;       // timings at start and end of the current word
-    int tm_current;
-    double dt;
-    int x;
-    int x_start, x_end;
+    int tm_current = render_priv->time - render_priv->state.event->Start;
 
-    tm_current = render_priv->time - render_priv->state.event->Start;
-    timing = 0;
-    s1 = s2 = 0;
-    for (i = 0; i <= render_priv->text_info.length; ++i) {
-        cur = render_priv->text_info.glyphs + i;
-        if ((i == render_priv->text_info.length)
-            || (cur->effect_type != EF_NONE)) {
-            s1 = s2;
-            s2 = cur;
-            if (s1) {
-                e1 = s2 - 1;
-                tm_start = timing + s1->effect_skip_timing;
-                tm_end = tm_start + s1->effect_timing;
-                timing = tm_end;
-                x_start = 1000000;
-                x_end = -1000000;
-                for (cur2 = s1; cur2 <= e1; ++cur2) {
-                    x_start = FFMIN(x_start, d6_to_int(cur2->bbox.x_min + cur2->pos.x));
-                    x_end = FFMAX(x_end, d6_to_int(cur2->bbox.x_max + cur2->pos.x));
-                }
+    int timing = 0;
+    GlyphInfo *last_boundary = NULL;
+    for (int i = 0; i <= render_priv->text_info.length; i++) {
+        if (i < render_priv->text_info.length &&
+            render_priv->text_info.glyphs[i].effect_type == EF_NONE)
+            continue;
 
-                dt = (tm_current - tm_start);
-                if ((s1->effect_type == EF_KARAOKE)
-                    || (s1->effect_type == EF_KARAOKE_KO)) {
-                    if (dt >= 0)
-                        x = x_end + 1;
-                    else
-                        x = x_start;
-                } else if (s1->effect_type == EF_KARAOKE_KF) {
-                    dt /= (tm_end - tm_start);
-                    x = x_start + (x_end - x_start) * dt;
-                } else {
-                    ass_msg(render_priv->library, MSGL_ERR,
-                            "Unknown effect type");
-                    continue;
-                }
+        GlyphInfo *start = last_boundary;
+        GlyphInfo *end = render_priv->text_info.glyphs + i;
+        last_boundary = end;
+        if (!start)
+            continue;
 
-                for (cur2 = s1; cur2 <= e1; ++cur2) {
-                    cur2->effect_type = s1->effect_type;
-                    cur2->effect_timing = x - d6_to_int(cur2->pos.x);
-                }
-            }
+        int tm_start = timing + start->effect_skip_timing;
+        int tm_end = tm_start + start->effect_timing;
+        timing = tm_end;
+
+        int x_start = 1000000;
+        int x_end = -1000000;
+        for (GlyphInfo *info = start; info < end; info++) {
+            x_start = FFMIN(x_start, d6_to_int(info->bbox.x_min + info->pos.x));
+            x_end = FFMAX(x_end, d6_to_int(info->bbox.x_max + info->pos.x));
+        }
+
+        int x;
+        if (start->effect_type == EF_KARAOKE || start->effect_type == EF_KARAOKE_KO) {
+            x = tm_current < tm_start ? x_start : x_end + 1;
+        } else if (start->effect_type == EF_KARAOKE_KF) {
+            double dt = (double) (tm_current - tm_start) / (tm_end - tm_start);
+            x = x_start + (x_end - x_start) * dt;
+        } else {
+            ass_msg(render_priv->library, MSGL_ERR,
+                    "Unknown effect type");
+            continue;
+        }
+
+        for (GlyphInfo *info = start; info < end; info++) {
+            info->effect_type = start->effect_type;
+            info->effect_timing = x - d6_to_int(info->pos.x);
         }
     }
 }

--- a/libass/ass_parse.c
+++ b/libass/ass_parse.c
@@ -1006,12 +1006,12 @@ void process_karaoke_effects(ASS_Renderer *render_priv)
 
         int x;
         if (tm_current < tm_start)
-            x = -1000000;
+            x = -100000000;
         else if (tm_current >= tm_end)
-            x = 1000000;
+            x = 100000000;
         else {
-            int x_start = d6_to_int(start->pos.x);
-            int x_end = d6_to_int(end[-1].pos.x + end[-1].advance.x);
+            int x_start = start->pos.x;
+            int x_end = end[-1].pos.x + end[-1].advance.x;
             double dt = (double) (tm_current - tm_start) / (tm_end - tm_start);
             double frz = fmod(start->frz, 360);
             if (frz > 90 && frz < 270) {
@@ -1023,12 +1023,12 @@ void process_karaoke_effects(ASS_Renderer *render_priv)
                     info->c[1] = tmp;
                 }
             }
-            x = x_start + (x_end - x_start) * dt;
+            x = x_start + lrint((x_end - x_start) * dt);
         }
 
         for (GlyphInfo *info = start; info < end; info++) {
             info->effect_type = effect_type;
-            info->effect_timing = x - d6_to_int(info->pos.x);
+            info->effect_timing = x - info->pos.x;
         }
     }
 }

--- a/libass/ass_parse.c
+++ b/libass/ass_parse.c
@@ -997,22 +997,21 @@ void process_karaoke_effects(ASS_Renderer *render_priv)
         int tm_end = tm_start + start->effect_timing;
         timing = tm_end;
 
-        int x_start = 1000000;
-        int x_end = -1000000;
-        for (GlyphInfo *info = start; info < end; info++) {
-            x_start = FFMIN(x_start, d6_to_int(info->bbox.x_min + info->pos.x));
-            x_end = FFMAX(x_end, d6_to_int(info->bbox.x_max + info->pos.x));
-        }
-
         if (effect_type != EF_KARAOKE_KF)
             tm_end = tm_start;
 
         int x;
         if (tm_current < tm_start)
-            x = x_start;
+            x = -1000000;
         else if (tm_current >= tm_end)
-            x = x_end + 1;
+            x = 1000000;
         else {
+            int x_start = 1000000;
+            int x_end = -1000000;
+            for (GlyphInfo *info = start; info < end; info++) {
+                x_start = FFMIN(x_start, d6_to_int(info->bbox.x_min + info->pos.x));
+                x_end = FFMAX(x_end, d6_to_int(info->bbox.x_max + info->pos.x));
+            }
             double dt = (double) (tm_current - tm_start) / (tm_end - tm_start);
             x = x_start + (x_end - x_start) * dt;
         }

--- a/libass/ass_parse.c
+++ b/libass/ass_parse.c
@@ -1006,12 +1006,8 @@ void process_karaoke_effects(ASS_Renderer *render_priv)
         else if (tm_current >= tm_end)
             x = 1000000;
         else {
-            int x_start = 1000000;
-            int x_end = -1000000;
-            for (GlyphInfo *info = start; info < end; info++) {
-                x_start = FFMIN(x_start, d6_to_int(info->bbox.x_min + info->pos.x));
-                x_end = FFMAX(x_end, d6_to_int(info->bbox.x_max + info->pos.x));
-            }
+            int x_start = d6_to_int(start->pos.x);
+            int x_end = d6_to_int(end[-1].pos.x + end[-1].advance.x);
             double dt = (double) (tm_current - tm_start) / (tm_end - tm_start);
             x = x_start + (x_end - x_start) * dt;
         }

--- a/libass/ass_parse.c
+++ b/libass/ass_parse.c
@@ -1004,22 +1004,17 @@ void process_karaoke_effects(ASS_Renderer *render_priv)
             x_end = FFMAX(x_end, d6_to_int(info->bbox.x_max + info->pos.x));
         }
 
+        if (effect_type != EF_KARAOKE_KF)
+            tm_end = tm_start;
+
         int x;
-        if (effect_type == EF_KARAOKE || effect_type == EF_KARAOKE_KO) {
-            x = tm_current < tm_start ? x_start : x_end + 1;
-        } else if (effect_type == EF_KARAOKE_KF) {
-            if (tm_current < tm_start)
-                x = x_start;
-            else if (tm_current >= tm_end)
-                x = x_end + 1;
-            else {
-                double dt = (double) (tm_current - tm_start) / (tm_end - tm_start);
-                x = x_start + (x_end - x_start) * dt;
-            }
-        } else {
-            ass_msg(render_priv->library, MSGL_ERR,
-                    "Unknown effect type");
-            continue;
+        if (tm_current < tm_start)
+            x = x_start;
+        else if (tm_current >= tm_end)
+            x = x_end + 1;
+        else {
+            double dt = (double) (tm_current - tm_start) / (tm_end - tm_start);
+            x = x_start + (x_end - x_start) * dt;
         }
 
         for (GlyphInfo *info = start; info < end; info++) {

--- a/libass/ass_parse.c
+++ b/libass/ass_parse.c
@@ -1013,6 +1013,16 @@ void process_karaoke_effects(ASS_Renderer *render_priv)
             int x_start = d6_to_int(start->pos.x);
             int x_end = d6_to_int(end[-1].pos.x + end[-1].advance.x);
             double dt = (double) (tm_current - tm_start) / (tm_end - tm_start);
+            double frz = fmod(start->frz, 360);
+            if (frz > 90 && frz < 270) {
+                // Fill from right to left
+                dt = 1 - dt;
+                for (GlyphInfo *info = start; info < end; info++) {
+                    uint32_t tmp = info->c[0];
+                    info->c[0] = info->c[1];
+                    info->c[1] = tmp;
+                }
+            }
             x = x_start + (x_end - x_start) * dt;
         }
 

--- a/libass/ass_parse.c
+++ b/libass/ass_parse.c
@@ -972,7 +972,7 @@ void apply_transition_effects(ASS_Renderer *render_priv, ASS_Event *event)
  */
 void process_karaoke_effects(ASS_Renderer *render_priv)
 {
-    int tm_current = render_priv->time - render_priv->state.event->Start;
+    long long tm_current = render_priv->time - render_priv->state.event->Start;
 
     int timing = 0;
     Effect effect_type = EF_NONE;
@@ -993,8 +993,8 @@ void process_karaoke_effects(ASS_Renderer *render_priv)
         if (effect_type == EF_NONE)
             continue;
 
-        int tm_start = timing + start->effect_skip_timing;
-        int tm_end = tm_start + start->effect_timing;
+        long long tm_start = timing + start->effect_skip_timing;
+        long long tm_end = tm_start + start->effect_timing;
         timing = tm_end;
 
         if (effect_type != EF_KARAOKE_KF)

--- a/libass/ass_parse.c
+++ b/libass/ass_parse.c
@@ -1008,8 +1008,14 @@ void process_karaoke_effects(ASS_Renderer *render_priv)
         if (effect_type == EF_KARAOKE || effect_type == EF_KARAOKE_KO) {
             x = tm_current < tm_start ? x_start : x_end + 1;
         } else if (effect_type == EF_KARAOKE_KF) {
-            double dt = (double) (tm_current - tm_start) / (tm_end - tm_start);
-            x = x_start + (x_end - x_start) * dt;
+            if (tm_current < tm_start)
+                x = x_start;
+            else if (tm_current >= tm_end)
+                x = x_end + 1;
+            else {
+                double dt = (double) (tm_current - tm_start) / (tm_end - tm_start);
+                x = x_start + (x_end - x_start) * dt;
+            }
         } else {
             ass_msg(render_priv->library, MSGL_ERR,
                     "Unknown effect type");

--- a/libass/ass_parse.c
+++ b/libass/ass_parse.c
@@ -1010,8 +1010,14 @@ void process_karaoke_effects(ASS_Renderer *render_priv)
         else if (tm_current >= tm_end)
             x = 100000000;
         else {
-            int x_start = start->pos.x;
-            int x_end = end[-1].pos.x + end[-1].advance.x;
+            GlyphInfo *first_visible = start, *last_visible = end - 1;
+            while (first_visible < last_visible && first_visible->skip)
+                ++first_visible;
+            while (first_visible < last_visible && last_visible->skip)
+                --last_visible;
+
+            int x_start = first_visible->pos.x;
+            int x_end = last_visible->pos.x + last_visible->advance.x;
             double dt = (double) (tm_current - tm_start) / (tm_end - tm_start);
             double frz = fmod(start->frz, 360);
             if (frz > 90 && frz < 270) {

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -786,7 +786,7 @@ static ASS_Image *render_text(ASS_Renderer *render_priv)
             continue;
 
         if ((info->effect_type == EF_KARAOKE_KO)
-                && (info->effect_timing <= info->first_pos_x)) {
+                && (info->effect_timing <= 0)) {
             // do nothing
         } else {
             tail =
@@ -802,7 +802,7 @@ static ASS_Image *render_text(ASS_Renderer *render_priv)
 
         if ((info->effect_type == EF_KARAOKE)
                 || (info->effect_type == EF_KARAOKE_KO)) {
-            if (info->effect_timing > info->first_pos_x)
+            if (info->effect_timing > 0)
                 tail =
                     render_glyph(render_priv, info->bm, info->x, info->y,
                                  info->c[0], 0, 1000000, tail,
@@ -2329,7 +2329,6 @@ static void render_and_combine_glyphs(ASS_Renderer *render_priv,
                 memcpy(&current_info->c, &info->c, sizeof(info->c));
                 current_info->effect_type = info->effect_type;
                 current_info->effect_timing = info->effect_timing;
-                current_info->first_pos_x = info->bbox.x_max >> 6;
 
                 FilterDesc *filter = &current_info->filter;
                 filter->flags = flags;

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -2625,9 +2625,6 @@ ass_render_event(ASS_Renderer *render_priv, ASS_Event *event,
 
     preliminary_layout(render_priv);
 
-    // depends on glyph x coordinates being monotonous, so it should be done before line wrap
-    process_karaoke_effects(render_priv);
-
     int valign = render_priv->state.alignment & 12;
 
     int MarginL =
@@ -2644,6 +2641,9 @@ ass_render_event(ASS_Renderer *render_priv, ASS_Event *event,
 
     // wrap lines
     wrap_lines_smart(render_priv, max_text_width);
+
+    // depends on glyph x coordinates being monotonous within runs, so it should be done before reorder
+    process_karaoke_effects(render_priv);
 
     reorder_text(render_priv);
 

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -2417,7 +2417,7 @@ static void render_and_combine_glyphs(ASS_Renderer *render_priv,
         }
 
         if (info->effect_type == EF_KARAOKE_KF)
-            info->effect_timing += d6_to_int(info->leftmost_x);
+            info->effect_timing = d6_to_int(info->leftmost_x + info->effect_timing);
 
         for (int j = 0; j < info->bitmap_count; j++) {
             info->bitmaps[j].pos.x -= info->x;

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -1855,12 +1855,15 @@ fix_glyph_scaling(ASS_Renderer *priv, GlyphInfo *glyph)
 // Initial run splitting based purely on the characters' styles
 static void split_style_runs(ASS_Renderer *render_priv)
 {
+    Effect last_effect_type = render_priv->text_info.glyphs[0].effect_type;
     render_priv->text_info.glyphs[0].starts_new_run = true;
     for (int i = 1; i < render_priv->text_info.length; i++) {
         GlyphInfo *info = render_priv->text_info.glyphs + i;
         GlyphInfo *last = render_priv->text_info.glyphs + (i - 1);
+        Effect effect_type = info->effect_type;
         info->starts_new_run =
-            info->effect_type != EF_NONE ||
+            info->effect_timing ||  // but ignore effect_skip_timing
+            (effect_type != EF_NONE && effect_type != last_effect_type) ||
             info->drawing_text ||
             last->drawing_text ||
             strcmp(last->font->desc.family, info->font->desc.family) ||
@@ -1888,6 +1891,8 @@ static void split_style_runs(ASS_Renderer *render_priv)
             last->italic != info->italic ||
             last->bold != info->bold ||
             ((last->flags ^ info->flags) & ~DECO_ROTATE);
+        if (effect_type != EF_NONE)
+            last_effect_type = effect_type;
     }
 }
 

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -1019,7 +1019,7 @@ void reset_render_context(ASS_Renderer *render_priv, ASS_Style *style)
     render_priv->state.shadow_x = style->Shadow;
     render_priv->state.shadow_y = style->Shadow;
     render_priv->state.frx = render_priv->state.fry = 0.;
-    render_priv->state.frz = M_PI * style->Angle / 180.;
+    render_priv->state.frz = style->Angle;
     render_priv->state.fax = render_priv->state.fay = 0.;
     render_priv->state.font_encoding = style->Encoding;
 }
@@ -1248,9 +1248,13 @@ size_t ass_outline_construct(void *key, void *value, void *priv)
 static void calc_transform_matrix(ASS_Renderer *render_priv,
                                   GlyphInfo *info, double m[3][3])
 {
-    double sx = -sin(info->frx), cx = cos(info->frx);
-    double sy =  sin(info->fry), cy = cos(info->fry);
-    double sz = -sin(info->frz), cz = cos(info->frz);
+    double frx = M_PI / 180 * info->frx;
+    double fry = M_PI / 180 * info->fry;
+    double frz = M_PI / 180 * info->frz;
+
+    double sx = -sin(frx), cx = cos(frx);
+    double sy =  sin(fry), cy = cos(fry);
+    double sz = -sin(frz), cz = cos(frz);
 
     double fax = info->fax * info->scale_x / info->scale_y;
     double fay = info->fay * info->scale_y / info->scale_x;

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -280,6 +280,7 @@ static ASS_Image **render_glyph_i(ASS_Renderer *render_priv,
 
     dst_x += bm->left;
     dst_y += bm->top;
+    brk -= dst_x;
 
     // we still need to clip against screen boundaries
     zx = x2scr_pos_scaled(render_priv, 0);

--- a/libass/ass_render.h
+++ b/libass/ass_render.h
@@ -99,9 +99,14 @@ typedef struct {
     FilterDesc filter;
     uint32_t c[4];              // colors
     Effect effect_type;
-    int effect_timing;          // time duration of current karaoke word
-    // after process_karaoke_effects: distance in pixels from the glyph origin.
+
+    // during render_and_combine_glyphs: distance in pixels from the karaoke origin.
+    // after render_and_combine_glyphs: screen coordinate in pixels.
     // part of the glyph to the left of it is displayed in a different color.
+    int effect_timing;
+
+    // karaoke origin: screen coordinate of leftmost post-transform control point x in subpixels
+    int32_t leftmost_x;
 
     size_t bitmap_count, max_bitmap_count;
     BitmapRef *bitmaps;
@@ -142,7 +147,7 @@ typedef struct glyph_info {
     ASS_Vector cluster_advance;
     Effect effect_type;
     int effect_timing;          // time duration of current karaoke word
-    // after process_karaoke_effects: distance in pixels from the glyph origin.
+    // after process_karaoke_effects: distance in pixels from the karaoke origin.
     // part of the glyph to the left of it is displayed in a different color.
     int effect_skip_timing;     // delay after the end of last karaoke word
     int asc, desc;              // font max ascender and descender

--- a/libass/ass_render.h
+++ b/libass/ass_render.h
@@ -100,7 +100,7 @@ typedef struct {
     uint32_t c[4];              // colors
     Effect effect_type;
 
-    // during render_and_combine_glyphs: distance in pixels from the karaoke origin.
+    // during render_and_combine_glyphs: distance in subpixels from the karaoke origin.
     // after render_and_combine_glyphs: screen coordinate in pixels.
     // part of the glyph to the left of it is displayed in a different color.
     int effect_timing;
@@ -147,7 +147,7 @@ typedef struct glyph_info {
     ASS_Vector cluster_advance;
     Effect effect_type;
     int effect_timing;          // time duration of current karaoke word
-    // after process_karaoke_effects: distance in pixels from the karaoke origin.
+    // after process_karaoke_effects: distance in subpixels from the karaoke origin.
     // part of the glyph to the left of it is displayed in a different color.
     int effect_skip_timing;     // delay after the end of last karaoke word
     int asc, desc;              // font max ascender and descender

--- a/libass/ass_render.h
+++ b/libass/ass_render.h
@@ -103,8 +103,6 @@ typedef struct {
     // after process_karaoke_effects: distance in pixels from the glyph origin.
     // part of the glyph to the left of it is displayed in a different color.
 
-    int first_pos_x;
-
     size_t bitmap_count, max_bitmap_count;
     BitmapRef *bitmaps;
 

--- a/libass/ass_utils.h
+++ b/libass/ass_utils.h
@@ -160,12 +160,6 @@ static inline int double_to_d22(double x)
     return (int) (x * 0x400000);
 }
 
-// Calculate cache key for a rotational angle in radians
-static inline int rot_key(double a)
-{
-    return double_to_d22(remainder(a, 2 * M_PI));
-}
-
 #define FNV1_32A_INIT 0x811c9dc5U
 #define FNV1_32A_PRIME 16777619U
 


### PR DESCRIPTION
OK, sooo…

* This makes karaoke quite sane in the common case where there are no 3D transforms, fixing our regressions and old bugs. So it should now mostly Just Work in practice.
    * The behaviour of \kf may be surprising if the text has serifs extending far to the left or far to the right: the karaoke fill line instantly jumps to the first glyph’s origin point when karaoke starts, moves smoothly to the point where the next-beyond-last glyph’s origin would be, and instantly jumps to +infinity when karaoke ends.
* This makes karaoke more compatible with VSFilter, fixing our handling of edge cases, adding special cases that we didn’t handle at all, and reproducing VSFilter’s handling of karaoke on glyph run boundaries.

However, the various flavours of VSFilter handle \kf differently, and weirdly, when additional effects are involved:

* This makes our \kf _pretty close_ to guliverkli/Guliverkli2/xy-VSFilter/XySubFilter’s on text set in plain fonts with xbord ≥ ybord, without any blur, and with or without 3D transforms.
* With 3D transforms, MPC-HC’s \kf [looks different](https://chortos.selfip.net/~astiob/screens/karaoke-transformed/).
    * This appears saner at first.
    * But add border and blur, and MPC-HC’s \kf becomes absurd again.
* This makes our \kf _not_ match _any_ VSFilter when the font has serifs extending far to the left or far to the right, or when the vector drawing’s minimum x coordinate is nonzero, or when ybord > xbord, or with \blur, or with large \be in xy-VSFilter/XySubFilter (or be shifted by 1px with \be in Guliverkli2/MPC-HC).
    * Also, the more of these effects are involved, the more VSFilter’s \kf may be affected by rounding error from floor & ceil, causing it to shift left by up to 2 or 3 pixels. But note that XySubFilter does not attempt to scale this rounding error from video resolution. (It seems xy simply didn’t notice these problems with \kf, as he’s also changed its behaviour with \blur and \be.)
    * And Guliverkli2, xy-VSFilter/XySubFilter and MPC-HC all handle \kf with blur differently! (guliverkli doesn’t support blur. Except \be1, in which case there’s a 1px difference from the other VSFilters.)

This _can_ be emulated. We’d need to pick one VSFilter flavour to emulate though; we can’t do all at once. For example, [here](https://github.com/astiob/libass/commit/2226dd348f24f2300f23dbcadaa38101e20d35ca)’s an imperfect attempt at closely emulating Guliverkli2.

Two of these quirks are common to all VSFilters, and we could at least emulate those:

* Start the fill (in absence of blur, border etc.) at the glyph run’s leftmost control point after 3D transforms, floored, rather than the first glyph’s origin. Our quickest way to emulate this would be to use `bm->left`, which is roughly the leftmost point. (@MrSmile’s #343 does this, inadvertently.) It’s not the leftmost _control_ point though—there’s a difference for cubic curves—and it’s shifted by 1/64px before flooring, and its floor is computed in display resolution.
* Start the fill another (\ybord−\xbord) pixels to the left, if \ybord > \xbord. Plus rounding error, even if \xbord ≤ \ybord. Our quickest way to emulate this would be to ignore the rounding error and subtract (\ybord−\xbord).

If we really wanted, we could even emulate all of the shared rounding quirks.

Blur is where the various VSFilters really diverge. Blur is a late addition to ASS, so perhaps it’s not a surprise. Guliverkli2 and xy-VSFilter/XySubFilter shift the \kf fill to the left again, but by different amounts. MPC-HC attempts to do it better but only ends up being more bizarre, starting the fill more to the left but progressing it faster. None of them act sanely by any measure.