### PR TITLE
Reduce strdup() usage

### DIFF
--- a/libass/ass_cache.c
+++ b/libass/ass_cache.c
@@ -40,12 +40,13 @@
 // font cache
 static bool font_key_move(void *dst, void *src)
 {
-    ASS_FontDesc *k = src;
-    if (dst)
-        memcpy(dst, src, sizeof(ASS_FontDesc));
-    else
-        free(k->family);
-    return true;
+    if (!dst)
+        return true;
+
+    ASS_FontDesc *d = dst, *s = dst;
+    memcpy(dst, src, sizeof(ASS_FontDesc));
+    d->family.str = ass_copy_string(s->family);
+    return d->family.str;
 }
 
 static void font_destruct(void *key, void *value)
@@ -207,8 +208,8 @@ static bool outline_key_move(void *dst, void *src)
     }
     memcpy(dst, src, sizeof(OutlineHashKey));
     if (s->type == OUTLINE_DRAWING) {
-        d->u.drawing.text = strdup(s->u.drawing.text);
-        return d->u.drawing.text;
+        d->u.drawing.text.str = ass_copy_string(s->u.drawing.text);
+        return d->u.drawing.text.str;
     }
     if (s->type == OUTLINE_BORDER)
         ass_cache_inc_ref(s->u.border.outline);
@@ -226,7 +227,7 @@ static void outline_destruct(void *key, void *value)
         ass_cache_dec_ref(k->u.glyph.font);
         break;
     case OUTLINE_DRAWING:
-        free(k->u.drawing.text);
+        free((char *) k->u.drawing.text.str);
         break;
     case OUTLINE_BORDER:
         ass_cache_dec_ref(k->u.border.outline);

--- a/libass/ass_cache.c
+++ b/libass/ass_cache.c
@@ -38,31 +38,6 @@
 #include "ass_cache_template.h"
 
 // font cache
-static uint32_t font_hash(void *buf, uint32_t hval)
-{
-    ASS_FontDesc *desc = buf;
-    hval = fnv_32a_str(desc->family, hval);
-    hval = fnv_32a_buf(&desc->bold, sizeof(desc->bold), hval);
-    hval = fnv_32a_buf(&desc->italic, sizeof(desc->italic), hval);
-    hval = fnv_32a_buf(&desc->vertical, sizeof(desc->vertical), hval);
-    return hval;
-}
-
-static bool font_compare(void *key1, void *key2)
-{
-    ASS_FontDesc *a = key1;
-    ASS_FontDesc *b = key2;
-    if (strcmp(a->family, b->family) != 0)
-        return false;
-    if (a->bold != b->bold)
-        return false;
-    if (a->italic != b->italic)
-        return false;
-    if (a->vertical != b->vertical)
-        return false;
-    return true;
-}
-
 static bool font_key_move(void *dst, void *src)
 {
     ASS_FontDesc *k = src;

--- a/libass/ass_cache_template.h
+++ b/libass/ass_cache_template.h
@@ -5,7 +5,7 @@
 #define GENERIC(type, member) \
         type member;
 #define STRING(member) \
-        char *member;
+        ASS_StringView member;
 #define VECTOR(member) \
         ASS_Vector member;
 #define END(typedefnamename) \
@@ -22,7 +22,7 @@
 #define GENERIC(type, member) \
             a->member == b->member &&
 #define STRING(member) \
-            strcmp(a->member, b->member) == 0 &&
+            ass_string_equal(a->member, b->member) &&
 #define VECTOR(member) \
             a->member.x == b->member.x && a->member.y == b->member.y &&
 #define END(typedefname) \
@@ -38,7 +38,7 @@
 #define GENERIC(type, member) \
         hval = fnv_32a_buf(&p->member, sizeof(p->member), hval);
 #define STRING(member) \
-        hval = fnv_32a_str(p->member, hval);
+        hval = fnv_32a_buf(p->member.str, p->member.len, hval);
 #define VECTOR(member) GENERIC(, member.x); GENERIC(, member.y);
 #define END(typedefname) \
         return hval; \

--- a/libass/ass_cache_template.h
+++ b/libass/ass_cache_template.h
@@ -50,6 +50,13 @@
 
 
 
+START(font, ass_font_desc )
+    STRING(family)
+    GENERIC(unsigned, bold)
+    GENERIC(unsigned, italic)
+    GENERIC(int, vertical)  // @font vertical layout
+END(ASS_FontDesc)
+
 // describes an outline bitmap
 START(bitmap, bitmap_hash_key)
     GENERIC(OutlineHashValue *, outline)

--- a/libass/ass_font.c
+++ b/libass/ass_font.c
@@ -588,5 +588,5 @@ void ass_font_clear(ASS_Font *font)
         if (font->faces[i])
             FT_Done_Face(font->faces[i]);
     }
-    free(font->desc.family);
+    free((char *) font->desc.family.str);
 }

--- a/libass/ass_font.h
+++ b/libass/ass_font.h
@@ -25,7 +25,6 @@
 #include FT_OUTLINE_H
 
 typedef struct ass_font ASS_Font;
-typedef struct ass_font_desc ASS_FontDesc;
 
 #include "ass.h"
 #include "ass_types.h"
