### PR TITLE
ass_render: Replace Segment with Rect

### DIFF
--- a/libass/ass_render.h
+++ b/libass/ass_render.h
@@ -334,11 +334,6 @@ typedef struct {
     int y1;
 } Rect;
 
-typedef struct {
-    int a, b;                   // top and height
-    int ha, hb;                 // left and width
-} Segment;
-
 void reset_render_context(ASS_Renderer *render_priv, ASS_Style *style);
 void ass_frame_ref(ASS_Image *img);
 void ass_frame_unref(ASS_Image *img);


### PR DESCRIPTION
For a change from the alloc-stuff here's a small, cosmetic refactor.

---

Contrary to what the comments suggest Segment does not use one
absolute reference point and relative offsets, but two absolute points,
making it practically identical to the previously defined Rect with
  a ≙ y0,  b ≙ y1,  ha ≙ x0,  hb ≙ x1

For simplicity, replace Segment with Rect.