### PR TITLE
Use GitHubActions

### DIFF
--- a/.github/workflows/ghci.yml
+++ b/.github/workflows/ghci.yml
@@ -20,6 +20,10 @@ jobs:
           - os: ubuntu-18.04
             cc: gcc
             do_distc: yes
+          # Run Coverity on a clang build; Coverity's gcc causes issues
+          - os: ubuntu-18.04
+            cc: clang
+            do_coverity: yes
 
     steps:
       - name: checkout code
@@ -56,3 +60,87 @@ jobs:
 
       - name: distcheck
         run: if [ "x${{ matrix.do_distc }}" = "xyes" ] ; then make -j 2 distcheck; fi
+
+      - name: Coverity scan
+        env:
+          COVERITY_SCAN_TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
+          PROJECT_NAME: libass/libass
+          NOTIFY_EMAIL: none@example.com
+          TOOL_URL: https://scan.coverity.com/download/
+          UPLOAD_URL: https://scan.coverity.com/builds?project=libass%2Flibass
+          SCAN_URL: https://scan.coverity.com
+          RES_DIR: cov-int
+        run: |
+          if [ "x${{ matrix.do_coverity }}" = "xyes" ] \
+             && [ "x${{ github.repository }}" = "xlibass/libass" ] \
+             && [ "x${{ github.event_name }}" != "xpull_request" ]
+          then
+            exit_code=0
+            echo "Running Coverity ..."
+            # Remove previous build output
+            make clean
+            # The upstream script is borked and always exits with 1 even on success
+            # To get meaningful success/error status we're using our own script
+            # but we still want to be informed about upstream script changes
+            if curl -s https://scan.coverity.com/scripts/travisci_build_coverity_scan.sh \
+                | shasum -a 256 \
+                | grep -Eq '^234d71b4a5257a79559e66dd3ba5765576d2af4845da83af4975b77b14ab536b '
+            then
+               : remote unchanged
+            else
+              echo "Coverity's travis script changed!"
+              exit_code=1
+            fi
+
+            # Check if we are within quoata
+            quota_res="$(curl -s --form project="$PROJECT_NAME" \
+                                 --form token="$COVERITY_SCAN_TOKEN" \
+                                 "$SCAN_URL"/api/upload_permitted)"
+            if [ "$?" -ne 0 ] || [ "x$quota_res" = "xAccess denied" ] ; then
+              echo "Coverity denied access or did not respond!"
+              exit 1
+            elif echo "$quota_res" | grep -Eq 'upload_permitted": *true' ; then
+              echo "Within Coverity quota."
+            else
+              echo "Exceeding Coverity quota! Try again later."
+              echo "$quota_res" | grep -Eo 'next_upload_permitted_at":[^,}]*'
+              exit 0
+            fi
+
+            # Download cov tool and make it available
+            wget -nv "$TOOL_URL""$(uname)" \
+                 --post-data "project=$PROJECT_NAME&token=$COVERITY_SCAN_TOKEN" \
+                 -O cov-analysis-tool.tar.gz
+            mkdir cov-analysis-tool
+            tar xzf cov-analysis-tool.tar.gz --strip 1 -C cov-analysis-tool
+            export PATH="$(pwd)/cov-analysis-tool/bin:$PATH"
+
+            # Coverity Build
+            echo "Starting Coverity build..."
+            #mkdir "$RES_DIR" # already done by cov-build
+            COVERITY_UNSUPPORTED=1 cov-build --dir "$RES_DIR" make -j 2
+            cov-import-scm --dir "$RES_DIR" --scm git --log "$RES_DIR/scm_log.txt" 2>&1
+
+            # Submit results to Coverity's server
+            tar czf libass.tar.gz "$RES_DIR"
+            upstat="$(curl --silent --write-out "\n%{http_code}\n" \
+                       --form project="PROJECT_NAME"               \
+                       --form token="$COVERITY_SCAN_TOKEN"         \
+                       --form email="$NOTIFY_EMAIL"                \
+                       --form file=@libass.tar.gz                  \
+                       --form version="${{ github.sha }}"          \
+                       --form description="GitHubActions CI build" \
+                        "$UPLOAD_URL")"
+            if [ "$?" -ne 0 ] ; then
+              echo "Upload failed (curl error)"
+              exit_code=1
+            elif echo "$upstat" | tail -n 1 | grep -Eq '^2[0-9]{2}$' ; then
+              echo "Upload successful."
+            else
+              echo "Upload failed (server error)"
+              exit_code=1
+            fi
+            echo "$upstat" | head
+
+            exit $exit_code
+          fi

