### PR TITLE
Autotools Cosmetics: Part 2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9,9 +9,7 @@ AC_CONFIG_HEADER([config.h])
 
 # Checks for programs.
 AC_PROG_CC
-AC_PROG_CPP
 AM_PROG_CC_C_O
-AM_PROG_AS
 
 # Checks for header files.
 AC_HEADER_STDC

--- a/configure.ac
+++ b/configure.ac
@@ -40,9 +40,7 @@ AC_ARG_ENABLE([large-tiles], AS_HELP_STRING([--enable-large-tiles],
     [use larger tiles in the rasterizer (better performance, slightly worse quality) @<:@default=disabled@:>@]))
 
 # Checks for available libraries and define corresponding C Macros
-# and add packages to pkg-config for static linking
-OLDLIBS="$LIBS"
-LIBS=
+# Start with system libs, then check everything else via pkg-config
 AS_IF([test "x$ac_cv_header_iconv_h" = xyes], [
     ## Some iconv libraries like GNU's libiconv define iconv_open as a macro to
     ## libiconv_open. As SEARCH_LIBS tests linking not compilation, check for
@@ -67,7 +65,6 @@ AC_SEARCH_LIBS([lrint], [m], [
     AC_MSG_ERROR([Unable to locate math functions!])
 ])
 pkg_libs="$LIBS"
-LIBS="$OLDLIBS $LIBS"
 
 ## Check for libraries via pkg-config
 PKG_CHECK_MODULES([FREETYPE], [freetype2 >= 9.10.3], [

--- a/configure.ac
+++ b/configure.ac
@@ -223,8 +223,16 @@ AS_IF([test "x$enable_asm" != xno], [
                 [*darwin*], [
                     ASFLAGS="$ASFLAGS -f macho$BITTYPE -DPREFIX -DHAVE_ALIGNED_STACK=1"
                 ],
-                [*linux*|*dragonfly*|*bsd*|*solaris*|*haiku*], [
+                [*linux*|*solaris*|*haiku*], [
                     ASFLAGS="$ASFLAGS -f elf$BITTYPE -DHAVE_ALIGNED_STACK=1"
+                ],
+                [*dragonfly*|*bsd*], [
+                    ASFLAGS="$ASFLAGS -f elf$BITTYPE"
+                    AS_IF([test "x$BITS" = x64], [
+                        ASFLAGS="$ASFLAGS -DHAVE_ALIGNED_STACK=1"
+                    ], [
+                        ASFLAGS="$ASFLAGS -DHAVE_ALIGNED_STACK=0"
+                    ])
                 ],
                 [*cygwin*|*mingw*], [
                     ASFLAGS="$ASFLAGS -f win$BITTYPE"

--- a/configure.ac
+++ b/configure.ac
@@ -5,15 +5,13 @@ AC_CONFIG_MACRO_DIR([m4])
 define([AC_LIBTOOL_LANG_F77_CONFIG], [:])
 LT_INIT
 AC_CONFIG_SRCDIR([libass/ass.c])
-AC_CONFIG_HEADER([config.h])
+AC_CONFIG_HEADERS([config.h])
 
 # Checks for programs.
 AC_PROG_CC
 AM_PROG_CC_C_O
 
 # Checks for header files.
-AC_HEADER_STDC
-AC_HEADER_STDBOOL
 AC_CHECK_HEADERS_ONCE([iconv.h])
 
 # Checks for library functions.

--- a/configure.ac
+++ b/configure.ac
@@ -144,7 +144,7 @@ AS_IF([test "x$enable_directwrite" != xno], [
     # Linking to DirectWrite directly only works from Windows
     AC_MSG_CHECKING([for DIRECTWRITE])
     AC_LINK_IFELSE([
-        AC_LANG_PROGRAM([[#include <windows.h>]], [[;]], )
+        AC_LANG_PROGRAM([[#include <windows.h>]], [[;]])
     ], [
         AC_DEFINE(CONFIG_DIRECTWRITE, 1, [found DirectWrite])
         directwrite=true

--- a/configure.ac
+++ b/configure.ac
@@ -49,132 +49,143 @@ AS_IF([test "x$ac_cv_header_iconv_h" = xyes], [
     ## libiconv_open first. SEARCH_LIBS is smart enough to not add -liconv a second
     ## time in case both versions are defined in the local libiconv.
     use_libiconv=false
-    AC_SEARCH_LIBS([libiconv_open], [iconv], use_libiconv=true)
-    AC_SEARCH_LIBS([iconv_open], [iconv], use_libiconv=true)
+    AC_SEARCH_LIBS([libiconv_open], [iconv], [
+        use_libiconv=true
+    ])
+    AC_SEARCH_LIBS([iconv_open], [iconv], [
+        use_libiconv=true
+    ])
     AS_IF([test "x$use_libiconv" = xtrue], [
         AC_DEFINE(CONFIG_ICONV, 1, [use iconv])
     ])
 ])
 # Locate math functions. Most systems have it either in libc or libm, but a few
 # have some, eg C89, functions in libc and others in libm. Use C99 lrint to probe.
-AC_SEARCH_LIBS([lrint], [m],
-    [],
-    [AC_MSG_ERROR([Unable to locate math functions!])]
-)
+AC_SEARCH_LIBS([lrint], [m], [
+    # noop
+], [
+    AC_MSG_ERROR([Unable to locate math functions!])
+])
 pkg_libs="$LIBS"
 LIBS="$OLDLIBS $LIBS"
 
 ## Check for libraries via pkg-config
-PKG_CHECK_MODULES([FREETYPE], freetype2 >= 9.10.3, [
+PKG_CHECK_MODULES([FREETYPE], [freetype2 >= 9.10.3], [
     CFLAGS="$CFLAGS $FREETYPE_CFLAGS"
     LIBS="$LIBS $FREETYPE_LIBS"
     AC_DEFINE(CONFIG_FREETYPE, 1, [found freetype2 via pkg-config])
-    ])
+])
 
-PKG_CHECK_MODULES([FRIBIDI], fribidi >= 0.19.0, [
+PKG_CHECK_MODULES([FRIBIDI], [fribidi >= 0.19.0], [
     CFLAGS="$CFLAGS $FRIBIDI_CFLAGS"
     LIBS="$LIBS $FRIBIDI_LIBS"
     AC_DEFINE(CONFIG_FRIBIDI, 1, [found fribidi via pkg-config])
-    ])
+])
 
-PKG_CHECK_MODULES([HARFBUZZ], harfbuzz >= 1.2.3, [
+PKG_CHECK_MODULES([HARFBUZZ], [harfbuzz >= 1.2.3], [
     CFLAGS="$CFLAGS $HARFBUZZ_CFLAGS"
     LIBS="$LIBS $HARFBUZZ_LIBS"
     AC_DEFINE(CONFIG_HARFBUZZ, 1, [found harfbuzz via pkg-config])
-    ])
+])
 
 libpng=false
-if test x$enable_test = xyes || test x$enable_compare = xyes; then
-PKG_CHECK_MODULES([LIBPNG], libpng >= 1.2.0, [
-    CFLAGS="$CFLAGS $LIBPNG_CFLAGS"
-    AC_DEFINE(CONFIG_LIBPNG, 1, [found libpng via pkg-config])
-    libpng=true])
-fi
+AS_IF([test "x$enable_test" = xyes || test "x$enable_compare" = xyes], [
+    PKG_CHECK_MODULES([LIBPNG], [libpng >= 1.2.0], [
+        CFLAGS="$CFLAGS $LIBPNG_CFLAGS"
+        AC_DEFINE(CONFIG_LIBPNG, 1, [found libpng via pkg-config])
+        libpng=true
+    ])
+])
 
 ## Check for system font providers
 ### Fontconfig
-if test x$enable_fontconfig != xno; then
-PKG_CHECK_MODULES([FONTCONFIG], fontconfig >= 2.10.92, [
-    CFLAGS="$CFLAGS $FONTCONFIG_CFLAGS"
-    LIBS="$LIBS $FONTCONFIG_LIBS"
-    AC_DEFINE(CONFIG_FONTCONFIG, 1, [found fontconfig via pkg-config])
-	fontconfig=true
-    ], [fontconfig=false])
-fi
+AS_IF([test "x$enable_fontconfig" != xno], [
+    PKG_CHECK_MODULES([FONTCONFIG], [fontconfig >= 2.10.92], [
+        CFLAGS="$CFLAGS $FONTCONFIG_CFLAGS"
+        LIBS="$LIBS $FONTCONFIG_LIBS"
+        AC_DEFINE(CONFIG_FONTCONFIG, 1, [found fontconfig via pkg-config])
+        fontconfig=true
+    ], [
+        fontconfig=false
+    ])
+])
 
 ### Coretext
-if test x$enable_coretext != xno; then
-# Linking to CoreText directly only works from Mountain Lion and iOS.
-# In earlier OS X releases CoreText was part of the ApplicationServices
-# umbrella framework.
-AC_MSG_CHECKING([for CORETEXT])
-AC_COMPILE_IFELSE([
-  AC_LANG_PROGRAM(
-    [[#include <ApplicationServices/ApplicationServices.h>]],
-    [[CTFontDescriptorCopyAttribute(NULL, kCTFontURLAttribute);]])
-  ], [
-    LIBS="$LIBS -framework ApplicationServices -framework CoreFoundation"
-    AC_DEFINE(CONFIG_CORETEXT, 1, [found CoreText in ApplicationServices framework])
-    coretext=true
-    AC_MSG_RESULT([yes])
-  ], [
+AS_IF([test "x$enable_coretext" != xno], [
+    # Linking to CoreText directly only works from Mountain Lion and iOS.
+    # In earlier OS X releases CoreText was part of the ApplicationServices
+    # umbrella framework.
+    AC_MSG_CHECKING([for CORETEXT])
     AC_COMPILE_IFELSE([
-      AC_LANG_PROGRAM(
-        [[#include <CoreText/CoreText.h>]],
-        [[CTFontDescriptorCopyAttribute(NULL, kCTFontURLAttribute);]])
-      ], [
-        LIBS="$LIBS -framework CoreText -framework CoreFoundation"
-        AC_DEFINE(CONFIG_CORETEXT, 1, [found CoreText framework])
+        AC_LANG_PROGRAM( dnl# First test for legacy include
+            [[#include <ApplicationServices/ApplicationServices.h>]],
+            [[CTFontDescriptorCopyAttribute(NULL, kCTFontURLAttribute);]]
+        )
+    ], [
+        LIBS="$LIBS -framework ApplicationServices -framework CoreFoundation"
+        AC_DEFINE(CONFIG_CORETEXT, 1, [found CoreText in ApplicationServices framework])
         coretext=true
         AC_MSG_RESULT([yes])
-      ], [
-        coretext=false
-        AC_MSG_RESULT([no])
-      ])
-  ])
-fi
+    ], [
+        AC_COMPILE_IFELSE([
+            AC_LANG_PROGRAM( dnl# Otherwise check newer include style
+                [[#include <CoreText/CoreText.h>]],
+                [[CTFontDescriptorCopyAttribute(NULL, kCTFontURLAttribute);]]
+            )
+        ], [
+            LIBS="$LIBS -framework CoreText -framework CoreFoundation"
+            AC_DEFINE(CONFIG_CORETEXT, 1, [found CoreText framework])
+            coretext=true
+            AC_MSG_RESULT([yes])
+        ], [
+            coretext=false
+            AC_MSG_RESULT([no])
+        ])
+    ])
+])
 
 ### DirectWrite
-if test x$enable_directwrite != xno; then
-# Linking to DirectWrite directly only works from Windows
-AC_MSG_CHECKING([for DIRECTWRITE])
-AC_LINK_IFELSE([
-  AC_LANG_PROGRAM(
-    [[#include <windows.h>]],
-    [[;]],)
-  ], [
-    AC_DEFINE(CONFIG_DIRECTWRITE, 1, [found DirectWrite])
-    directwrite=true
-    AC_MSG_RESULT([yes])
-  ], [
-    directwrite=false
-    AC_MSG_RESULT([no])
-  ])
-fi
+AS_IF([test "x$enable_directwrite" != xno], [
+    # Linking to DirectWrite directly only works from Windows
+    AC_MSG_CHECKING([for DIRECTWRITE])
+    AC_LINK_IFELSE([
+        AC_LANG_PROGRAM([[#include <windows.h>]], [[;]], )
+    ], [
+        AC_DEFINE(CONFIG_DIRECTWRITE, 1, [found DirectWrite])
+        directwrite=true
+        AC_MSG_RESULT([yes])
+    ], [
+        directwrite=false
+        AC_MSG_RESULT([no])
+    ])
+])
 
 ## Require at least one system font provider by default
-if test x$enable_require_system_font_provider != xno &&
-   test x$fontconfig != xtrue &&
-   test x$directwrite != xtrue &&
-   test x$coretext != xtrue
-then
-    AC_MSG_ERROR([\
-Either DirectWrite (on Windows), CoreText (on OSX), or Fontconfig \
-(Linux, other) is required. If you really want to compile without \
-a system font provider, add --disable-require-system-font-provider])
-fi
+AS_IF([test "x$enable_require_system_font_provider" != xno  dnl
+        && test "x$fontconfig" != xtrue                     dnl
+        && test "x$directwrite" != xtrue                    dnl
+        && test "x$coretext" != xtrue                       ], [
+    AC_MSG_ERROR(m4_text_wrap(m4_normalize([
+            Either DirectWrite (on Windows), CoreText (on OSX), or Fontconfig
+            (Linux, other) is required. If you really want to compile without
+            a system font provider, add --disable-require-system-font-provider]),
+        [                  ],
+        [No system font provider!],
+        [78]
+    ))
+])
 
 ## Now add packages to pkg_requires
 pkg_requires="freetype2 >= 9.10.3"
 pkg_requires="fribidi >= 0.19.0, ${pkg_requires}"
 pkg_requires="harfbuzz >= 1.2.3, ${pkg_requires}"
-if test x$fontconfig = xtrue; then
+AS_IF([test "x$fontconfig" = xtrue], [
     pkg_requires="fontconfig >= 2.10.92, ${pkg_requires}"
-fi
+])
 
 
 # Locate and configure Assembler appropriately
-AS_IF([test x$enable_asm != xno], [
+AS_IF([test "x$enable_asm" != xno], [
     AS_CASE([$host],
         [i?86-*], [
             INTEL=true
@@ -182,51 +193,59 @@ AS_IF([test x$enable_asm != xno], [
             X86=true
             BITS=32
             BITTYPE=32
-            ASFLAGS="$ASFLAGS -DARCH_X86_64=0" ],
+            ASFLAGS="$ASFLAGS -DARCH_X86_64=0"
+        ],
         [x86_64-*-gnux32|amd64-*-gnux32], [
             AS=nasm
             INTEL=true
             X64=true
             BITS=64
             BITTYPE=x32
-            ASFLAGS="$ASFLAGS -DARCH_X86_64=1 -DPIC" ],
+            ASFLAGS="$ASFLAGS -DARCH_X86_64=1 -DPIC"
+        ],
         [x86_64-*|amd64-*], [
             AS=nasm
             INTEL=true
             X64=true
             BITS=64
             BITTYPE=64
-            ASFLAGS="$ASFLAGS -DARCH_X86_64=1 -DPIC" ],
-        )
-    AS_IF([test x$INTEL = xtrue], [
+            ASFLAGS="$ASFLAGS -DARCH_X86_64=1 -DPIC"
+        ],
+        [ # default
+            INTEL=false
+        ]
+    )
+    AS_IF([test "x$INTEL" = xtrue], [
         AC_CHECK_PROG([nasm_check], [$AS], [yes])
-        AS_IF([test x$nasm_check != xyes], [
+        AS_IF([test "x$nasm_check" != xyes], [
             AC_MSG_WARN(nasm was not found; ASM functions are disabled.)
             AC_MSG_WARN(Install nasm for a significantly faster libass build.)
             enable_asm=no
         ], [
             AS_CASE([$host],
                 [*darwin*], [
-                    ASFLAGS="$ASFLAGS -f macho$BITTYPE -DPREFIX -DHAVE_ALIGNED_STACK=1" ],
+                    ASFLAGS="$ASFLAGS -f macho$BITTYPE -DPREFIX -DHAVE_ALIGNED_STACK=1"
+                ],
                 [*linux*|*dragonfly*|*bsd*|*solaris*|*haiku*], [
-                    ASFLAGS="$ASFLAGS -f elf$BITTYPE -DHAVE_ALIGNED_STACK=1" ],
+                    ASFLAGS="$ASFLAGS -f elf$BITTYPE -DHAVE_ALIGNED_STACK=1"
+                ],
                 [*cygwin*|*mingw*], [
                     ASFLAGS="$ASFLAGS -f win$BITTYPE"
-                    AS_IF([test x$BITS = x64], [
+                    AS_IF([test "x$BITS" = x64], [
                         ASFLAGS="$ASFLAGS -DHAVE_ALIGNED_STACK=1"
                     ], [
                         ASFLAGS="$ASFLAGS -DHAVE_ALIGNED_STACK=0 -DPREFIX"
                     ])
                 ],
-                [ #default
+                [ # default
                     AC_MSG_ERROR(m4_text_wrap(m4_normalize([
                             Please contact libass upstream to figure out if ASM
                             support for your platform can be added.
                             In the meantime you will need to use --disable-asm.]),
                         [                  ],
                         [could not identify NASM format for $host !],
-                        [78])
-                    )
+                        [78]
+                    ))
                 ]
             )
             ASFLAGS="$ASFLAGS -DHAVE_CPUNOP=0 -Dprivate_prefix=ass"
@@ -254,37 +273,39 @@ AC_SUBST([ASFLAGS], ["$ASFLAGS"])
 AC_SUBST([AS], ["$AS"])
 
 ## Relay package configuration to Makefiles
-AC_SUBST([PKG_LIBS_DEFAULT], [$(test x$enable_shared = xno && echo ${pkg_libs})])
-AC_SUBST([PKG_REQUIRES_DEFAULT], [$(test x$enable_shared = xno && echo ${pkg_requires})])
-AC_SUBST([PKG_LIBS_PRIVATE], [$(test x$enable_shared = xno || echo ${pkg_libs})])
-AC_SUBST([PKG_REQUIRES_PRIVATE], [$(test x$enable_shared = xno || echo ${pkg_requires})])
+AC_SUBST([PKG_LIBS_DEFAULT], [$(test "x$enable_shared" = xno && echo "${pkg_libs}")])
+AC_SUBST([PKG_REQUIRES_DEFAULT], [$(test "x$enable_shared" = xno && echo "${pkg_requires}")])
+AC_SUBST([PKG_LIBS_PRIVATE], [$(test "x$enable_shared" = xno || echo "${pkg_libs}")])
+AC_SUBST([PKG_REQUIRES_PRIVATE], [$(test "x$enable_shared" = xno || echo "${pkg_requires}")])
 
 ## Setup conditionals for use in Makefiles
-AM_CONDITIONAL([ASM], [test x$enable_asm != xno])
-AM_CONDITIONAL([INTEL], [test x$INTEL = xtrue])
-AM_CONDITIONAL([X86], [test x$X86 = xtrue])
-AM_CONDITIONAL([X64], [test x$X64 = xtrue])
+AM_CONDITIONAL([ASM], [test "x$enable_asm" != xno])
+AM_CONDITIONAL([INTEL], [test "x$INTEL" = xtrue])
+AM_CONDITIONAL([X86], [test "x$X86" = xtrue])
+AM_CONDITIONAL([X64], [test "x$X64" = xtrue])
 
-AM_CONDITIONAL([ENABLE_LARGE_TILES], [test x$enable_large_tiles = xyes])
+AM_CONDITIONAL([ENABLE_LARGE_TILES], [test "x$enable_large_tiles" = xyes])
 
-AM_CONDITIONAL([ENABLE_COMPARE], [test x$enable_compare = xyes && test x$libpng = xtrue])
-AM_CONDITIONAL([ENABLE_TEST], [test x$enable_test = xyes && test x$libpng = xtrue])
-AM_CONDITIONAL([ENABLE_PROFILE], [test x$enable_profile = xyes])
+AM_CONDITIONAL([ENABLE_COMPARE], [test "x$enable_compare" = xyes && test "x$libpng" = xtrue])
+AM_CONDITIONAL([ENABLE_TEST], [test "x$enable_test" = xyes && test "x$libpng" = xtrue])
+AM_CONDITIONAL([ENABLE_PROFILE], [test "x$enable_profile" = xyes])
 
-AM_CONDITIONAL([FONTCONFIG], [test x$fontconfig = xtrue])
-AM_CONDITIONAL([CORETEXT], [test x$coretext = xtrue])
-AM_CONDITIONAL([DIRECTWRITE], [test x$directwrite = xtrue])
+AM_CONDITIONAL([FONTCONFIG], [test "x$fontconfig" = xtrue])
+AM_CONDITIONAL([CORETEXT], [test "x$coretext" = xtrue])
+AM_CONDITIONAL([DIRECTWRITE], [test "x$directwrite" = xtrue])
 
 ## Define C Macros not relating to libraries
-AM_COND_IF([ASM],
-    [AC_DEFINE(CONFIG_ASM, 1, [ASM enabled])],
-    [AC_DEFINE(CONFIG_ASM, 0, [ASM enabled])]
-    )
+AM_COND_IF([ASM], [
+    AC_DEFINE(CONFIG_ASM, 1, [ASM enabled])
+], [
+    AC_DEFINE(CONFIG_ASM, 0, [ASM enabled])
+])
 
-AM_COND_IF([ENABLE_LARGE_TILES],
-    [AC_DEFINE(CONFIG_LARGE_TILES, 1, [use large tiles])],
-    [AC_DEFINE(CONFIG_LARGE_TILES, 0, [use small tiles])]
-    )
+AM_COND_IF([ENABLE_LARGE_TILES], [
+    AC_DEFINE(CONFIG_LARGE_TILES, 1, [use large tiles])
+], [
+    AC_DEFINE(CONFIG_LARGE_TILES, 0, [use small tiles])
+])
 
 ## Setup output beautifier.
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])

--- a/configure.ac
+++ b/configure.ac
@@ -272,11 +272,9 @@ AS_IF([test "x$enable_asm" != xno], [
 AC_SUBST([ASFLAGS], ["$ASFLAGS"])
 AC_SUBST([AS], ["$AS"])
 
-## Relay package configuration to Makefiles
-AC_SUBST([PKG_LIBS_DEFAULT], [$(test "x$enable_shared" = xno && echo "${pkg_libs}")])
-AC_SUBST([PKG_REQUIRES_DEFAULT], [$(test "x$enable_shared" = xno && echo "${pkg_requires}")])
-AC_SUBST([PKG_LIBS_PRIVATE], [$(test "x$enable_shared" = xno || echo "${pkg_libs}")])
-AC_SUBST([PKG_REQUIRES_PRIVATE], [$(test "x$enable_shared" = xno || echo "${pkg_requires}")])
+## Relay package configuration to libass.pc.in
+AC_SUBST([PKG_LIBS_PRIVATE], [${pkg_libs}])
+AC_SUBST([PKG_REQUIRES_PRIVATE], [${pkg_requires}])
 
 ## Setup conditionals for use in Makefiles
 AM_CONDITIONAL([ASM], [test "x$enable_asm" != xno])

--- a/configure.ac
+++ b/configure.ac
@@ -14,7 +14,7 @@ AM_PROG_CC_C_O
 # Checks for header files.
 AC_HEADER_STDC
 AC_HEADER_STDBOOL
-AC_CHECK_HEADERS([stdint.h iconv.h])
+AC_CHECK_HEADERS_ONCE([iconv.h])
 
 # Checks for library functions.
 AC_CHECK_FUNCS([strdup strndup])
@@ -43,15 +43,17 @@ AC_ARG_ENABLE([large-tiles], AS_HELP_STRING([--enable-large-tiles],
 # and add packages to pkg-config for static linking
 OLDLIBS="$LIBS"
 LIBS=
-use_libiconv=false
-## Some iconv libraries like GNU's libiconv define iconv_open as a macro to
-## libiconv_open. As SEARCH_LIBS tests linking not compilation, check for
-## libiconv_open first. SEARCH_LIBS is smart enough to not add -liconv a second
-## time in case both versions are defined in the local libiconv.
-AC_SEARCH_LIBS([libiconv_open], [iconv], use_libiconv=true)
-AC_SEARCH_LIBS([iconv_open], [iconv], use_libiconv=true)
-AS_IF([test "x$use_libiconv" = xtrue], [
-    AC_DEFINE(CONFIG_ICONV, 1, [use iconv])
+AS_IF([test "x$ac_cv_header_iconv_h" = xyes], [
+    ## Some iconv libraries like GNU's libiconv define iconv_open as a macro to
+    ## libiconv_open. As SEARCH_LIBS tests linking not compilation, check for
+    ## libiconv_open first. SEARCH_LIBS is smart enough to not add -liconv a second
+    ## time in case both versions are defined in the local libiconv.
+    use_libiconv=false
+    AC_SEARCH_LIBS([libiconv_open], [iconv], use_libiconv=true)
+    AC_SEARCH_LIBS([iconv_open], [iconv], use_libiconv=true)
+    AS_IF([test "x$use_libiconv" = xtrue], [
+        AC_DEFINE(CONFIG_ICONV, 1, [use iconv])
+    ])
 ])
 # Locate math functions. Most systems have it either in libc or libm, but a few
 # have some, eg C89, functions in libc and others in libm. Use C99 lrint to probe.

--- a/libass.pc.in
+++ b/libass.pc.in
@@ -6,8 +6,8 @@ includedir=@includedir@
 Name: libass
 Description: LibASS is an SSA/ASS subtitles rendering library
 Version: @PACKAGE_VERSION@
-Requires: @PKG_REQUIRES_DEFAULT@
+Requires:
 Requires.private: @PKG_REQUIRES_PRIVATE@
-Libs: -L${libdir} -lass @PKG_LIBS_DEFAULT@
+Libs: -L${libdir} -lass
 Libs.private: @PKG_LIBS_PRIVATE@
 Cflags: -I${includedir}


### PR DESCRIPTION
Currently we mix bare shell parts with autoconf's M4-macros in configure.ac. And where M4-macros are used our style makes it easy to miss commas, which are crucial to functonality and missing them often won't result in errors as usually all but the first few parameters are optional. *(Also indents are inconsistent)*

My ideas to improve this are:
  1) Better reflect shell constructs the macros will epxand to in linebreaks and indent levels.
       This will hopefully also make it more obvious to the reader what the macros and parameters do.
  2) placing commas on dedicated and/or same line as brackets they will be much harder to miss
      and unbalanced brackets should cause noticeable errors.
  3) Use (shell-)comments to fill in noops or for case-default etc *(should we use M4-comments (`dnl`, or a combination of both `dnl#` instead?)*

Here's a mockup example with basic examples: 
```autoconf
#Extra indent level to reflect loop over headers (not-/found is executed for every found/missing header)
AC_CHECK_HEADERS([inttypes.h stdint.h sys/types.h],
        [do_stuff_for_found_hheaders]
    ,
        [do_other_stuff_for_missing_headers]
)

#Or if we want to be prepared for possible future multiliners:
#(imo we should use _only_ one variant in configure.ac)
AC_CHECK_HEADERS([inttypes.h stdint.h sys/types.h],
    [
        #action for each found header
    ],[
        #action for each missing header
    ]
)


# Prentend lrint could be in any of lib[cmwe] (or in some other lib already in $LIBS)
found_lrint=false
AC_SEARCH_LIBS([lrint], [m w e], [
    found_lrint=true
],[
    #noop (the not-found action could maybe be dropped altogether here)
])

AS_IF([test "x$found_lrint" = xtrue], [
    #noop
],[
    AC_MSG_ERROR([Unable to locate lrint!])
])

AS_CASE([$host],
    [*linux*|*solaris*|*bsd*|*dragonfly*|*darwin*],[
        HTYPE=UNIXLIKE
    ],[*-haiku*|*-beos*],[
        HTYPE=BEOSLIKE
    ],[#default  (← there's no case-condition prepending the default action, so add a comment for clarity)
        AC_MSG_ERROR([Unknown host system!])
    ]
)

```
Imho as long as we *only* have one liners in `AC_CHECK_HEADERS` the first variation is fine, however if multiliners start to appear, we should switch all instances to the second version and **not** mix both variations.

One thing the above style does not handle ideally, is the optional include/link parameters of `AC_SEARCH_LIBS` and `AC_CHECK_HEADERS` — which we currently do not use.
The following is the best way, I could come up with. At least commas at the start of the line are imo harder to miss then at the end of a line, but it's also far from ideal:
```autoconf
# Extra indent level to seperate conditional code from _always_ applying parameter
AC_SEARCH_LIBS([lrint], [m w e],
        [
            found_lrint=true
        ],[
            #noop
        ]
    ,[-lX11]
)

# 2×indent for in-loop actions, 1×indent for following macro parameter
# (doesn't really indicate the loop anymore, as SEARCH_LIBS does the same, but I don't have a better idea)
AC_CHECK_HEADERS([inttypes.h stdint.h sys/types.h],
        [
            #action for each found header
        ],[
            #action for each missing header
        ]
    ,[#include <stdlib.h>]
)
```

Requesting feedback on the proposed style and its variations. If somebody has a better idea how to deal with the optional include/link parameters, that would be great.