@@ -38,13 +37,6 @@ typedef struct ass_font_desc ASS_FontDesc;
 #define DECO_UNDERLINE     1
 #define DECO_STRIKETHROUGH 2
 #define DECO_ROTATE        4
-
-struct ass_font_desc {
-    char *family;
-    unsigned bold;
-    unsigned italic;
-    int vertical;               // @font vertical layout
-};
 
 struct ass_font {
     ASS_FontDesc desc;

--- a/libass/ass_fontselect.c
+++ b/libass/ass_fontselect.c
@@ -692,7 +692,7 @@ char *ass_font_select(ASS_FontSelector *priv, ASS_Library *library,
                       int *uid, ASS_FontStream *data, uint32_t code)
 {
     char *res = 0;
-    const char *family = font->desc.family;
+    const char *family = font->desc.family.str;  // always zero-terminated
     unsigned bold = font->desc.bold;
     unsigned italic = font->desc.italic;
     ASS_FontProvider *default_provider = priv->default_provider;

--- a/libass/ass_render.h
+++ b/libass/ass_render.h
@@ -131,7 +131,7 @@ typedef struct glyph_info {
     int glyph_index;
     hb_script_t script;
     double font_size;
-    char *drawing_text;
+    ASS_StringView drawing_text;
     int drawing_scale;
     int drawing_pbo;
     OutlineHashValue *outline;
@@ -239,7 +239,7 @@ typedef struct {
     double shadow_x;
     double shadow_y;
     double pbo;                 // drawing baseline offset
-    char *clip_drawing_text;
+    ASS_StringView clip_drawing_text;
 
     // used to store RenderContext.style when doing selective style overrides
     ASS_Style override_style_temp_storage;
@@ -262,7 +262,7 @@ typedef struct {
     int scroll_y0, scroll_y1;
 
     // face properties
-    char *family;
+    ASS_StringView family;
     unsigned bold;
     unsigned italic;
     int treat_family_as_pattern;

--- a/libass/ass_shaper.c
+++ b/libass/ass_shaper.c
@@ -665,7 +665,7 @@ static bool shape_harfbuzz(ASS_Shaper *shaper, GlyphInfo *glyphs, size_t len)
         glyphs[i].skip = true;
 
     for (i = 0; i < len; i++) {
-        if (glyphs[i].drawing_text) {
+        if (glyphs[i].drawing_text.str) {
             glyphs[i].skip = false;
             continue;
         }
@@ -805,7 +805,7 @@ void ass_shaper_find_runs(ASS_Shaper *shaper, ASS_Renderer *render_priv,
     // find appropriate fonts for the shape runs
     for (i = 0; i < len; i++) {
         GlyphInfo *info = glyphs + i;
-        if (!info->drawing_text) {
+        if (!info->drawing_text.str) {
             // set size and get glyph index
             ass_font_get_index(render_priv->fontselect, info->font,
                     info->symbol, &info->face_index, &info->glyph_index);

--- a/libass/ass_utils.h
+++ b/libass/ass_utils.h
@@ -52,6 +52,26 @@ int has_avx(void);
 int has_avx2(void);
 #endif
 
+typedef struct {
+    const char *str;
+    size_t len;
+} ASS_StringView;
+
+static inline char *ass_copy_string(ASS_StringView src)
+{
+    char *buf = malloc(src.len + 1);
+    if (buf) {
+        memcpy(buf, src.str, src.len);
+        buf[src.len] = '\0';
+    }
+    return buf;
+}
+
+static inline bool ass_string_equal(ASS_StringView str1, ASS_StringView str2)
+{
+    return str1.len == str2.len && !memcmp(str1.str, str2.str, str1.len);
+}
+
 #ifndef HAVE_STRNDUP
 char *ass_strndup(const char *s, size_t n);
 #define strndup ass_strndup
@@ -163,9 +183,9 @@ static inline int double_to_d22(double x)
 #define FNV1_32A_INIT 0x811c9dc5U
 #define FNV1_32A_PRIME 16777619U
 
-static inline uint32_t fnv_32a_buf(void *buf, size_t len, uint32_t hval)
+static inline uint32_t fnv_32a_buf(const void *buf, size_t len, uint32_t hval)
 {
-    unsigned char *bp = (unsigned char *) buf;
+    const uint8_t *bp = buf;
     size_t n = (len + 3) / 4;
 
     switch (len % 4) {
@@ -176,15 +196,6 @@ static inline uint32_t fnv_32a_buf(void *buf, size_t len, uint32_t hval)
                } while (--n > 0);
     }
 
-    return hval;
-}
-static inline uint32_t fnv_32a_str(const char *str, uint32_t hval)
-{
-    unsigned char *s = (unsigned char *) str;
-    while (*s) {
-        hval ^= *s++;
-        hval *= FNV1_32A_PRIME;
-    }
     return hval;
 }
 


### PR DESCRIPTION
I've removed most of strdups from rendering. Error handling should be simpler too.
There is a bunch of strdups in `ass.c` but that's impossible to remove without API change.

There is some concern that low-level parsing functions `mystrto*()` do not respect new string boundaries, but in our case we always have appropriate delimiter after string reference (`argto*()` rely on that too).