### PR TITLE
Treat zero-area events like VSFilter

### DIFF
--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -3005,7 +3005,9 @@ fix_collisions(ASS_Renderer *render_priv, EventImages *imgs, int cnt)
     // fill used[] with fixed events
     for (i = 0; i < cnt; ++i) {
         ASS_RenderPriv *priv;
-        if (!imgs[i].detect_collisions)
+        // VSFilter considers events colliding if their intersections area is non-zero,
+        // zero-area events are therefore effectively fixed as well
+        if (!imgs[i].detect_collisions || !imgs[i].height  || !imgs[i].width)
             continue;
         priv = get_render_priv(render_priv, imgs[i].event);
         if (priv && priv->height > 0) { // it's a fixed event
@@ -3044,7 +3046,7 @@ fix_collisions(ASS_Renderer *render_priv, EventImages *imgs, int cnt)
     // try to fit other events in free spaces
     for (i = 0; i < cnt; ++i) {
         ASS_RenderPriv *priv;
-        if (!imgs[i].detect_collisions)
+        if (!imgs[i].detect_collisions || !imgs[i].height  || !imgs[i].width)
             continue;
         priv = get_render_priv(render_priv, imgs[i].event);
         if (priv && priv->height == 0) {        // not a fixed event

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -1520,6 +1520,7 @@ static void measure_text(ASS_Renderer *render_priv)
 {
     TextInfo *text_info = &render_priv->text_info;
     text_info->height = 0;
+    text_info->border_x = 0;
 
     int cur_line = 0;
     double scale = 0.5 / 64;


### PR DESCRIPTION
Instead of calculating the intersection rect and testing for an zero area *(as VSF does)*, treating zero-area event's as fixed and otherwise keeping the current intersection code should yield identical results (while probably being a tad faster than VSF).

There's one more `shift_event` call which I didn't modify here: https://github.com/libass/libass/blob/700e131c78e6c917369c02161c4c8e2408d963e5/libass/ass_render.c#L3031-L3037
I'm not sure what this one does, but it seems to work without modifying this call.