### PR TITLE
Fix embedded and memory fonts

### DIFF
--- a/compare/compare.c
+++ b/compare/compare.c
@@ -535,6 +535,7 @@ int main(int argc, char *argv[])
         return 1;
     }
     ass_set_message_cb(lib, msg_callback, NULL);
+    ass_set_extract_fonts(lib, true);
 
     ItemList list;
     if (!init_items(&list)) {

--- a/libass/ass.h
+++ b/libass/ass.h
@@ -698,6 +698,8 @@ void ass_add_font(ASS_Library *library, const char *name, const char *data,
 
 /**
  * \brief Remove all fonts stored in an ass_library object.
+ * This can only be called safely if all ASS_Track and ASS_Renderer instances
+ * associated with the library handle have been released first.
  * \param library library handle
  */
 void ass_clear_fonts(ASS_Library *library);

--- a/libass/ass_fontselect.c
+++ b/libass/ass_fontselect.c
@@ -992,7 +992,6 @@ static ASS_FontProvider *
 ass_embedded_fonts_add_provider(ASS_Library *lib, ASS_FontSelector *selector,
                                 FT_Library ftlib)
 {
-    int i;
     ASS_FontProvider *priv = ass_font_provider_new(selector, &ft_funcs, NULL);
     if (priv == NULL)
         return NULL;
@@ -1001,7 +1000,7 @@ ass_embedded_fonts_add_provider(ASS_Library *lib, ASS_FontSelector *selector,
         load_fonts_from_dir(lib, lib->fonts_dir);
     }
 
-    for (i = 0; i < lib->num_fontdata; ++i)
+    for (size_t i = 0; i < lib->num_fontdata; i++)
         process_fontdata(priv, lib, ftlib, i);
 
     return priv;

--- a/libass/ass_fontselect.h
+++ b/libass/ass_fontselect.h
@@ -225,9 +225,8 @@ void ass_map_font(const ASS_FontMapping *map, int len, const char *name,
                   ASS_FontProviderMetaData *meta);
 
 ASS_FontSelector *
-ass_fontselect_init(ASS_Library *library,
-                    FT_Library ftlibrary, const char *family,
-                    const char *path, const char *config,
+ass_fontselect_init(ASS_Library *library, FT_Library ftlibrary, size_t *num_emfonts,
+                    const char *family, const char *path, const char *config,
                     ASS_DefaultFontProvider dfp);
 char *ass_font_select(ASS_FontSelector *priv, ASS_Library *library,
                       ASS_Font *font, int *index, char **postscript_name,
@@ -286,5 +285,11 @@ bool ass_get_font_info(ASS_Library *lib, FT_Library ftlib, const char *path,
  *
  */
 void ass_font_provider_free(ASS_FontProvider *provider);
+
+/**
+ * \brief Update embedded and memory fonts
+ */
+size_t ass_update_embedded_fonts(ASS_Library *lib, ASS_FontSelector *selector,
+                                 FT_Library ftlib, size_t num_loaded);
 
 #endif                          /* LIBASS_FONTSELECT_H */

--- a/libass/ass_library.h
+++ b/libass/ass_library.h
@@ -33,7 +33,7 @@ struct ass_library {
     char **style_overrides;
 
     ASS_Fontdata *fontdata;
-    int num_fontdata;
+    size_t num_fontdata;
     void (*msg_callback)(int, const char *, va_list, void *);
     void *msg_callback_data;
 };

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -2862,6 +2862,12 @@ ass_start_frame(ASS_Renderer *render_priv, ASS_Track *track,
 
     ass_lazy_track_init(render_priv->library, render_priv->track);
 
+    if (render_priv->library->num_fontdata != render_priv->num_emfonts) {
+        assert(render_priv->library->num_fontdata > render_priv->num_emfonts);
+        render_priv->num_emfonts = ass_update_embedded_fonts(render_priv->library,
+            render_priv->fontselect, render_priv->ftlibrary, render_priv->num_emfonts);
+    }
+
     ass_shaper_set_kerning(render_priv->shaper, track->Kerning);
     ass_shaper_set_language(render_priv->shaper, track->Language);
     ass_shaper_set_level(render_priv->shaper, render_priv->settings.shaper);

--- a/libass/ass_render.h
+++ b/libass/ass_render.h
@@ -293,6 +293,7 @@ struct ass_renderer {
     ASS_Library *library;
     FT_Library ftlibrary;
     ASS_FontSelector *fontselect;
+    size_t num_emfonts;
     ASS_Settings settings;
     int render_id;
     ASS_Shaper *shaper;

--- a/libass/ass_render_api.c
+++ b/libass/ass_render_api.c
@@ -155,7 +155,7 @@ void ass_set_fonts(ASS_Renderer *priv, const char *default_font,
     if (priv->fontselect)
         ass_fontselect_free(priv->fontselect);
     priv->fontselect = ass_fontselect_init(priv->library, priv->ftlibrary,
-            default_family, default_font, config, dfp);
+            &priv->num_emfonts, default_family, default_font, config, dfp);
 }
 
 void ass_set_selective_style_override_enabled(ASS_Renderer *priv, int bits)

--- a/profile/profile.c
+++ b/profile/profile.c
@@ -49,6 +49,7 @@ static void init(int frame_w, int frame_h)
     }
 
     ass_set_message_cb(ass_library, msg_callback, NULL);
+    ass_set_extract_fonts(ass_library, 1);
 
     ass_renderer = ass_renderer_init(ass_library);
     if (!ass_renderer) {

--- a/test/test.c
+++ b/test/test.c
@@ -99,6 +99,7 @@ static void init(int frame_w, int frame_h)
     }
 
     ass_set_message_cb(ass_library, msg_callback, NULL);
+    ass_set_extract_fonts(ass_library, 1);
 
     ass_renderer = ass_renderer_init(ass_library);
     if (!ass_renderer) {


### PR DESCRIPTION
With this embedded fonts now work in VLC and our own utilities.
FFmpeg and Aegisub do not properly use `ass_set_extract_fonts`, so it still doesn't work for there *(but patching them should be fairly easy)*.