### PR TITLE
Fix \fscx0, \fscy0 and a positioning bug with right-to-left \fay

### DIFF
--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -2130,6 +2130,8 @@ static void apply_baseline_shear(ASS_Renderer *render_priv)
         if (text_info->glyphs[i].linebreak || last_fay != info->fay)
             shear = 0;
         last_fay = info->fay;
+        if (!info->scale_x || !info->scale_y)
+            info->skip = true;
         if (info->skip)
             continue;
         for (GlyphInfo *cur = info; cur; cur = cur->next)

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -838,7 +838,7 @@ static void compute_string_bbox(TextInfo *text, ASS_DRect *bbox)
     if (text->length > 0) {
         bbox->x_min = +32000;
         bbox->x_max = -32000;
-        bbox->y_min = d6_to_double(text->glyphs[0].pos.y) - text->lines[0].asc;
+        bbox->y_min = -text->lines[0].asc;
         bbox->y_max = bbox->y_min + text->height;
 
         for (int i = 0; i < text->length; i++) {

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -2115,8 +2115,11 @@ static void reorder_text(ASS_Renderer *render_priv)
             last_pen_x = pen.x;
         }
         last_fay = info->fay;
-        if (info->skip) continue;
+        if (info->skip)
+            continue;
         ASS_Vector cluster_pen = pen;
+        pen.x += info->cluster_advance.x;
+        pen.y += info->cluster_advance.y;
         while (info) {
             info->pos.x = info->offset.x + cluster_pen.x;
             info->pos.y = info->offset.y + cluster_pen.y;
@@ -2124,9 +2127,6 @@ static void reorder_text(ASS_Renderer *render_priv)
             cluster_pen.y += info->advance.y;
             info = info->next;
         }
-        info = text_info->glyphs + cmap[i];
-        pen.x += info->cluster_advance.x;
-        pen.y += info->cluster_advance.y;
     }
 }
 

--- a/libass/ass_shaper.c
+++ b/libass/ass_shaper.c
@@ -1020,6 +1020,11 @@ FriBidiStrIndex *ass_shaper_reorder(ASS_Shaper *shaper, TextInfo *text_info)
     return shaper->cmap;
 }
 
+FriBidiStrIndex *ass_shaper_get_reorder_map(ASS_Shaper *shaper)
+{
+    return shaper->cmap;
+}
+
 /**
  * \brief Resolve a Windows font charset number to a suitable base
  * direction. Generally, use LTR for compatibility with VSFilter. The

--- a/libass/ass_shaper.h
+++ b/libass/ass_shaper.h
@@ -45,6 +45,7 @@ void ass_shaper_set_bidi_brackets(ASS_Shaper *shaper, bool match_brackets);
 bool ass_shaper_shape(ASS_Shaper *shaper, TextInfo *text_info);
 void ass_shaper_cleanup(ASS_Shaper *shaper, TextInfo *text_info);
 FriBidiStrIndex *ass_shaper_reorder(ASS_Shaper *shaper, TextInfo *text_info);
+FriBidiStrIndex *ass_shaper_get_reorder_map(ASS_Shaper *shaper);
 FriBidiParType resolve_base_direction(int font_encoding);
 
 void ass_shaper_font_data_free(ASS_ShaperFontData *priv);


### PR DESCRIPTION
Avoid the divisions by zero for \fscx0 and \fscy0. Regardless of the divisions by zero, avoid drawing any border. Two birds with one stone. Extra speed is a bonus.

~~Reset baseline everywhere that it should reset, rather than on the arbitrary condition that \fay must change.~~ in #441 now