### PR TITLE
ass_render: fix aliasing when 1a=0 but 3a>0

### DIFF
--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -2012,6 +2012,7 @@ static bool parse_events(ASS_Renderer *render_priv, ASS_Event *event)
         info->frz = render_priv->state.frz;
         info->fax = render_priv->state.fax;
         info->fay = render_priv->state.fay;
+        info->fade = render_priv->state.fade;
 
         info->hspacing_scaled = double_to_d6(info->hspacing *
                 render_priv->font_scale * info->scale_x);
@@ -2325,7 +2326,7 @@ static void render_and_combine_glyphs(ASS_Renderer *render_priv,
             if ((flags & FILTER_NONZERO_BORDER &&
                  info->a_pre_fade[0] == 0 &&
                  info->a_pre_fade[1] == 0 &&
-                 _a(info->c[2]) == 0) ||
+                 info->fade == 0) ||
                 info->border_style == 3)
                 flags |= FILTER_FILL_IN_BORDER;
 

--- a/libass/ass_render.h
+++ b/libass/ass_render.h
@@ -168,6 +168,7 @@ typedef struct glyph_info {
     unsigned italic;
     unsigned bold;
     int flags;
+    int fade;
 
     int shape_run_id;
 


### PR DESCRIPTION
I'd misunderstood the vsfilter code in 12cf524b831289cf67ba3432264fa01a69c3bbb5 and written something that's very close, but not quite identical, to what it does. This should get us the rest of the way there.