### PR TITLE
Print libass version

### DIFF
--- a/.github/workflows/ghci.yml
+++ b/.github/workflows/ghci.yml
@@ -29,14 +29,6 @@ jobs:
       - name: checkout code
         uses: actions/checkout@v2
 
-      - name: retrieve caches
-        uses: actions/cache@v2
-        with:
-          path: |
-            $HOME/Library/Caches/Homebrew
-            /usr/local/Homebrew
-          key: ${{ runner.os }}-${{ matrix.os }}-build
-
       - name: install deps
         run: |
           if echo "${{ matrix.os }}" | grep -qE '^macos-' ; then

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,5 @@
-AC_INIT(libass, 0.15.0)
+m4_define([LIBASS_VERSION], [0.15.0])
+AC_INIT(libass, LIBASS_VERSION)
 AM_INIT_AUTOMAKE([foreign])
 AC_CONFIG_MACRO_DIR([m4])
 # Disable Fortran checks
@@ -300,6 +301,21 @@ AM_COND_IF([ENABLE_LARGE_TILES], [
 ], [
     AC_DEFINE(CONFIG_LARGE_TILES, 0, [use small tiles])
 ])
+
+## Make a guess about the source code version
+AS_IF([test -d "${srcdir}/.git"], [
+    AC_PATH_PROG([git_bin], [git])
+    AS_IF([test -n "$git_bin"], [
+        srcversion_string="commit: $("$git_bin" -C "$srcdir" describe --tags --long --always --dirty --broken --abbrev=40)"
+    ], [
+        srcversion_string="custom after: LIBASS_VERSION"
+    ])
+], [
+    dnl# Hope no one creates custom tarballs without adjusting the version
+    srcversion_string="tarball: LIBASS_VERSION"
+])
+AC_DEFINE_UNQUOTED([CONFIG_SOURCEVERSION], ["$srcversion_string"],
+                   [string containing info about the used source])
 
 ## Setup output beautifier.
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -24,6 +24,7 @@
 #include <string.h>
 #include <stdbool.h>
 
+#include "ass.h"
 #include "ass_outline.h"
 #include "ass_render.h"
 #include "ass_parse.h"
@@ -49,6 +50,9 @@ ASS_Renderer *ass_renderer_init(ASS_Library *library)
     FT_Library ft;
     ASS_Renderer *priv = 0;
     int vmajor, vminor, vpatch;
+
+    ass_msg(library, MSGL_INFO, "libass API version: 0x%X", LIBASS_VERSION);
+    ass_msg(library, MSGL_INFO, "libass source: %s", CONFIG_SOURCEVERSION);
 
     error = FT_Init_FreeType(&ft);
     if (error) {


### PR DESCRIPTION
This could help us in future bug reports and we already do so for shapers and freetype.
 Also include a guess about the source code version, which may not be entirely reliable, if custom tarballs are involved, commits are added after configure was called or if patches are applied without creating commits. But it may be good enough™ for most cases.
 
 On the other hand this may lead us astray if any of the aforementioned are involved, not sure what's better. What are your thoughts on the "source version guess"?
 