### PR TITLE
ASS Feature: WRAP_UNICODE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -30,6 +30,8 @@ AC_ARG_ENABLE([directwrite], AS_HELP_STRING([--disable-directwrite],
     [disable DirectWrite support (Windows only) @<:@default=check@:>@]))
 AC_ARG_ENABLE([coretext], AS_HELP_STRING([--disable-coretext],
     [disable CoreText support (OSX only) @<:@default=check@:>@]))
+AC_ARG_ENABLE([libunibreak], AS_HELP_STRING([--disable-libunibreak],
+    [disable libunibreak support @<:@default=check@:>@]))
 AC_ARG_ENABLE([require-system-font-provider], AS_HELP_STRING([--disable-require-system-font-provider],
     [allow compilation even if no system font provider was found @<:@default=enabled:>@]))
 AC_ARG_ENABLE([asm], AS_HELP_STRING([--disable-asm],
@@ -101,6 +103,19 @@ AS_IF([test "x$enable_test" = xyes || test "x$enable_compare" = xyes], [
         CFLAGS="$CFLAGS $LIBPNG_CFLAGS"
         AC_DEFINE(CONFIG_LIBPNG, 1, [found libpng via pkg-config])
         libpng=true
+    ])
+])
+
+AS_IF([test "x$enable_libunibreak" != xno], [
+    PKG_CHECK_MODULES([LIBUNIBREAK], [libunibreak >= 1.1], [
+        pkg_requires="libunibreak >= 1.1, ${pkg_requires}"
+        CFLAGS="$CFLAGS $LIBUNIBREAK_CFLAGS"
+        LIBS="$LIBS $LIBUNIBREAK_LIBS"
+        AC_DEFINE(CONFIG_UNIBREAK, 1, [found libunibreak via pkg-config])
+    ], [
+        AS_IF([test "x$enable_libunibreak" = xyes], [
+            AC_MSG_ERROR([libunibreak support was requested, but it was not found.])
+        ])
     ])
 ])
 

--- a/libass/ass.c
+++ b/libass/ass.c
@@ -1546,6 +1546,9 @@ int ass_track_set_feature(ASS_Track *track, ASS_Feature feature, int enable)
 #ifdef USE_FRIBIDI_EX_API
         FEATURE_MASK(ASS_FEATURE_BIDI_BRACKETS) |
 #endif
+#ifdef CONFIG_UNIBREAK
+        FEATURE_MASK(ASS_FEATURE_WRAP_UNICODE) |
+#endif
         FEATURE_MASK(ASS_FEATURE_WHOLE_TEXT_LAYOUT) |
         0;
     uint32_t requested = 0;

--- a/libass/ass.h
+++ b/libass/ass.h
@@ -24,7 +24,7 @@
 #include <stdarg.h>
 #include "ass_types.h"
 
