### PR TITLE
Autotools Cosmetics: Part 1

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,4 @@
 ACLOCAL_AMFLAGS = -I m4
-AUTOMAKE_OPTIONS = foreign
 EXTRA_DIST = libass.pc.in Changelog
 
 pkgconfigdir = $(libdir)/pkgconfig

--- a/configure.ac
+++ b/configure.ac
@@ -282,8 +282,8 @@ AM_COND_IF([ASM],
     )
 
 AM_COND_IF([ENABLE_LARGE_TILES],
-    [AC_DEFINE(CONFIG_LARGE_TILES, 1, [use large tiles])]
-    [AC_DEFINE(CONFIG_LARGE_TILES, 0, [use small tiles])],
+    [AC_DEFINE(CONFIG_LARGE_TILES, 1, [use large tiles])],
+    [AC_DEFINE(CONFIG_LARGE_TILES, 0, [use small tiles])]
     )
 
 ## Setup output beautifier.

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_INIT(libass, 0.15.0)
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([foreign])
 AC_CONFIG_MACRO_DIR([m4])
 # Disable Fortran checks
 define([AC_LIBTOOL_LANG_F77_CONFIG], [:])

--- a/configure.ac
+++ b/configure.ac
@@ -46,6 +46,10 @@ AC_ARG_ENABLE([large-tiles], AS_HELP_STRING([--enable-large-tiles],
 OLDLIBS="$LIBS"
 LIBS=
 use_libiconv=false
+## Some iconv libraries like GNU's libiconv define iconv_open as a macro to
+## libiconv_open. As SEARCH_LIBS tests linking not compilation, check for
+## libiconv_open first. SEARCH_LIBS is smart enough to not add -liconv a second
+## time in case both versions are defined in the local libiconv.
 AC_SEARCH_LIBS([libiconv_open], [iconv], use_libiconv=true)
 AC_SEARCH_LIBS([iconv_open], [iconv], use_libiconv=true)
 AS_IF([test "x$use_libiconv" = xtrue], [

--- a/configure.ac
+++ b/configure.ac
@@ -21,18 +21,7 @@ AC_CHECK_HEADERS([stdint.h iconv.h])
 # Checks for library functions.
 AC_CHECK_FUNCS([strdup strndup])
 
-# Checks for libraries.
-# Add them to pkg-config for static linking.
-OLDLIBS="$LIBS"
-LIBS=
-use_libiconv=false
-AC_SEARCH_LIBS([libiconv_open], [iconv], use_libiconv=true)
-AC_SEARCH_LIBS([iconv_open], [iconv], use_libiconv=true)
-AC_CHECK_LIB([m], [fabs])
-pkg_libs="$LIBS"
-LIBS="$OLDLIBS $LIBS"
-
-# Check for libraries via pkg-config
+# Query configuration parameters and set their description
 AC_ARG_ENABLE([test], AS_HELP_STRING([--enable-test],
     [enable test program (requires libpng) @<:@default=no@:>@]))
 AC_ARG_ENABLE([compare], AS_HELP_STRING([--enable-compare],
@@ -52,6 +41,135 @@ AC_ARG_ENABLE([asm], AS_HELP_STRING([--disable-asm],
 AC_ARG_ENABLE([large-tiles], AS_HELP_STRING([--enable-large-tiles],
     [use larger tiles in the rasterizer (better performance, slightly worse quality) @<:@default=disabled@:>@]))
 
+# Checks for available libraries and define corresponding C Macros
+# and add packages to pkg-config for static linking
+OLDLIBS="$LIBS"
+LIBS=
+use_libiconv=false
+AC_SEARCH_LIBS([libiconv_open], [iconv], use_libiconv=true)
+AC_SEARCH_LIBS([iconv_open], [iconv], use_libiconv=true)
+AC_CHECK_LIB([m], [fabs])
+pkg_libs="$LIBS"
+LIBS="$OLDLIBS $LIBS"
+
+## Check for libraries via pkg-config
+PKG_CHECK_MODULES([FREETYPE], freetype2 >= 9.10.3, [
+    CFLAGS="$CFLAGS $FREETYPE_CFLAGS"
+    CXXFLAGS="$CFLAGS $FREETYPE_CFLAGS"
+    LIBS="$LIBS $FREETYPE_LIBS"
+    AC_DEFINE(CONFIG_FREETYPE, 1, [found freetype2 via pkg-config])
+    ])
+
+PKG_CHECK_MODULES([FRIBIDI], fribidi >= 0.19.0, [
+    CFLAGS="$CFLAGS $FRIBIDI_CFLAGS"
+    LIBS="$LIBS $FRIBIDI_LIBS"
+    AC_DEFINE(CONFIG_FRIBIDI, 1, [found fribidi via pkg-config])
+    ])
+
+PKG_CHECK_MODULES([HARFBUZZ], harfbuzz >= 1.2.3, [
+    CFLAGS="$CFLAGS $HARFBUZZ_CFLAGS"
+    LIBS="$LIBS $HARFBUZZ_LIBS"
+    AC_DEFINE(CONFIG_HARFBUZZ, 1, [found harfbuzz via pkg-config])
+    ])
+
+libpng=false
+if test x$enable_test = xyes || test x$enable_compare = xyes; then
+PKG_CHECK_MODULES([LIBPNG], libpng >= 1.2.0, [
+    CFLAGS="$CFLAGS $LIBPNG_CFLAGS"
+    AC_DEFINE(CONFIG_LIBPNG, 1, [found libpng via pkg-config])
+    libpng=true])
+fi
+
+## Check for system font providers
+### Fontconfig
+if test x$enable_fontconfig != xno; then
+PKG_CHECK_MODULES([FONTCONFIG], fontconfig >= 2.10.92, [
+    CFLAGS="$CFLAGS $FONTCONFIG_CFLAGS"
+    LIBS="$LIBS $FONTCONFIG_LIBS"
+    AC_DEFINE(CONFIG_FONTCONFIG, 1, [found fontconfig via pkg-config])
+	fontconfig=true
+    ], [fontconfig=false])
+fi
+
+### Coretext
+if test x$enable_coretext != xno; then
+# Linking to CoreText directly only works from Mountain Lion and iOS.
+# In earlier OS X releases CoreText was part of the ApplicationServices
+# umbrella framework.
+AC_MSG_CHECKING([for CORETEXT])
+AC_COMPILE_IFELSE([
+  AC_LANG_PROGRAM(
+    [[#include <ApplicationServices/ApplicationServices.h>]],
+    [[CTFontDescriptorCopyAttribute(NULL, kCTFontURLAttribute);]])
+  ], [
+    LIBS="$LIBS -framework ApplicationServices -framework CoreFoundation"
+    AC_DEFINE(CONFIG_CORETEXT, 1, [found CoreText in ApplicationServices framework])
+    coretext=true
+    AC_MSG_RESULT([yes])
+  ], [
+    AC_COMPILE_IFELSE([
+      AC_LANG_PROGRAM(
+        [[#include <CoreText/CoreText.h>]],
+        [[CTFontDescriptorCopyAttribute(NULL, kCTFontURLAttribute);]])
+      ], [
+        LIBS="$LIBS -framework CoreText -framework CoreFoundation"
+        AC_DEFINE(CONFIG_CORETEXT, 1, [found CoreText framework])
+        coretext=true
+        AC_MSG_RESULT([yes])
+      ], [
+        coretext=false
+        AC_MSG_RESULT([no])
+      ])
+  ])
+fi
+
+### DirectWrite
+if test x$enable_directwrite != xno; then
+# Linking to DirectWrite directly only works from Windows
+AC_MSG_CHECKING([for DIRECTWRITE])
+AC_LINK_IFELSE([
+  AC_LANG_PROGRAM(
+    [[#include <windows.h>]],
+    [[;]],)
+  ], [
+    AC_DEFINE(CONFIG_DIRECTWRITE, 1, [found DirectWrite])
+    directwrite=true
+    AC_MSG_RESULT([yes])
+  ], [
+    directwrite=false
+    AC_MSG_RESULT([no])
+  ])
+fi
+
+## Require at least one system font provider by default
+if test x$enable_require_system_font_provider != xno &&
+   test x$fontconfig != xtrue &&
+   test x$directwrite != xtrue &&
+   test x$coretext != xtrue
+then
+    AC_MSG_ERROR([\
+Either DirectWrite (on Windows), CoreText (on OSX), or Fontconfig \
+(Linux, other) is required. If you really want to compile without \
+a system font provider, add --disable-require-system-font-provider])
+fi
+
+## Now add packages to pkg-config for static linking
+if test "$use_libiconv" = true; then
+    AC_DEFINE(CONFIG_ICONV, 1, [use iconv])
+    if test x"$ac_cv_search_libiconv_open" != x"none required" &&
+       test x"$ac_cv_search_iconv_open" != x"none required"; then
+        pkg_libs="${pkg_libs} -liconv"
+    fi
+fi
+pkg_requires="freetype2 >= 9.10.3"
+pkg_requires="fribidi >= 0.19.0, ${pkg_requires}"
+pkg_requires="harfbuzz >= 1.2.3, ${pkg_requires}"
+if test x$fontconfig = xtrue; then
+    pkg_requires="fontconfig >= 2.10.92, ${pkg_requires}"
+fi
+
+
+# Locate and configure Assembler appropriately
 AS_IF([test x$enable_asm != xno], [
     AS_CASE([$host],
         [i?86-*], [
@@ -124,152 +242,47 @@ AS_IF([test x$enable_asm != xno], [
     ])
 ])
 
+
+# Relay config results to output files
+
+## Tell Makefiles which assembler and flags to use
 AC_SUBST([ASFLAGS], ["$ASFLAGS"])
 AC_SUBST([AS], ["$AS"])
 
+## Relay package configuration to Makefiles
+AC_SUBST([PKG_LIBS_DEFAULT], [$(test x$enable_shared = xno && echo ${pkg_libs})])
+AC_SUBST([PKG_REQUIRES_DEFAULT], [$(test x$enable_shared = xno && echo ${pkg_requires})])
+AC_SUBST([PKG_LIBS_PRIVATE], [$(test x$enable_shared = xno || echo ${pkg_libs})])
+AC_SUBST([PKG_REQUIRES_PRIVATE], [$(test x$enable_shared = xno || echo ${pkg_requires})])
+
+## Setup conditionals for use in Makefiles
 AM_CONDITIONAL([ASM], [test x$enable_asm != xno])
 AM_CONDITIONAL([INTEL], [test x$INTEL = xtrue])
 AM_CONDITIONAL([X86], [test x$X86 = xtrue])
 AM_CONDITIONAL([X64], [test x$X64 = xtrue])
 
+AM_CONDITIONAL([ENABLE_LARGE_TILES], [test x$enable_large_tiles = xyes])
+
+AM_CONDITIONAL([ENABLE_COMPARE], [test x$enable_compare = xyes && test x$libpng = xtrue])
+AM_CONDITIONAL([ENABLE_TEST], [test x$enable_test = xyes && test x$libpng = xtrue])
+AM_CONDITIONAL([ENABLE_PROFILE], [test x$enable_profile = xyes])
+
+AM_CONDITIONAL([FONTCONFIG], [test x$fontconfig = xtrue])
+AM_CONDITIONAL([CORETEXT], [test x$coretext = xtrue])
+AM_CONDITIONAL([DIRECTWRITE], [test x$directwrite = xtrue])
+
+## Define C Macros not relating to libraries
 AM_COND_IF([ASM],
     [AC_DEFINE(CONFIG_ASM, 1, [ASM enabled])],
     [AC_DEFINE(CONFIG_ASM, 0, [ASM enabled])]
     )
-
-AM_CONDITIONAL([ENABLE_LARGE_TILES], [test x$enable_large_tiles = xyes])
 
 AM_COND_IF([ENABLE_LARGE_TILES],
     [AC_DEFINE(CONFIG_LARGE_TILES, 1, [use large tiles])]
     [AC_DEFINE(CONFIG_LARGE_TILES, 0, [use small tiles])],
     )
 
-PKG_CHECK_MODULES([FREETYPE], freetype2 >= 9.10.3, [
-    CFLAGS="$CFLAGS $FREETYPE_CFLAGS"
-    CXXFLAGS="$CFLAGS $FREETYPE_CFLAGS"
-    LIBS="$LIBS $FREETYPE_LIBS"
-    AC_DEFINE(CONFIG_FREETYPE, 1, [found freetype2 via pkg-config])
-    ])
-
-PKG_CHECK_MODULES([FRIBIDI], fribidi >= 0.19.0, [
-    CFLAGS="$CFLAGS $FRIBIDI_CFLAGS"
-    LIBS="$LIBS $FRIBIDI_LIBS"
-    AC_DEFINE(CONFIG_FRIBIDI, 1, [found fribidi via pkg-config])
-    ])
-
-if test x$enable_fontconfig != xno; then
-PKG_CHECK_MODULES([FONTCONFIG], fontconfig >= 2.10.92, [
-    CFLAGS="$CFLAGS $FONTCONFIG_CFLAGS"
-    LIBS="$LIBS $FONTCONFIG_LIBS"
-    AC_DEFINE(CONFIG_FONTCONFIG, 1, [found fontconfig via pkg-config])
-	fontconfig=true
-    ], [fontconfig=false])
-fi
-AM_CONDITIONAL([FONTCONFIG], [test x$fontconfig = xtrue])
-
-if test x$enable_coretext != xno; then
-# Linking to CoreText directly only works from Mountain Lion and iOS.
-# In earlier OS X releases CoreText was part of the ApplicationServices
-# umbrella framework.
-AC_MSG_CHECKING([for CORETEXT])
-AC_COMPILE_IFELSE([
-  AC_LANG_PROGRAM(
-    [[#include <ApplicationServices/ApplicationServices.h>]],
-    [[CTFontDescriptorCopyAttribute(NULL, kCTFontURLAttribute);]])
-  ], [
-    LIBS="$LIBS -framework ApplicationServices -framework CoreFoundation"
-    AC_DEFINE(CONFIG_CORETEXT, 1, [found CoreText in ApplicationServices framework])
-    coretext=true
-    AC_MSG_RESULT([yes])
-  ], [
-    AC_COMPILE_IFELSE([
-      AC_LANG_PROGRAM(
-        [[#include <CoreText/CoreText.h>]],
-        [[CTFontDescriptorCopyAttribute(NULL, kCTFontURLAttribute);]])
-      ], [
-        LIBS="$LIBS -framework CoreText -framework CoreFoundation"
-        AC_DEFINE(CONFIG_CORETEXT, 1, [found CoreText framework])
-        coretext=true
-        AC_MSG_RESULT([yes])
-      ], [
-        coretext=false
-        AC_MSG_RESULT([no])
-      ])
-  ])
-fi
-AM_CONDITIONAL([CORETEXT], [test x$coretext = xtrue])
-
-
-
-if test x$enable_directwrite != xno; then
-# Linking to DirectWrite directly only works from Windows
-AC_MSG_CHECKING([for DIRECTWRITE])
-AC_LINK_IFELSE([
-  AC_LANG_PROGRAM(
-    [[#include <windows.h>]],
-    [[;]],)
-  ], [
-    AC_DEFINE(CONFIG_DIRECTWRITE, 1, [found DirectWrite])
-    directwrite=true
-    AC_MSG_RESULT([yes])
-  ], [
-    directwrite=false
-    AC_MSG_RESULT([no])
-  ])
-fi
-AM_CONDITIONAL([DIRECTWRITE], [test x$directwrite = xtrue])
-
-PKG_CHECK_MODULES([HARFBUZZ], harfbuzz >= 1.2.3, [
-    CFLAGS="$CFLAGS $HARFBUZZ_CFLAGS"
-    LIBS="$LIBS $HARFBUZZ_LIBS"
-    AC_DEFINE(CONFIG_HARFBUZZ, 1, [found harfbuzz via pkg-config])
-    ])
-
-libpng=false
-if test x$enable_test = xyes || test x$enable_compare = xyes; then
-PKG_CHECK_MODULES([LIBPNG], libpng >= 1.2.0, [
-    CFLAGS="$CFLAGS $LIBPNG_CFLAGS"
-    AC_DEFINE(CONFIG_LIBPNG, 1, [found libpng via pkg-config])
-    libpng=true])
-fi
-
-AM_CONDITIONAL([ENABLE_TEST], [test x$enable_test = xyes && test x$libpng = xtrue])
-AM_CONDITIONAL([ENABLE_COMPARE], [test x$enable_compare = xyes && test x$libpng = xtrue])
-
-AM_CONDITIONAL([ENABLE_PROFILE], [test x$enable_profile = xyes])
-
-# add packages to pkg-config for static linking
-if test "$use_libiconv" = true; then
-    AC_DEFINE(CONFIG_ICONV, 1, [use iconv])
-    if test x"$ac_cv_search_libiconv_open" != x"none required" &&
-       test x"$ac_cv_search_iconv_open" != x"none required"; then
-        pkg_libs="${pkg_libs} -liconv"
-    fi
-fi
-pkg_requires="freetype2 >= 9.10.3"
-pkg_requires="fribidi >= 0.19.0, ${pkg_requires}"
-pkg_requires="harfbuzz >= 1.2.3, ${pkg_requires}"
-if test x$fontconfig = xtrue; then
-    pkg_requires="fontconfig >= 2.10.92, ${pkg_requires}"
-fi
-
-if test x$enable_require_system_font_provider != xno &&
-   test x$fontconfig != xtrue &&
-   test x$directwrite != xtrue &&
-   test x$coretext != xtrue
-then
-    AC_MSG_ERROR([\
-Either DirectWrite (on Windows), CoreText (on OSX), or Fontconfig \
-(Linux, other) is required. If you really want to compile without \
-a system font provider, add --disable-require-system-font-provider])
-fi
-
-AC_SUBST([PKG_LIBS_DEFAULT], [$(test x$enable_shared = xno && echo ${pkg_libs})])
-AC_SUBST([PKG_REQUIRES_DEFAULT], [$(test x$enable_shared = xno && echo ${pkg_requires})])
-AC_SUBST([PKG_LIBS_PRIVATE], [$(test x$enable_shared = xno || echo ${pkg_libs})])
-AC_SUBST([PKG_REQUIRES_PRIVATE], [$(test x$enable_shared = xno || echo ${pkg_requires})])
-
-# Setup output beautifier.
+## Setup output beautifier.
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 AC_CONFIG_FILES([Makefile libass/Makefile test/Makefile compare/Makefile profile/Makefile libass.pc])

--- a/configure.ac
+++ b/configure.ac
@@ -48,6 +48,9 @@ LIBS=
 use_libiconv=false
 AC_SEARCH_LIBS([libiconv_open], [iconv], use_libiconv=true)
 AC_SEARCH_LIBS([iconv_open], [iconv], use_libiconv=true)
+AS_IF([test "x$use_libiconv" = xtrue], [
+    AC_DEFINE(CONFIG_ICONV, 1, [use iconv])
+])
 AC_CHECK_LIB([m], [fabs])
 pkg_libs="$LIBS"
 LIBS="$OLDLIBS $LIBS"
@@ -153,14 +156,7 @@ Either DirectWrite (on Windows), CoreText (on OSX), or Fontconfig \
 a system font provider, add --disable-require-system-font-provider])
 fi
 
-## Now add packages to pkg-config for static linking
-if test "$use_libiconv" = true; then
-    AC_DEFINE(CONFIG_ICONV, 1, [use iconv])
-    if test x"$ac_cv_search_libiconv_open" != x"none required" &&
-       test x"$ac_cv_search_iconv_open" != x"none required"; then
-        pkg_libs="${pkg_libs} -liconv"
-    fi
-fi
+## Now add packages to pkg_requires
 pkg_requires="freetype2 >= 9.10.3"
 pkg_requires="fribidi >= 0.19.0, ${pkg_requires}"
 pkg_requires="harfbuzz >= 1.2.3, ${pkg_requires}"

--- a/configure.ac
+++ b/configure.ac
@@ -86,7 +86,7 @@ AS_IF([test x$enable_asm != xno], [
             AS_CASE([$host],
                 [*darwin*], [
                     ASFLAGS="$ASFLAGS -f macho$BITTYPE -DPREFIX -DHAVE_ALIGNED_STACK=1" ],
-                [*linux*|*dragonfly*|*bsd*|*solaris*], [
+                [*linux*|*dragonfly*|*bsd*|*solaris*|*haiku*], [
                     ASFLAGS="$ASFLAGS -f elf$BITTYPE -DHAVE_ALIGNED_STACK=1" ],
                 [*cygwin*|*mingw*], [
                     ASFLAGS="$ASFLAGS -f win$BITTYPE"
@@ -95,7 +95,18 @@ AS_IF([test x$enable_asm != xno], [
                     ], [
                         ASFLAGS="$ASFLAGS -DHAVE_ALIGNED_STACK=0 -DPREFIX"
                     ])
-                ])
+                ],
+                [ #default
+                    AC_MSG_ERROR(m4_text_wrap(m4_normalize([
+                            Please contact libass upstream to figure out if ASM
+                            support for your platform can be added.
+                            In the meantime you will need to use --disable-asm.]),
+                        [                  ],
+                        [could not identify NASM format for $host !],
+                        [78])
+                    )
+                ]
+            )
             ASFLAGS="$ASFLAGS -DHAVE_CPUNOP=0 -Dprivate_prefix=ass"
             AC_MSG_CHECKING([if $AS supports vpmovzxwd])
             echo "vpmovzxwd ymm0, xmm0" > conftest.asm

--- a/configure.ac
+++ b/configure.ac
@@ -62,7 +62,6 @@ LIBS="$OLDLIBS $LIBS"
 ## Check for libraries via pkg-config
 PKG_CHECK_MODULES([FREETYPE], freetype2 >= 9.10.3, [
     CFLAGS="$CFLAGS $FREETYPE_CFLAGS"
-    CXXFLAGS="$CFLAGS $FREETYPE_CFLAGS"
     LIBS="$LIBS $FREETYPE_LIBS"
     AC_DEFINE(CONFIG_FREETYPE, 1, [found freetype2 via pkg-config])
     ])

--- a/configure.ac
+++ b/configure.ac
@@ -55,7 +55,12 @@ AC_SEARCH_LIBS([iconv_open], [iconv], use_libiconv=true)
 AS_IF([test "x$use_libiconv" = xtrue], [
     AC_DEFINE(CONFIG_ICONV, 1, [use iconv])
 ])
-AC_CHECK_LIB([m], [fabs])
+# Locate math functions. Most systems have it either in libc or libm, but a few
+# have some, eg C89, functions in libc and others in libm. Use C99 lrint to probe.
+AC_SEARCH_LIBS([lrint], [m],
+    [],
+    [AC_MSG_ERROR([Unable to locate math functions!])]
+)
 pkg_libs="$LIBS"
 LIBS="$OLDLIBS $LIBS"
 


### PR DESCRIPTION
Except for the first commit, all changes are purely cosmetic.

Commit 1 adds NASM support for Haiku and makes configure print an error when trying to use NASM on a supported architecture but unrecognised platform. *(currently it just silently produces borked files)*

The main cosmetic improvement of this PR is reodering the configure logic to be imo easier to understand. While doing so I noticed some odd bits; the last 3 commits remove these seemingly unnecessary parts. *(Please tell me if they did serve some purposes afterall)*

Configuration and *(non-static)* compilation was tested on Debian Buster, Debian Sid, OpenIndiana Hipster and Haiku R1/beta2.

---

Furthermore I'm planning to replace the bare shell control structures with proper Autotools-M4 macros and change the `configure.ac` style to better reflect the control structures some macros expand to in a future pr., Imho this would further improve readability.
The reason this is not done here in Part 1, is that any requested change on the reordering would likely cause many merge conflicts with a later style-change commit, which seems like unnecessary work.