### PR TITLE
ass_render: Break at last position if no space was seen

### DIFF
--- a/libass/ass.c
+++ b/libass/ass.c
@@ -1524,7 +1524,7 @@ static const uint64_t supported_features =
 #ifdef USE_FRIBIDI_EX_API
     1LL << ASS_FEATURE_BIDI_BRACKETS |
 #endif
-    0;
+    1LL << ASS_FEATURE_FORCE_WRAP_ON_OVERFLOW;
 
 int ass_track_set_feature(ASS_Track *track, ASS_Feature feature, int enable)
 {

--- a/libass/ass.h
+++ b/libass/ass.h
@@ -572,6 +572,15 @@ ASS_Track *ass_new_track(ASS_Library *);
 int ass_track_set_feature(ASS_Track *track, ASS_Feature feature, int enable);
 
 /**
+ * \brief Check if a feature is enabled
+ * \param track track
+ * \param feature the specific feature to check the state of
+ * \return 0 if disabled, a positive integer with feature-dependent meaning if
+ * enabled, -1 if feature is unknown
+ */
+int ass_track_get_feature_state(ASS_Track *track, ASS_Feature feature);
+
+/**
  * \brief Deallocate track and all its child objects (styles and events).
  * \param track track to deallocate or NULL
  */

--- a/libass/ass.h
+++ b/libass/ass.h
@@ -24,7 +24,7 @@
 #include <stdarg.h>
 #include "ass_types.h"
 
-#define LIBASS_VERSION 0x01500000
+#define LIBASS_VERSION 0x01500001
 
 #ifdef __cplusplus
 extern "C" {
@@ -237,6 +237,14 @@ typedef enum {
      * may return -1) if libass was compiled against old FriBidi.
      */
     ASS_FEATURE_BIDI_BRACKETS,
+
+    /**
+     * If no explicit ("\n") or implicit (" ") wrap point is found, wrap at the
+     * last seen character when doing smart wrap.
+     *
+     * Has no effect if wrap_mode is 2.
+     */
+    ASS_FEATURE_FORCE_WRAP_ON_OVERFLOW,
 
     // New enum values can be added here in new ABI-compatible library releases.
 } ASS_Feature;

--- a/libass/ass_priv.h
+++ b/libass/ass_priv.h
@@ -61,9 +61,8 @@ struct parser_priv {
     // tracks [Script Info] headers set by the script
     uint32_t header_flags;
 
-#ifdef USE_FRIBIDI_EX_API
-    bool bidi_brackets;
-#endif
+    // Enabled ASS_Feature flags
+    uint32_t features;
 };
 
 #endif /* LIBASS_PRIV_H */

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -2858,7 +2858,7 @@ ass_start_frame(ASS_Renderer *render_priv, ASS_Track *track,
     ass_shaper_set_level(render_priv->shaper, render_priv->settings.shaper);
 #ifdef USE_FRIBIDI_EX_API
     ass_shaper_set_bidi_brackets(render_priv->shaper,
-            track->parser_priv->bidi_brackets);
+            ass_track_get_feature_state(track, ASS_FEATURE_BIDI_BRACKETS));
 #endif
 
     // PAR correction

--- a/libass/libass.sym
+++ b/libass/libass.sym
@@ -44,3 +44,4 @@ ass_set_selective_style_override_enabled
 ass_set_selective_style_override
 ass_set_check_readorder
 ass_track_set_feature
+ass_track_get_feature_state


### PR DESCRIPTION
It's pretty common (in Chinese/Japanese/Korean especially) to not have any spaces to split on. Currently, these cases simply overflow the render area.

If this happens, try a last ditch attempt to wrap at the last character seen. This dramatically improves the usability of long subtitles with no clear break point.

Compared to https://github.com/libass/libass/pull/372, this pull request is much simpler (but complementary): we just split in any case where we will overflow the buffer as a last resort. Cases like https://github.com/mpv-player/mpv/issues/8115 demonstrate demand for this.

Example previous issues which show demand for this behaviour:

- https://github.com/mpv-player/mpv/issues/8115
- https://github.com/mpv-player/mpv/issues/2203
- https://github.com/libass/libass/issues/348
- https://github.com/libass/libass/issues/360

This PR also contains a change to how we do feature enumeration, in order to better support ASS_FEATURE_INCOMPATIBLE_EXTENSIONS as the feature list grows.