### PR TITLE
docs: fix simple typo, ouline -> outline

### DIFF
--- a/libass/ass_outline.h
+++ b/libass/ass_outline.h
@@ -83,7 +83,7 @@ typedef struct {
     char *segments;
 } ASS_Outline;
 
-// ouline point coordinates should always be in [-OUTLINE_MAX, +OUTLINE_MAX] range
+// outline point coordinates should always be in [-OUTLINE_MAX, +OUTLINE_MAX] range
 #define OUTLINE_MAX  (((int32_t) 1 << 28) - 1)
 // cubic spline splitting requires 8 * OUTLINE_MAX + 4 <= INT32_MAX
 


### PR DESCRIPTION
There is a small typo in libass/ass_outline.h.

Should read `outline` rather than `ouline`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md