### PR TITLE
bitmap: subtract fill from stroke without dividing

### DIFF
--- a/libass/ass_bitmap.c
+++ b/libass/ass_bitmap.c
@@ -211,7 +211,7 @@ void fix_outline(Bitmap *bm_g, Bitmap *bm_o)
 
     for (int32_t y = 0; y < b - t; y++) {
         for (int32_t x = 0; x < r - l; x++)
-            o[x] = (o[x] > g[x]) ? o[x] - (g[x] / 2) : 0;
+            o[x] = (o[x] > g[x]) ? o[x] - g[x] : 0;
         g += bm_g->stride;
         o += bm_o->stride;
     }


### PR DESCRIPTION
This is what vsfilter does, and looks better on most inputs.
I'm guessing we used to do it differently because it looked better before 12cf524b831289cf67ba3432264fa01a69c3bbb5 and 706f23d84180d36538c467e20b461677781cab16.

Test script; improvement most noticeable on the triangle drawing in the top-left:
[border_aliasing_with_1aFF.txt](https://github.com/libass/libass/files/6063280/border_aliasing_with_1aFF.txt)
VSFilter:
![image](https://user-images.githubusercontent.com/819638/109537973-2bdbdb80-7a85-11eb-87ef-b4a2309f321e.png)
Before:
![image](https://user-images.githubusercontent.com/819638/109533218-9b4ecc80-7a7f-11eb-93da-2cd618099b0f.png)
After:
![image](https://user-images.githubusercontent.com/819638/109533259-a570cb00-7a7f-11eb-9630-51d582a43afb.png)

This is a case multiple people have pointed out to me as problematic in libass. This _does_ seem to slightly worsen another related case, but that I'm not super worried about because it's comparatively uncommon and the difference isn't huge:
[border_aliasing_with_1aFF-2.txt](https://github.com/libass/libass/files/6063279/border_aliasing_with_1aFF-2.txt)
VSFilter:
![image](https://user-images.githubusercontent.com/819638/109533931-62fbbe00-7a80-11eb-9291-ff4dd9b95d6d.png)
Before:
![image](https://user-images.githubusercontent.com/819638/109533948-698a3580-7a80-11eb-990b-03bd28447910.png)
After:
![image](https://user-images.githubusercontent.com/819638/109533968-6e4ee980-7a80-11eb-8ef6-60fc130bc3dc.png)

In the previous version, the aliasing here was extremely subtle (but present, and thus not matching vsfilter); with this patch it's a bit more noticeable. Somehow, vsfilter manages not to visibly alias on this edge at all; might have something to do with the way it does the actual drawing? Maybe a rounding thing, somehow? I'm not sure; definitely worth looking into.