### PR TITLE
Faster format line processing

### DIFF
--- a/libass/ass.c
+++ b/libass/ass.c
@@ -39,7 +39,7 @@
 #include "ass_shaper.h"
 #include "ass_string.h"
 
-#define ass_atof(STR) (ass_strtod((STR),NULL))
+#define ass_atof(STR) (ass_strtod((STR), NULL))
 
 static const ASS_FormatToken ass_style_format[] = {
     ASS_FMT_Name, ASS_FMT_FontName, ASS_FMT_FontSize, ASS_FMT_PrimaryColour,
@@ -262,7 +262,7 @@ static long long string2timecode(ASS_Library *library, char *p)
     return tm;
 }
 
-#define NEXT(str,token) \
+#define NEXT(str, token) \
     token = next_token(&str); \
     if (!token) break;
 
@@ -283,7 +283,7 @@ static long long string2timecode(ASS_Library *library, char *p)
         target->name = strdup(token); \
         break;
 
-#define TIMEVAL_ALTNAME(fieldname,formatname) \
+#define TIMEVAL_ALTNAME(fieldname, formatname) \
     case ASS_FMT_ ## formatname : \
         target->fieldname = string2timecode(track->library, token); \
         break;
@@ -293,14 +293,14 @@ static long long string2timecode(ASS_Library *library, char *p)
         target->name = lookup_style(track, token); \
         break;
 
-#define ANYVAL(name,func) \
+#define ANYVAL(name, func) \
     case ASS_FMT_ ## name : \
         target->name = func(token); \
         break;
 
