### PR TITLE
Improve ISO-C compatability

### DIFF
--- a/libass/ass_blur.c
+++ b/libass/ass_blur.c
@@ -407,7 +407,7 @@ static void calc_gauss(double *res, int n, double r2)
 {
     double alpha = 0.5 / r2;
     double mul = exp(-alpha), mul2 = mul * mul;
-    double cur = sqrt(alpha / M_PI);
+    double cur = sqrt(alpha / ASS_PI);
 
     res[0] = cur;
     cur *= mul;

--- a/libass/ass_compat.h
+++ b/libass/ass_compat.h
@@ -26,4 +26,15 @@
 #define inline __inline
 #endif
 
+#ifndef HAVE_STRDUP
+char *ass_strdup_fallback(const char *s); // definition in ass_utils.c
+#define strdup ass_strdup_fallback
+#endif
+
+#ifndef HAVE_STRNDUP
+#include <stddef.h>
+char *ass_strndup_fallback(const char *s, size_t n); // definition in ass_utils.c
+#define strndup ass_strndup_fallback
+#endif
+
 #endif                          /* LIBASS_COMPAT_H */

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -1246,9 +1246,9 @@ size_t ass_outline_construct(void *key, void *value, void *priv)
 static void calc_transform_matrix(ASS_Renderer *render_priv,
                                   GlyphInfo *info, double m[3][3])
 {
-    double frx = M_PI / 180 * info->frx;
-    double fry = M_PI / 180 * info->fry;
-    double frz = M_PI / 180 * info->frz;
+    double frx = ASS_PI / 180 * info->frx;
+    double fry = ASS_PI / 180 * info->fry;
+    double frz = ASS_PI / 180 * info->frz;
 
     double sx = -sin(frx), cx = cos(frx);
     double sy =  sin(fry), cy = cos(fry);

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -511,7 +511,7 @@ static bool quantize_transform(double m[3][3], ASS_Vector *pos,
     //  = m_zx * (x + sign(m_zx) * dx) + m_zy * (y + sign(m_zy) * dy) + z0.
 
     // D(f)--absolute value of error in quantity f
-    // as function of error in matrix coefficients, i. e. D(m_??).
+    // as function of error in matrix coefficients, i. e. D(m_ij) for i, j from {x, y, z}.
     // Error in constant is zero, i. e. D(dx) = D(dy) = D(z0) = 0.
     // In the following calculation errors are considered small
     // and second- and higher-order terms are dropped.
@@ -536,7 +536,7 @@ static bool quantize_transform(double m[3][3], ASS_Vector *pos,
 
     // To estimate acceptable error in matrix coefficient
     // set error in all other coefficients to zero and solve system
-    // D(x_out) <= ACCURACY & D(y_out) <= ACCURACY for desired D(m_??).
+    // D(x_out) <= ACCURACY & D(y_out) <= ACCURACY for desired D(m_ij).
     // ACCURACY here is some part of total error, i. e. ACCURACY ~ POSITION_PRECISION.
     // Note that POSITION_PRECISION isn't total error, it's convenient constant.
     // True error can be up to several POSITION_PRECISION.
@@ -1400,7 +1400,7 @@ get_bitmap_glyph(ASS_Renderer *render_priv, GlyphInfo *info,
 
         // Notation from quantize_transform().
         // Note that goal here is to estimate acceptable error for stroking, i. e. D(x) and D(y).
-        // Matrix coefficients are constants now, so D(m_??) = 0.
+        // Matrix coefficients are constants now, so D(m_ij) = 0 for all i, j from {x, y, z}.
 
         // D(z) <= |m_zx| * D(x) + |m_zy| * D(y),
         // D(x_out) = D((m_xx * x + m_xy * y) / z)

--- a/libass/ass_utils.c
+++ b/libass/ass_utils.c
@@ -66,8 +66,20 @@ int has_avx2(void)
 
 #endif // ASM
 
+// Fallbacks
+#ifndef HAVE_STRDUP
+char *ass_strdup_fallback(const char *str)
+{
+    size_t len    = strlen(str) + 1;
+    char *new_str = malloc(len);
+    if (new_str)
+        memcpy(new_str, str, len);
+    return new_str;
+}
+#endif
+
 #ifndef HAVE_STRNDUP
-char *ass_strndup(const char *s, size_t n)
+char *ass_strndup_fallback(const char *s, size_t n)
 {
     char *end = memchr(s, 0, n);
     size_t len = end ? end - s : n;

--- a/libass/ass_utils.h
+++ b/libass/ass_utils.h
@@ -72,11 +72,6 @@ static inline bool ass_string_equal(ASS_StringView str1, ASS_StringView str2)
     return str1.len == str2.len && !memcmp(str1.str, str2.str, str1.len);
 }
 
-#ifndef HAVE_STRNDUP
-char *ass_strndup(const char *s, size_t n);
-#define strndup ass_strndup
-#endif
-
 void *ass_aligned_alloc(size_t alignment, size_t size, bool zero);
 void ass_aligned_free(void *ptr);
 

--- a/libass/ass_utils.h
+++ b/libass/ass_utils.h
@@ -46,6 +46,8 @@
 #define FFMIN(a,b) ((a) > (b) ? (b) : (a))
 #define FFMINMAX(c,a,b) FFMIN(FFMAX(c, a), b)
 
+#define ASS_PI 3.14159265358979323846
+
 #if (defined(__i386__) || defined(__x86_64__)) && CONFIG_ASM
 int has_sse2(void);
 int has_avx(void);


### PR DESCRIPTION
Does not actually change our target to ISO C99 + POSIX `str(n)dup`.  
~~I'm not sure about putting `ASS_PI` into `ass_compat.h`, but couldn't come up with a better place for it.~~ `ASS_PI` has been moved to `ass_utils.h`