### PR TITLE
Add extra precision configure switch

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -123,15 +123,13 @@ AM_CONDITIONAL([X64], [test x$X64 = xtrue])
 
 AM_COND_IF([ASM],
     [AC_DEFINE(CONFIG_ASM, 1, [ASM enabled])],
-    [AC_DEFINE(CONFIG_ASM, 0, [ASM enabled])]
-    )
+    [AC_DEFINE(CONFIG_ASM, 0, [ASM enabled])])
 
 AM_CONDITIONAL([ENABLE_LARGE_TILES], [test x$enable_large_tiles = xyes])
 
 AM_COND_IF([ENABLE_LARGE_TILES],
-    [AC_DEFINE(CONFIG_LARGE_TILES, 1, [use large tiles])]
-    [AC_DEFINE(CONFIG_LARGE_TILES, 0, [use small tiles])],
-    )
+    [AC_DEFINE(CONFIG_LARGE_TILES, 1, [use large tiles])],
+    [AC_DEFINE(CONFIG_LARGE_TILES, 0, [use small tiles])])
 
 PKG_CHECK_MODULES([FREETYPE], freetype2 >= 9.10.3, [
     CFLAGS="$CFLAGS $FREETYPE_CFLAGS"

--- a/configure.ac
+++ b/configure.ac
@@ -49,8 +49,8 @@ AC_ARG_ENABLE([require-system-font-provider], AS_HELP_STRING([--disable-require-
     [allow compilation even if no system font provider was found @<:@default=enabled:>@]))
 AC_ARG_ENABLE([asm], AS_HELP_STRING([--disable-asm],
     [disable compiling with ASM @<:@default=check@:>@]))
-AC_ARG_ENABLE([large-tiles], AS_HELP_STRING([--enable-large-tiles],
-    [use larger tiles in the rasterizer (better performance, slightly worse quality) @<:@default=disabled@:>@]))
+AC_ARG_ENABLE([extra-precision], AS_HELP_STRING([--enable-extra-precision],
+    [improve rendering precision at the cost of performance @<:@default=disabled@:>@]))
 
 AS_IF([test x$enable_asm != xno], [
     AS_CASE([$host],
@@ -125,11 +125,11 @@ AM_COND_IF([ASM],
     [AC_DEFINE(CONFIG_ASM, 1, [ASM enabled])],
     [AC_DEFINE(CONFIG_ASM, 0, [ASM enabled])])
 
-AM_CONDITIONAL([ENABLE_LARGE_TILES], [test x$enable_large_tiles = xyes])
+AM_CONDITIONAL([ENABLE_EXTRA_PRECISION], [test x$enable_extra_precision = xyes])
 
-AM_COND_IF([ENABLE_LARGE_TILES],
-    [AC_DEFINE(CONFIG_LARGE_TILES, 1, [use large tiles])],
-    [AC_DEFINE(CONFIG_LARGE_TILES, 0, [use small tiles])])
+AM_COND_IF([ENABLE_EXTRA_PRECISION],
+    [AC_DEFINE(CONFIG_EXTRA_PRECISION, 1, [extra precision])],
+    [AC_DEFINE(CONFIG_EXTRA_PRECISION, 0, [default precision])])
 
 PKG_CHECK_MODULES([FREETYPE], freetype2 >= 9.10.3, [
     CFLAGS="$CFLAGS $FREETYPE_CFLAGS"

--- a/libass/ass_func_template.h
+++ b/libass/ass_func_template.h
@@ -92,7 +92,7 @@ void DECORATE(blur8_vert)(int16_t *dst, const int16_t *src,
 const BitmapEngine DECORATE(bitmap_engine) = {
     .align_order = ALIGN,
 
-#if CONFIG_LARGE_TILES
+#if CONFIG_ASM && !CONFIG_EXTRA_PRECISION
     .tile_order = 5,
     .fill_solid = DECORATE(fill_solid_tile32),
     .fill_halfplane = DECORATE(fill_halfplane_tile32),

--- a/libass/ass_rasterizer.c
+++ b/libass/ass_rasterizer.c
@@ -189,9 +189,12 @@ static bool add_line(RasterizerData *rst, ASS_Vector pt0, ASS_Vector pt1)
     line->a *= 1 << shift;
     line->b *= 1 << shift;
     line->c *= 1 << shift;
+#if CONFIG_EXTRA_PRECISION
+    line->scale = ((uint64_t) 1 << 61) / max_ab;
+#else
     line->scale = (uint64_t) 0x53333333 * (uint32_t) (max_ab * (uint64_t) max_ab >> 32) >> 32;
     line->scale += 0x8810624D - (0xBBC6A7EF * (uint64_t) max_ab >> 32);
-    //line->scale = ((uint64_t) 1 << 61) / max_ab;
+#endif
     return true;
 }
 

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -36,11 +36,18 @@
 #define MAX_SUB_BITMAPS_INITIAL 64
 #define SUBPIXEL_MASK 63
 #define STROKER_PRECISION 16     // stroker error in integer units, unrelated to final accuracy
-#define RASTERIZER_PRECISION 16  // rasterizer spline approximation error in 1/64 pixel units
-#define POSITION_PRECISION 8.0   // rough estimate of transform error in 1/64 pixel units
 #define MAX_PERSP_SCALE 16.0
-#define SUBPIXEL_ORDER 3  // ~ log2(64 / POSITION_PRECISION)
 #define BLUR_PRECISION (1.0 / 256)  // blur error as fraction of full input range
+
+#if CONFIG_EXTRA_PRECISION
+#define RASTERIZER_PRECISION 8  // rasterizer spline approximation error in 1/64 pixel units
+#define POSITION_PRECISION 2.0  // rough estimate of transform error in 1/64 pixel units
+#define SUBPIXEL_ORDER 5        // ~ log2(64 / POSITION_PRECISION)
+#else
+#define RASTERIZER_PRECISION 16
+#define POSITION_PRECISION 4.0
+#define SUBPIXEL_ORDER 4
+#endif
 
 
 ASS_Renderer *ass_renderer_init(ASS_Library *library)


### PR DESCRIPTION
This is my version of PR https://github.com/libass/libass/pull/329.

I've updated visual quality assessment tests (more tests, better reference target) and checked additional parameter values, so the table now looks the following:

| LT|div| RP | PP| err   | 360    | 720    | 1080   | |
|---|---|----|---|-------|--------|--------|--------|-|
| &minus; | &minus; | 16 | 8 | 2.691 | 25.756 | 35.071 | 44.928 | old default |
| &minus; | &minus; | 16 | 4 | 1.758 | 25.702 | 35.107 | 45.789 | new default (no asm) |
| &minus; | &minus; | 8  | 8 | 2.675 | 27.556 | 39.706 | 51.864 | |
| &minus; | &minus; | 8  | 4 | 1.557 | 27.589 | 39.656 | 51.748 | |
| &minus; | + | 16 | 8 | 2.680 | 28.269 | 37.872 | 47.693 | |
| &minus; | + | 16 | 4 | 1.644 | 28.192 | 37.971 | 47.886 | |
| &minus; | + | 16 | 2 | 1.533 | 28.002 | 37.462 | 47.024 | |
| &minus; | + | 8  | 8 | 2.670 | 30.336 | 42.981 | 55.318 | |
| &minus; | + | 8  | 4 | 1.497 | 30.488 | 42.790 | 55.233 | |
| &minus; | + | 8  | 2 | 1.488 | 30.140 | 42.137 | 54.447 | extra precision |
| &minus; | + | 4  | 8 | 2.090 | 34.755 | 51.438 | 66.953 | |
| &minus; | + | 4  | 4 | 1.473 | 35.042 | 52.274 | 67.621 | |
| &minus; | + | 4  | 2 | 1.399 | 34.442 | 51.237 | 66.674 | |
| + | &minus; | 20 | 8 | 2.395 | 22.647 | 30.737 | 39.008 | |
| + | &minus; | 20 | 4 | 2.306 | 22.611 | 30.729 | 38.873 | |
| + | &minus; | 16 | 8 | 2.358 | 22.747 | 31.262 | 40.384 | |
| + | &minus; | 16 | 4 | 2.029 | 22.757 | 31.260 | 40.258 | new default (asm) |
| + | &minus; | 16 | 2 | 1.638 | 22.605 | 30.901 | 39.465 | |
| + | &minus; | 8  | 8 | 2.270 | 24.488 | 35.683 | 46.670 | |
| + | &minus; | 8  | 4 | 1.817 | 24.461 | 35.508 | 46.612 | |
| + | + | 16 | 8 | 2.589 | 25.417 | 34.336 | 43.409 | |
| + | + | 16 | 4 | 1.680 | 25.479 | 34.299 | 43.320 | |
| + | + | 8  | 8 | 2.602 | 27.306 | 38.843 | 50.031 | |
| + | + | 8  | 4 | 1.598 | 27.364 | 38.938 | 50.172 | |

Legend:
* **LT** = large tiles;
* **div** = exact division;
* **RP** = `RASTERIZER_PRECISION`;
* **PP** = `POSITION_PRECISION`;
* **err** = average error of some bunch of `compare` tests;
* **360**/**720**/**1080** = time of rendering of my rasterizer-heavy clip at different screen sizes.

Large tiles are now enabled by default if assembly is present, as without good vector assembly it's slower instead.