--- a/.github/workflows/ghci.yml
+++ b/.github/workflows/ghci.yml
@@ -1,0 +1,50 @@
+name: GitHub CI tests
+
+on:
+  push:
+    branches: [master, ci, coverity_scan]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, macos-10.15]
+        cc: [gcc, clang]
+        exclude:
+          - os: macos-10.15
+            cc: gcc
+        include:
+          # Enable distcheck for one build
+          - os: ubuntu-18.04
+            cc: gcc
+            do_distc: yes
+
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+
+      - name: install deps
+        run: |
+          if echo "${{ matrix.os }}" | grep -qE '^macos-' ; then
+            #brew update
+            # fontconfig, freetype, autoconf and libtool are preinstalled
+            # and `brew install` fails if a non-uptodate version is already installed
+            #brew upgrade fontconfig freetype autoconf libtool
+            brew install automake fribidi harfbuzz nasm
+          else
+            sudo apt-get update #&& sudo apt-get upgrade
+            sudo apt-get install -y \
+                 libfontconfig1-dev libfreetype6-dev libfribidi-dev \
+                 libharfbuzz-dev nasm ${{ matrix.cc }}
+          fi
+
+      - name: configure
+        run: ./autogen.sh && CC="${{ matrix.cc }}" ./configure
+
+      - name: compile
+        run: test "x${{ matrix.do_distc }}" = "xyes" || make -j 2
+
+      - name: distcheck
+        run: if [ "x${{ matrix.do_distc }}" = "xyes" ] ; then make -j 2 distcheck; fi

--- a/.github/workflows/ghci.yml
+++ b/.github/workflows/ghci.yml
@@ -25,6 +25,14 @@ jobs:
       - name: checkout code
         uses: actions/checkout@v2
 
+      - name: retrieve caches
+        uses: actions/cache@v2
+        with:
+          path: |
+            $HOME/Library/Caches/Homebrew
+            /usr/local/Homebrew
+          key: ${{ runner.os }}-${{ matrix.os }}-build
+
       - name: install deps
         run: |
           if echo "${{ matrix.os }}" | grep -qE '^macos-' ; then


### PR DESCRIPTION
`travis-ci.org` will [close on 31.12.2020](https://docs.travis-ci.com/user/migrate/open-source-repository-migration#q-when-will-the-migration-from-travis-ciorg-to-travis-cicom-be-completed) and `travis-ci.com` [does no longer offer MacOS builds to free users](https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing).
Since the project is currently hosted on GitHub using GHA as a travis replacement seemed like the least amount of work.

Compared to our travis builds GHA is currently missing IRC notifications and Coverity.
To my knowledge there's unfortunately no easy way to get IRC notifications with GHA.
I don't think it's possible for me to migrate Coverity to GHA as I don't know about the tokens. @astiob, iimn your familiar with the Coverity stuff, could you take a look at if Coverity can be integrated into the GHA builds? GHA's docs on secret values can be found here: https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets

An example of it in work can be found [here](https://github.com/TheOneric/libass/actions/runs/403298501). *(Note that GitHub only shows the full log if logged in, which is a bit annoying. I'm not sure if all looged in users can see the logs or only those with some form of repo access)*