-#define COLORVAL(name) ANYVAL(name,parse_color_header)
-#define INTVAL(name)   ANYVAL(name,atoi)
-#define FPVAL(name)    ANYVAL(name,ass_atof)
+#define COLORVAL(name) ANYVAL(name, parse_color_header)
+#define INTVAL(name)   ANYVAL(name, atoi)
+#define FPVAL(name)    ANYVAL(name, ass_atof)
 
 // skip spaces in str beforehand, or trim leading spaces afterwards
 static inline void advance_token_pos(const char **const str,
@@ -432,8 +432,8 @@ static int process_event_tail(ASS_Track *track, ASS_Event *event,
             INTVAL(MarginL)
             INTVAL(MarginR)
             INTVAL(MarginV)
-            TIMEVAL_ALTNAME(Start,Start)
-            TIMEVAL_ALTNAME(Duration,End)
+            TIMEVAL_ALTNAME(Start, Start)
+            TIMEVAL_ALTNAME(Duration, End)
             default:
                 //Nothing
                 break;
@@ -466,7 +466,7 @@ static int process_event_tail(ASS_Track *track, ASS_Event *event,
 #define PARSE_START_STR if (0) {
 #define PARSE_END_STR   }
 
-#define ANYVAL_STR(name,func) \
+#define ANYVAL_STR(name, func) \
     } else if (ass_strcasecmp(tname, #name) == 0) { \
         target->name = func(token);
 
@@ -478,9 +478,9 @@ static int process_event_tail(ASS_Track *track, ASS_Event *event,
             target->name = new_str; \
         }
 
-#define COLORVAL_STR(name) ANYVAL_STR(name,parse_color_header)
-#define INTVAL_STR(name) ANYVAL_STR(name,atoi)
-#define FPVAL_STR(name) ANYVAL_STR(name,ass_atof)
+#define COLORVAL_STR(name) ANYVAL_STR(name, parse_color_header)
+#define INTVAL_STR(name) ANYVAL_STR(name, atoi)
+#define FPVAL_STR(name) ANYVAL_STR(name, ass_atof)
 
 
 /**

--- a/libass/ass.c
+++ b/libass/ass.c
@@ -267,55 +267,6 @@ static long long string2timecode(ASS_Library *library, char *p)
     if (!token) break;
 
 
-#define ALIAS(alias,name) \
-        if (ass_strcasecmp(tname, #alias) == 0) {tname = #name;}
-
-/* One section started with PARSE_START and PARSE_END parses a single token
- * (contained in the variable named token) for the header indicated by the
- * variable tname. It does so by chaining a number of else-if statements, each
- * of which checks if the tname variable indicates that this header should be
- * parsed. The first parameter of the macro gives the name of the header.
- *
- * The string that is passed is in str. str is advanced to the next token if
- * a header could be parsed. The parsed results are stored in the variable
- * target, which has the type ASS_Style* or ASS_Event*.
- */
-#define PARSE_START if (0) {
-#define PARSE_END   }
-
-#define ANYVAL(name,func) \
-    } else if (ass_strcasecmp(tname, #name) == 0) { \
-        target->name = func(token);
-
-#define STRVAL(name) \
-    } else if (ass_strcasecmp(tname, #name) == 0) { \
-        char *new_str = strdup(token); \
-        if (new_str) { \
-            free(target->name); \
-            target->name = new_str; \
-        }
-
-#define STARREDSTRVAL(name) \
-    } else if (ass_strcasecmp(tname, #name) == 0) { \
-        while (*token == '*') ++token; \
-        char *new_str = strdup(token); \
-        if (new_str) { \
-            free(target->name); \
-            target->name = new_str; \
-        }
-
-#define COLORVAL(name) ANYVAL(name,parse_color_header)
-#define INTVAL(name) ANYVAL(name,atoi)
-#define FPVAL(name) ANYVAL(name,ass_atof)
-#define TIMEVAL(name) \
-    } else if (ass_strcasecmp(tname, #name) == 0) { \
-        target->name = string2timecode(track->library, token);
-
-#define STYLEVAL(name) \
-    } else if (ass_strcasecmp(tname, #name) == 0) { \
-        target->name = lookup_style(track, token);
-
-
 #define PARSE_START_TK switch (fmt->tokens[tokenpos]) {
 #define PARSE_END_TK   }
 
@@ -501,6 +452,37 @@ static int process_event_tail(ASS_Track *track, ASS_Event *event,
     return event->Text ? 0 : -1;
 }
 
+
+/* One section started with PARSE_START and PARSE_END parses a single token
+ * (contained in the variable named token) for the header indicated by the
+ * variable tname. It does so by chaining a number of else-if statements, each
+ * of which checks if the tname variable indicates that this header should be
+ * parsed. The first parameter of the macro gives the name of the header.
+ *
+ * The string that is passed is in str. str is advanced to the next token if
+ * a header could be parsed. The parsed results are stored in the variable
+ * target, which has the type ASS_Style* (or ASS_Event*).
+ */
+#define PARSE_START if (0) {
+#define PARSE_END   }
+
+#define ANYVAL(name,func) \
+    } else if (ass_strcasecmp(tname, #name) == 0) { \
+        target->name = func(token);
+
+#define STRVAL(name) \
+    } else if (ass_strcasecmp(tname, #name) == 0) { \
+        char *new_str = strdup(token); \
+        if (new_str) { \
+            free(target->name); \
+            target->name = new_str; \
+        }
+
+#define COLORVAL(name) ANYVAL(name,parse_color_header)
+#define INTVAL(name) ANYVAL(name,atoi)
+#define FPVAL(name) ANYVAL(name,ass_atof)
+
+
 /**
  * \brief Parse command line style overrides (--ass-force-style option)
  * \param track track to apply overrides to
@@ -584,6 +566,13 @@ void ass_process_force_style(ASS_Track *track)
             *dt = '.';
     }
 }
+
+#undef PARSE_START
+#undef PARSE_END
+#undef STRVAL
+#undef COLORVAL
+#undef FPVAL
+#undef INTVAL
 
 /**
  * \brief Parse the Style line

--- a/libass/ass.c
+++ b/libass/ass.c
@@ -694,20 +694,6 @@ static int process_style(ASS_Track *track, char *str)
     return 0;
 }
 
-static bool format_line_compare(const ASS_FormatToken *fmt1, size_t num1,
-                                const ASS_FormatToken *fmt2, size_t num2)
-{
-    if (num1 != num2)
-        return false;
-    for (size_t i = 0; i < num1; ++i) {
-        if (*fmt1 != *fmt2)
-            return false;
-        ++fmt1;
-        ++fmt2;
-    }
-    return true;
-}
-
 
 /**
  * \brief Set SBAS=1 if not set explicitly in case of custom format line
@@ -728,8 +714,8 @@ static void custom_format_line_compatibility(ASS_Track *const track,
                                              const ASS_FormatToken *std,
                                              size_t num_std)
 {
-    if (!(track->parser_priv->header_flags & SINFO_SCALEDBORDER)
-        && !format_line_compare(fmt, num_fmt, std, num_std)) {
+    if (!(track->parser_priv->header_flags & SINFO_SCALEDBORDER) &&
+            (num_std != num_fmt || memcmp(fmt, std, num_std * sizeof(*fmt)))) {
         ass_msg(track->library, MSGL_INFO,
                "Track has custom format line(s). "
                 "'ScaledBorderAndShadow' will default to 'yes'.");

--- a/libass/ass.c
+++ b/libass/ass.c
@@ -267,40 +267,40 @@ static long long string2timecode(ASS_Library *library, char *p)
     if (!token) break;
 
 
-#define PARSE_START_TK switch (fmt->tokens[tokenpos]) {
-#define PARSE_END_TK   }
+#define PARSE_START switch (fmt->tokens[tokenpos]) {
+#define PARSE_END   }
 
-#define STRVAL_TK(name) \
+#define STRVAL(name) \
     case ASS_FMT_ ## name : \
         free(target->name); \
         target->name = strdup(token); \
         break;
 
-#define STARREDSTRVAL_TK(name) \
+#define STARREDSTRVAL(name) \
     case ASS_FMT_ ## name : \
         while (*token == '*') ++token; \
         free(target->name); \
         target->name = strdup(token); \
         break;
 
-#define TIMEVAL_ALTNAME_TK(fieldname,formatname) \
+#define TIMEVAL_ALTNAME(fieldname,formatname) \
     case ASS_FMT_ ## formatname : \
         target->fieldname = string2timecode(track->library, token); \
         break;
 
-#define STYLEVAL_TK(name) \
+#define STYLEVAL(name) \
     case ASS_FMT_ ## name : \
         target->name = lookup_style(track, token); \
         break;
 
-#define ANYVAL_TK(name,func) \
+#define ANYVAL(name,func) \
     case ASS_FMT_ ## name : \
         target->name = func(token); \
         break;
 
-#define COLORVAL_TK(name) ANYVAL_TK(name,parse_color_header)
-#define INTVAL_TK(name)   ANYVAL_TK(name,atoi)
-#define FPVAL_TK(name)    ANYVAL_TK(name,ass_atof)
+#define COLORVAL(name) ANYVAL(name,parse_color_header)
+#define INTVAL(name)   ANYVAL(name,atoi)
+#define FPVAL(name)    ANYVAL(name,ass_atof)
 
 // skip spaces in str beforehand, or trim leading spaces afterwards
 static inline void advance_token_pos(const char **const str,
@@ -424,20 +424,20 @@ static int process_event_tail(ASS_Track *track, ASS_Event *event,
     for (tokenpos = n_ignored; tokenpos + 1 < fmt->n_tokens; ++tokenpos) {
         NEXT(p, token);
 
-        PARSE_START_TK
-            INTVAL_TK(Layer)
-            STYLEVAL_TK(Style)
-            STRVAL_TK(Name)
-            STRVAL_TK(Effect)
-            INTVAL_TK(MarginL)
-            INTVAL_TK(MarginR)
-            INTVAL_TK(MarginV)
-            TIMEVAL_ALTNAME_TK(Start,Start)
-            TIMEVAL_ALTNAME_TK(Duration,End)
+        PARSE_START
+            INTVAL(Layer)
+            STYLEVAL(Style)
+            STRVAL(Name)
+            STRVAL(Effect)
+            INTVAL(MarginL)
+            INTVAL(MarginR)
+            INTVAL(MarginV)
+            TIMEVAL_ALTNAME(Start,Start)
+            TIMEVAL_ALTNAME(Duration,End)
             default:
                 //Nothing
                 break;
-        PARSE_END_TK
+        PARSE_END
     }
     if (tokenpos != fmt->n_tokens - 1)
         return 1;
@@ -463,14 +463,14 @@ static int process_event_tail(ASS_Track *track, ASS_Event *event,
  * a header could be parsed. The parsed results are stored in the variable
  * target, which has the type ASS_Style* (or ASS_Event*).
  */
-#define PARSE_START if (0) {
-#define PARSE_END   }
+#define PARSE_START_STR if (0) {
+#define PARSE_END_STR   }
 
-#define ANYVAL(name,func) \
+#define ANYVAL_STR(name,func) \
     } else if (ass_strcasecmp(tname, #name) == 0) { \
         target->name = func(token);
 
-#define STRVAL(name) \
+#define STRVAL_STR(name) \
     } else if (ass_strcasecmp(tname, #name) == 0) { \
         char *new_str = strdup(token); \
         if (new_str) { \
@@ -478,9 +478,9 @@ static int process_event_tail(ASS_Track *track, ASS_Event *event,
             target->name = new_str; \
         }
 
-#define COLORVAL(name) ANYVAL(name,parse_color_header)
-#define INTVAL(name) ANYVAL(name,atoi)
-#define FPVAL(name) ANYVAL(name,ass_atof)
+#define COLORVAL_STR(name) ANYVAL_STR(name,parse_color_header)
+#define INTVAL_STR(name) ANYVAL_STR(name,atoi)
+#define FPVAL_STR(name) ANYVAL_STR(name,ass_atof)
 
 
 /**
@@ -533,32 +533,32 @@ void ass_process_force_style(ASS_Track *track)
             if (style == NULL
                 || ass_strcasecmp(track->styles[sid].Name, style) == 0) {
                 target = track->styles + sid;
-                PARSE_START
-                    STRVAL(FontName)
-                    COLORVAL(PrimaryColour)
-                    COLORVAL(SecondaryColour)
-                    COLORVAL(OutlineColour)
-                    COLORVAL(BackColour)
-                    FPVAL(FontSize)
-                    INTVAL(Bold)
-                    INTVAL(Italic)
-                    INTVAL(Underline)
-                    INTVAL(StrikeOut)
-                    FPVAL(Spacing)
-                    FPVAL(Angle)
-                    INTVAL(BorderStyle)
-                    INTVAL(Alignment)
-                    INTVAL(Justify)
-                    INTVAL(MarginL)
-                    INTVAL(MarginR)
-                    INTVAL(MarginV)
-                    INTVAL(Encoding)
-                    FPVAL(ScaleX)
-                    FPVAL(ScaleY)
-                    FPVAL(Outline)
-                    FPVAL(Shadow)
-                    FPVAL(Blur)
-                PARSE_END
+                PARSE_START_STR
+                    STRVAL_STR(FontName)
+                    COLORVAL_STR(PrimaryColour)
+                    COLORVAL_STR(SecondaryColour)
+                    COLORVAL_STR(OutlineColour)
+                    COLORVAL_STR(BackColour)
+                    FPVAL_STR(FontSize)
+                    INTVAL_STR(Bold)
+                    INTVAL_STR(Italic)
+                    INTVAL_STR(Underline)
+                    INTVAL_STR(StrikeOut)
+                    FPVAL_STR(Spacing)
+                    FPVAL_STR(Angle)
+                    INTVAL_STR(BorderStyle)
+                    INTVAL_STR(Alignment)
+                    INTVAL_STR(Justify)
+                    INTVAL_STR(MarginL)
+                    INTVAL_STR(MarginR)
+                    INTVAL_STR(MarginV)
+                    INTVAL_STR(Encoding)
+                    FPVAL_STR(ScaleX)
+                    FPVAL_STR(ScaleY)
+                    FPVAL_STR(Outline)
+                    FPVAL_STR(Shadow)
+                    FPVAL_STR(Blur)
+                PARSE_END_STR
             }
         }
         *eq = '=';
@@ -567,12 +567,12 @@ void ass_process_force_style(ASS_Track *track)
     }
 }
 
-#undef PARSE_START
-#undef PARSE_END
-#undef STRVAL
-#undef COLORVAL
-#undef FPVAL
-#undef INTVAL
+#undef PARSE_START_STR
+#undef PARSE_END_STR
+#undef STRVAL_STR
+#undef COLORVAL_STR
+#undef FPVAL_STR
+#undef INTVAL_STR
 
 /**
  * \brief Parse the Style line
@@ -619,34 +619,34 @@ static int process_style(ASS_Track *track, char *str)
     for (tokenpos = 0; tokenpos < fmt->n_tokens; ++tokenpos) {
         NEXT(p, token); //breaks if no more tokens
 
-        PARSE_START_TK
-            STARREDSTRVAL_TK(Name)
-            STRVAL_TK(FontName)
-            COLORVAL_TK(PrimaryColour)
-            COLORVAL_TK(SecondaryColour)
-            COLORVAL_TK(OutlineColour) // TertiaryColor
-            COLORVAL_TK(BackColour)
-            FPVAL_TK(FontSize)
-            INTVAL_TK(Bold)
-            INTVAL_TK(Italic)
-            INTVAL_TK(Underline)
-            INTVAL_TK(StrikeOut)
-            FPVAL_TK(Spacing)
-            FPVAL_TK(Angle)
-            INTVAL_TK(BorderStyle)
-            INTVAL_TK(Alignment)
-            INTVAL_TK(MarginL)
-            INTVAL_TK(MarginR)
-            INTVAL_TK(MarginV)
-            INTVAL_TK(Encoding)
-            FPVAL_TK(ScaleX)
-            FPVAL_TK(ScaleY)
-            FPVAL_TK(Outline)
-            FPVAL_TK(Shadow)
+        PARSE_START
+            STARREDSTRVAL(Name)
+            STRVAL(FontName)
+            COLORVAL(PrimaryColour)
+            COLORVAL(SecondaryColour)
+            COLORVAL(OutlineColour) // TertiaryColor
+            COLORVAL(BackColour)
+            FPVAL(FontSize)
+            INTVAL(Bold)
+            INTVAL(Italic)
+            INTVAL(Underline)
+            INTVAL(StrikeOut)
+            FPVAL(Spacing)
+            FPVAL(Angle)
+            INTVAL(BorderStyle)
+            INTVAL(Alignment)
+            INTVAL(MarginL)
+            INTVAL(MarginR)
+            INTVAL(MarginV)
+            INTVAL(Encoding)
+            FPVAL(ScaleX)
+            FPVAL(ScaleY)
+            FPVAL(Outline)
+            FPVAL(Shadow)
             default:
                 //Nothing
                 break;
-        PARSE_END_TK
+        PARSE_END
     }
     if (tokenpos != fmt->n_tokens) {
         ass_free_style(track, sid);

--- a/libass/ass_priv.h
+++ b/libass/ass_priv.h
@@ -46,6 +46,55 @@ typedef enum {
     // max 32 enumerators
 } ScriptInfo;
 
+typedef enum ASS_FormatToken {
+    // cases must match field names in ASS_Track
+    ASS_FMT_UNKNOWN,
+    ASS_FMT_Name,            // ASS Style, ASS Event, SSA Style, SSA Event
+    ASS_FMT_FontName,        // ASS Style, SSA Style
+    ASS_FMT_FontSize,        // ASS Style, SSA Style
+    ASS_FMT_PrimaryColour,   // ASS Style, SSA Style
+    ASS_FMT_SecondaryColour, // ASS Style, SSA Style
+    ASS_FMT_OutlineColour,   // ASS Style
+    ASS_FMT_BackColour,      // ASS Style, SSA Style
+    ASS_FMT_Bold,            // ASS Style, SSA Style
+    ASS_FMT_Italic,          // ASS Style, SSA Style
+    ASS_FMT_Underline,       // ASS Style
+    ASS_FMT_StrikeOut,       // ASS Style
+    ASS_FMT_ScaleX,          // ASS Style
+    ASS_FMT_ScaleY,          // ASS Style
+    ASS_FMT_Spacing,         // ASS Style
+    ASS_FMT_Angle,           // ASS Style
+    ASS_FMT_BorderStyle,     // ASS Style, SSA Style
+    ASS_FMT_Outline,         // ASS Style, SSA Style
+    ASS_FMT_Shadow,          // ASS Style, SSA Style
+    ASS_FMT_Alignment,       // ASS Style, SSA Style
+    ASS_FMT_MarginL,         // ASS Style, ASS Event, SSA Style, SSA Event
+    ASS_FMT_MarginR,         // ASS Style, ASS Event, SSA Style, SSA Event
+    ASS_FMT_MarginV,         // ASS Style, ASS Event, SSA Style, SSA Event
+    ASS_FMT_Encoding,        // ASS Style, SSA Style
+    ASS_FMT_Layer,           // ASS Event
+    ASS_FMT_Start,           // ASS Event, SSA Event
+    ASS_FMT_End,             // ASS Event, SSA Event
+    ASS_FMT_Style,           // ASS Event, SSA Event
+    ASS_FMT_Effect,          // ASS Event, SSA Event
+    ASS_FMT_Text,            // ASS Event, SSA Event
+    // SSA exclusive (currently ignored)
+    ASS_FMT_TertiaryColour,  // SSA Style
+    ASS_FMT_AlphaLevel,      // SSA Style
+    ASS_FMT_Marked,          // SSA Event
+    // TODO: check v4++-FormatToken's actual in-file names
+    ASS_FMT_RelativeTo,      // v4++ Extension (not sure what RelativeTo is supposed to do)
+    ASS_FMT_MarginT,         // v4++ Extension (margin top;    replaces MarginV)
+    ASS_FMT_MarginB          // v4++ Extension (margin bottom; replaces MarginV)
+} ASS_FormatToken;
+
+typedef struct {
+    size_t n_tokens;
+    size_t max_tokens;
+    ASS_FormatToken *tokens;
+    char *string; // to check for changes in public track fields
+} ASS_FormatLine;
+
 struct parser_priv {
     ParserState state;
     char *fontname;
@@ -64,6 +113,9 @@ struct parser_priv {
 #ifdef USE_FRIBIDI_EX_API
     bool bidi_brackets;
 #endif
+
+    ASS_FormatLine style_format;
+    ASS_FormatLine event_format;
 };
 
 #endif /* LIBASS_PRIV_H */


### PR DESCRIPTION
This is an alternative to #35 .
Unlike #35 however this approach does not special case any particular Format line content and order and applies to all parsing entries, not just ass_process_chunk. This is done by tokenising the format line when it's first encountered. Notably this also removes strdup as a failure source for format lines specifically, ASS_track's format strings are still strduped, but they are not used anywhere internally and are only retained for ABI compatibility.

**Performance:**
I'm using callgrind's cost estimate for performance measuring.

In general the (inclusive) cost reduction of only `process_text` was usually around 20-25% and for `process_event_tail` around 25-30%.  
The _total_ cost reduction however is lower and varies much more depending on the file. It never causes performance regressions.

For basic dialogue the gains are utterly irrelevant, while if there are many events the impact is stronger — but if those events are costly enough the relative gains stay low. Here are some benchmarks: `event(s)PerFrame` files are synthetic and use very cheap events, while all others are taken from real-world files.

```
Old data removed to avoid confusion (Still available in edit history)
Below analysis still refers to old data samples though.
```

[Synthetic test files](https://github.com/libass/libass/files/6039033/469_syntest.zip)

`dialogue` and `1eventPerFrame` are examples of few (but cheap) events per Frame.

`fxkara_1` and `mpv-7712` have many events in total but the cost of rendering the events is more outweighs this.

The synthetic tests as well as the `zoinks-neptunia` sample, do have many cheap enough events for the gains to become noticeable. In `zoink-neptunia`'s case a frame-by-frame animated logo consisting of around 1000 ASS-drawings (each in its own Dialogue-event) is responsible for this.

`YuruCamp2_02_rock` also uses animated multiple ASS-Drawings, but unlike `zoinks-neptunia` it's not animated frame by frame but split into section which are each animated via tags *(epf switches between ~80 and ~700 sections)*.  Also many of them use much more drawing commands then the ones from `zoink-neptunia` making them more expensive individually. If we limit the sample to a ~700epf section, the relative overall gain rises to 1.2%.


~~Apart from performance, in it's current form, this also removes `strdup` as a failure source for format lines for valid ASS files.~~


**Note:** Sections about API-change and RFC parts removed (see history)