-#define LIBASS_VERSION 0x01600000
+#define LIBASS_VERSION 0x01600010
 
 #ifdef __cplusplus
 extern "C" {
@@ -265,6 +265,19 @@ typedef enum {
      * events to be always processed as if this feature is enabled.
      */
     ASS_FEATURE_WHOLE_TEXT_LAYOUT,
+
+    /**
+     * Break lines according to the Unicode Line Breaking Algorithm.
+     * If the track language is set, some additional language-specific tweaks
+     * may be applied. Setting this enables more breaking opportunities
+     * compared to classic ASS. However, it is still possible for long words
+     * without breaking opportunities to cause overfull lines.
+     * This is incompatible with VSFilter and disabled by default.
+     *
+     * This feature may be unavailable at runtime if
+     * libass was compiled without libunibreak support.
+     */
+    ASS_FEATURE_WRAP_UNICODE,
 
     // New enum values can be added here in new ABI-compatible library releases.
 } ASS_Feature;

--- a/libass/ass_library.c
+++ b/libass/ass_library.c
@@ -24,6 +24,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdarg.h>
+#ifdef CONFIG_UNIBREAK
+#include <linebreak.h>
+#endif
 
 #include "ass.h"
 #include "ass_library.h"
@@ -44,6 +47,10 @@ ASS_Library *ass_library_init(void)
     ASS_Library* lib = calloc(1, sizeof(*lib));
     if (lib)
         lib->msg_callback = ass_msg_handler;
+    #ifdef CONFIG_UNIBREAK
+    // libunibreak works without, but its docs suggest this improves performance
+    init_linebreak();
+    #endif
     return lib;
 }
 

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -1759,6 +1759,7 @@ wrap_lines_rebalance(ASS_Renderer *render_priv, double max_text_width, char *uni
                     if (DIFF(l1_new, l2_new) < DIFF(l1, l2)) {
                         w->linebreak = 1;
                         s2->linebreak = 0;
+                        s2 = w;
                         exit = 0;
                     }
                 }

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -1703,7 +1703,7 @@ wrap_lines_naive(ASS_Renderer *render_priv, double max_text_width, char *unibrks
 
 /*
  * Shift soft linebreaks to balance out line lengths
- * May remove but never add linebreaks
+ * Does not change the linebreak count
  * FIXME: implement style 0 and 3 correctly
  */
 static void
@@ -1742,6 +1742,8 @@ wrap_lines_rebalance(ASS_Renderer *render_priv, double max_text_width, char *uni
                     }
                     if (w->symbol == ' ')
                         ++w;
+                    if (w == s1)
+                        continue; // Merging linebreaks is never beneficial
 
                     l1 = d6_to_double(((s2 - 1)->bbox.x_max + (s2 - 1)->pos.x) -
                         (s1->bbox.x_min + s1->pos.x));
@@ -1755,10 +1757,7 @@ wrap_lines_rebalance(ASS_Renderer *render_priv, double max_text_width, char *uni
                         (w->bbox.x_min + w->pos.x));
 
                     if (DIFF(l1_new, l2_new) < DIFF(l1, l2)) {
-                        if (w->linebreak || w == text_info->glyphs)
-                            text_info->n_lines--;
-                        if (w != text_info->glyphs)
-                            w->linebreak = 1;
+                        w->linebreak = 1;
                         s2->linebreak = 0;
                         exit = 0;
                     }

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -1744,6 +1744,7 @@ wrap_lines_rebalance(ASS_Renderer *render_priv, double max_text_width, char *uni
                     // Find last word of line and trim surrounding whitespace before measuring
                     // (whitespace ' ' will also get trimmed in rendering)
                     GlyphInfo *w = rewind_trailing_spaces(s1, s2);
+                    GlyphInfo *e1_old = w;
                     while ((w > s1) && (!ALLOWBREAK(w->symbol, w - text_info->glyphs))) {
                         --w;
                     }
@@ -1756,15 +1757,19 @@ wrap_lines_rebalance(ASS_Renderer *render_priv, double max_text_width, char *uni
                     if (w == s1)
                         continue; // Merging linebreaks is never beneficial
 
-                    l1 = d6_to_double(((s2 - 1)->bbox.x_max + (s2 - 1)->pos.x) -
+                    GlyphInfo *e2 = rewind_trailing_spaces(s2, s3);
+
+                    l1 = d6_to_double(
+                        (e1_old->bbox.x_max + e1_old->pos.x) -
                         (s1->bbox.x_min + s1->pos.x));
-                    l2 = d6_to_double(((s3 - 1)->bbox.x_max + (s3 - 1)->pos.x) -
+                    l2 = d6_to_double(
+                        (e2->bbox.x_max + e2->pos.x) -
                         (s2->bbox.x_min + s2->pos.x));
                     l1_new = d6_to_double(
                         (e1->bbox.x_max + e1->pos.x) -
                         (s1->bbox.x_min + s1->pos.x));
                     l2_new = d6_to_double(
-                        ((s3 - 1)->bbox.x_max + (s3 - 1)->pos.x) -
+                        (e2->bbox.x_max + e2->pos.x) -
                         (w->bbox.x_min + w->pos.x));
 
                     if (DIFF(l1_new, l2_new) < DIFF(l1, l2)) {

--- a/libass/ass_render.h
+++ b/libass/ass_render.h
@@ -22,6 +22,7 @@
 
 #include <inttypes.h>
 #include <stdbool.h>
+#include <fribidi.h>
 #include <ft2build.h>
 #include FT_FREETYPE_H
 #include FT_GLYPH_H
@@ -186,6 +187,7 @@ typedef struct {
 
 typedef struct {
     GlyphInfo *glyphs;
+    FriBidiChar *event_text;
     int length;
     LineInfo *lines;
     int n_lines;

--- a/libass/ass_render.h
+++ b/libass/ass_render.h
@@ -188,6 +188,7 @@ typedef struct {
 typedef struct {
     GlyphInfo *glyphs;
     FriBidiChar *event_text;
+    char *breaks;
     int length;
     LineInfo *lines;
     int n_lines;

--- a/libass/ass_shaper.c
+++ b/libass/ass_shaper.c
@@ -50,7 +50,7 @@ struct ass_shaper {
 
     // FriBidi log2vis
     int n_glyphs, n_pars;
-    FriBidiChar *event_text;
+    FriBidiChar *event_text; // just a reference, owned by text_info
     FriBidiCharType *ctypes;
     FriBidiLevel *emblevels;
     FriBidiStrIndex *cmap;
@@ -103,8 +103,7 @@ void ass_shaper_info(ASS_Library *lib)
 static bool check_allocations(ASS_Shaper *shaper, size_t new_size, size_t n_pars)
 {
     if (new_size > shaper->n_glyphs) {
-        if (!ASS_REALLOC_ARRAY(shaper->event_text, new_size) ||
-            !ASS_REALLOC_ARRAY(shaper->ctypes, new_size) ||
+        if (!ASS_REALLOC_ARRAY(shaper->ctypes, new_size) ||
 #ifdef USE_FRIBIDI_EX_API
             (shaper->bidi_brackets && !ASS_REALLOC_ARRAY(shaper->btypes, new_size)) ||
 #endif
@@ -128,7 +127,6 @@ void ass_shaper_free(ASS_Shaper *shaper)
 {
     ass_cache_done(shaper->metrics_cache);
     free(shaper->features);
-    free(shaper->event_text);
     free(shaper->ctypes);
 #ifdef USE_FRIBIDI_EX_API
     free(shaper->btypes);
@@ -974,6 +972,7 @@ bool ass_shaper_shape(ASS_Shaper *shaper, TextInfo *text_info)
     int i, ret, last_break;
     FriBidiParType dir, *pdir;
     GlyphInfo *glyphs = text_info->glyphs;
+    shaper->event_text = text_info->event_text;
 
     int n_pars = 1;
     for (i = 0; i < text_info->length - 1; i++)


### PR DESCRIPTION
Supersedes the inactive #372. *(GitHub: this closes #372, fixes #360)*

Adds an optional dependency on [libunibreak](https://github.com/adah1972/libunibreak) in order to get Unicode line breaking info.

In #372 the line break info got stored in a VLA, but with texts being arbitrarily long this seems too prone to stack overflows as most compilers I'm aware of allocate VLAs on the stack. To avoid frequent (de)allocations a shared scratch buffer is used instead.
Afaict the line wrapping should normally only happen once per event so there's no benefit in caching the line breaking info.

I'm not completely happy with how `WRAP_UNICODE` being enabled is rechecked for every glyph, but I don't think there's a way to avoid this without either duplicating the wrapping code or using function pointers. *(are function pointers faster than branching once?)* Also line wrapping is probably not a performance critical part of the rendering process.

Reworking `ass_track_set_feature` is left to #481.

---

Note, that there's an `[RFC]` commit unrelated to Unicode line wrapping: Upon reading the code it occurred to me this may be a bug, but I can't think of a sample where any line breaks are removed. Does this change seem sensible to you?