### PR TITLE
Core Text: fix font fallback, check allocations, reuse FT_Library

### DIFF
--- a/libass/ass_coretext.c
+++ b/libass/ass_coretext.c
@@ -49,7 +49,8 @@ static char *cfstr2buf(CFStringRef string)
         size_t len = CFStringGetLength(string);
         CFIndex buf_len = CFStringGetMaximumSizeForEncoding(len, encoding);
         char *buf = malloc(buf_len);
-        CFStringGetCString(string, buf, buf_len, encoding);
+        if (buf)
+            CFStringGetCString(string, buf, buf_len, encoding);
         return buf;
     }
 }
@@ -57,7 +58,7 @@ static char *cfstr2buf(CFStringRef string)
 static void destroy_font(void *priv)
 {
     CTFontDescriptorRef fontd = priv;
-    SAFE_CFRelease(fontd);
+    CFRelease(fontd);
 }
 
 static bool is_postscript_font_format(CFNumberRef cfformat)
@@ -76,8 +77,10 @@ static bool check_postscript(void *priv)
     CTFontDescriptorRef fontd = priv;
     CFNumberRef cfformat =
         CTFontDescriptorCopyAttribute(fontd, kCTFontFormatAttribute);
+    if (!cfformat)
+        return false;
     bool ret = is_postscript_font_format(cfformat);
-    SAFE_CFRelease(cfformat);
+    CFRelease(cfformat);
     return ret;
 }
 
@@ -94,7 +97,7 @@ static bool check_glyph(void *priv, uint32_t code)
         return true;
 
     bool result = CFCharacterSetIsLongCharacterMember(set, code);
-    SAFE_CFRelease(set);
+    CFRelease(set);
     return result;
 }
 
@@ -104,13 +107,11 @@ static char *get_font_file(CTFontDescriptorRef fontd)
     if (!url)
         return NULL;
     CFStringRef path = CFURLCopyFileSystemPath(url, kCFURLPOSIXPathStyle);
-    if (!path) {
-        SAFE_CFRelease(url);
+    CFRelease(url);
+    if (!path)
         return NULL;
-    }
     char *buffer = cfstr2buf(path);
-    SAFE_CFRelease(path);
-    SAFE_CFRelease(url);
+    CFRelease(path);
     return buffer;
 }
 
@@ -120,7 +121,7 @@ static char *get_name(CTFontDescriptorRef fontd, CFStringRef attr)
     CFStringRef name = CTFontDescriptorCopyAttribute(fontd, attr);
     if (name) {
         ret = cfstr2buf(name);
-        SAFE_CFRelease(name);
+        CFRelease(name);
     }
     return ret;
 }
@@ -205,45 +206,61 @@ static void match_fonts(void *priv, ASS_Library *lib, ASS_FontProvider *provider
 {
     FT_Library ftlib = priv;
 
+    CFStringRef cfname =
+        CFStringCreateWithCString(NULL, name, kCFStringEncodingUTF8);
+    if (!cfname)
+        return;
+
     enum { attributes_n = 3 };
-    CTFontDescriptorRef ctdescrs[attributes_n];
-    CFMutableDictionaryRef cfattrs[attributes_n];
+    CTFontDescriptorRef ctdescrs[attributes_n] = {0};
     CFStringRef attributes[attributes_n] = {
         kCTFontFamilyNameAttribute,
         kCTFontDisplayNameAttribute,
         kCTFontNameAttribute,
     };
 
-    CFStringRef cfname =
-        CFStringCreateWithCString(NULL, name, kCFStringEncodingUTF8);
+    CFArrayRef descriptors = NULL;
+    CTFontCollectionRef ctcoll = NULL;
+    CFArrayRef fontsd = NULL;
 
     for (int i = 0; i < attributes_n; i++) {
-        cfattrs[i] = CFDictionaryCreateMutable(NULL, 0, 0, 0);
-        CFDictionaryAddValue(cfattrs[i], attributes[i], cfname);
-        ctdescrs[i] = CTFontDescriptorCreateWithAttributes(cfattrs[i]);
+        CFDictionaryRef cfattrs =
+            CFDictionaryCreate(NULL,
+                (const void **)&attributes[i],
+                (const void **)&cfname,
+                1, NULL, NULL);
+        if (!cfattrs)
+            goto cleanup;
+        ctdescrs[i] = CTFontDescriptorCreateWithAttributes(cfattrs);
+        CFRelease(cfattrs);
+        if (!ctdescrs[i])
+            goto cleanup;
     }
 
-    CFArrayRef descriptors =
+    descriptors =
         CFArrayCreate(NULL, (const void **)&ctdescrs, attributes_n, NULL);
+    if (!descriptors)
+        goto cleanup;
 
-    CTFontCollectionRef ctcoll =
-        CTFontCollectionCreateWithFontDescriptors(descriptors, 0);
+    ctcoll = CTFontCollectionCreateWithFontDescriptors(descriptors, 0);
+    if (!ctcoll)
+        goto cleanup;
 
-    CFArrayRef fontsd =
-        CTFontCollectionCreateMatchingFontDescriptors(ctcoll);
+    fontsd = CTFontCollectionCreateMatchingFontDescriptors(ctcoll);
+    if (!fontsd)
+        goto cleanup;
 
     process_descriptors(lib, ftlib, provider, fontsd);
 
+cleanup:
     SAFE_CFRelease(fontsd);
     SAFE_CFRelease(ctcoll);
 
-    for (int i = 0; i < attributes_n; i++) {
-        SAFE_CFRelease(cfattrs[i]);
+    for (int i = 0; i < attributes_n; i++)
         SAFE_CFRelease(ctdescrs[i]);
-    }
 
     SAFE_CFRelease(descriptors);
-    SAFE_CFRelease(cfname);
+    CFRelease(cfname);
 }
 
 static char *get_fallback(void *priv, ASS_Library *lib,
@@ -253,19 +270,42 @@ static char *get_fallback(void *priv, ASS_Library *lib,
 
     CFStringRef name = CFStringCreateWithBytes(
         0, (UInt8 *)family, strlen(family), kCFStringEncodingUTF8, false);
+    if (!name)
+        return NULL;
+
     CTFontRef font = CTFontCreateWithName(name, 0, NULL);
+    CFRelease(name);
+    if (!font)
+        return NULL;
+
     uint32_t codepointle = OSSwapHostToLittleInt32(codepoint);
+
     CFStringRef r = CFStringCreateWithBytes(
         0, (UInt8*)&codepointle, sizeof(codepointle),
         kCFStringEncodingUTF32LE, false);
+    if (!r) {
+        CFRelease(font);
+        return NULL;
+    }
+
     CTFontRef fb = CTFontCreateForString(font, r, CFRangeMake(0, 1));
+    CFRelease(font);
+    CFRelease(r);
+    if (!fb)
+        return NULL;
+
     CTFontDescriptorRef fontd = CTFontCopyFontDescriptor(fb);
+    CFRelease(fb);
+    if (!fontd)
+        return NULL;
 
     char *res_name = NULL;
     char *path = NULL;
     ASS_FontProviderMetaData meta = {0};
     if (get_font_info_ct(lib, ftlib, fontd, &path, &meta))
         res_name = meta.families[0];
+
+    CFRelease(fontd);
 
     for (int i = 1 /* skip res_name */; i < meta.n_family; i++)
         free(meta.families[i]);
@@ -279,12 +319,6 @@ static char *get_fallback(void *priv, ASS_Library *lib,
     free(meta.postscript_name);
 
     free(path);
-
-    SAFE_CFRelease(name);
-    SAFE_CFRelease(font);
-    SAFE_CFRelease(r);
-    SAFE_CFRelease(fb);
-    SAFE_CFRelease(fontd);
 
     return res_name;
 }

--- a/libass/ass_coretext.c
+++ b/libass/ass_coretext.c
@@ -143,7 +143,7 @@ static void process_descriptors(ASS_Library *lib, ASS_FontProvider *provider,
         int index = -1;
 
         char *path = get_font_file(fontd);
-        if (!path || strcmp("", path) == 0) {
+        if (!path || !*path) {
             // skip the font if the URL field in the font descriptor is empty
             free(path);
             continue;

--- a/libass/ass_coretext.h
+++ b/libass/ass_coretext.h
@@ -26,7 +26,7 @@
 
 ASS_FontProvider *
 ass_coretext_add_provider(ASS_Library *lib, ASS_FontSelector *selector,
-                          const char *config);
+                          const char *config, FT_Library ftlib);
 
 #endif
 

--- a/libass/ass_directwrite.c
+++ b/libass/ass_directwrite.c
@@ -749,7 +749,8 @@ typedef HRESULT (WINAPI *DWriteCreateFactoryFn)(
  */
 ASS_FontProvider *ass_directwrite_add_provider(ASS_Library *lib,
                                                ASS_FontSelector *selector,
-                                               const char *config)
+                                               const char *config,
+                                               FT_Library ftlib)
 {
     HRESULT hr = S_OK;
     IDWriteFactory *dwFactory = NULL;

--- a/libass/ass_directwrite.c
+++ b/libass/ass_directwrite.c
@@ -424,7 +424,8 @@ static int encode_utf16(wchar_t *chars, uint32_t codepoint)
     }
 }
 
-static char *get_fallback(void *priv, const char *base, uint32_t codepoint)
+static char *get_fallback(void *priv, ASS_Library *lib,
+                          const char *base, uint32_t codepoint)
 {
     HRESULT hr;
     ProviderPrivate *provider_priv = (ProviderPrivate *)priv;

--- a/libass/ass_directwrite.h
+++ b/libass/ass_directwrite.h
@@ -24,6 +24,6 @@
 
 ASS_FontProvider *
 ass_directwrite_add_provider(ASS_Library *lib, ASS_FontSelector *selector,
-                          const char *config);
+                             const char *config, FT_Library ftlib);
 
 #endif

--- a/libass/ass_fontconfig.c
+++ b/libass/ass_fontconfig.c
@@ -220,7 +220,8 @@ static void cache_fallbacks(ProviderPrivate *fc)
     FcPatternDestroy(pat);
 }
 
-static char *get_fallback(void *priv, const char *family, uint32_t codepoint)
+static char *get_fallback(void *priv, ASS_Library *lib,
+                          const char *family, uint32_t codepoint)
 {
     ProviderPrivate *fc = (ProviderPrivate *)priv;
     FcResult result;

--- a/libass/ass_fontconfig.c
+++ b/libass/ass_fontconfig.c
@@ -317,7 +317,7 @@ static ASS_FontProviderFuncs fontconfig_callbacks = {
 
 ASS_FontProvider *
 ass_fontconfig_add_provider(ASS_Library *lib, ASS_FontSelector *selector,
-                            const char *config)
+                            const char *config, FT_Library ftlib)
 {
     int rc;
     ProviderPrivate *fc = NULL;

--- a/libass/ass_fontconfig.h
+++ b/libass/ass_fontconfig.h
@@ -26,7 +26,7 @@
 
 ASS_FontProvider *
 ass_fontconfig_add_provider(ASS_Library *lib, ASS_FontSelector *selector,
-                            const char *config);
+                            const char *config, FT_Library ftlib);
 
 #endif
 

--- a/libass/ass_fontselect.c
+++ b/libass/ass_fontselect.c
@@ -717,7 +717,7 @@ char *ass_font_select(ASS_FontSelector *priv, ASS_Library *library,
         if (!search_family || !*search_family)
             search_family = "Arial";
         char *fallback_family = default_provider->funcs.get_fallback(
-                default_provider->priv, search_family, code);
+                default_provider->priv, library, search_family, code);
 
         if (fallback_family) {
             res = select_font(priv, library, fallback_family, bold, italic,

--- a/libass/ass_fontselect.c
+++ b/libass/ass_fontselect.c
@@ -658,7 +658,8 @@ static char *select_font(ASS_FontSelector *priv, ASS_Library *library,
         // TODO: consider changing the API to make more efficient
         // implementations possible.
         for (int i = 0; i < meta.n_fullname; i++) {
-            default_provider->funcs.match_fonts(library, default_provider,
+            default_provider->funcs.match_fonts(default_provider->priv,
+                                                library, default_provider,
                                                 meta.fullnames[i]);
         }
         result = find_font(priv, library, meta, bold, italic, index,
@@ -1010,7 +1011,7 @@ ass_embedded_fonts_add_provider(ASS_Library *lib, ASS_FontSelector *selector,
 struct font_constructors {
     ASS_DefaultFontProvider id;
     ASS_FontProvider *(*constructor)(ASS_Library *, ASS_FontSelector *,
-                                     const char *);
+                                     const char *, FT_Library);
     const char *name;
 };
 
@@ -1062,7 +1063,8 @@ ass_fontselect_init(ASS_Library *library,
             if (dfp == font_constructors[i].id ||
                 dfp == ASS_FONTPROVIDER_AUTODETECT) {
                 priv->default_provider =
-                    font_constructors[i].constructor(library, priv, config);
+                    font_constructors[i].constructor(library, priv,
+                                                     config, ftlibrary);
                 if (priv->default_provider) {
                     ass_msg(library, MSGL_INFO, "Using font provider %s",
                             font_constructors[i].name);

--- a/libass/ass_fontselect.h
+++ b/libass/ass_fontselect.h
@@ -101,11 +101,13 @@ typedef void    (*DestroyProviderFunc)(void *priv);
  * This is called by fontselect whenever a new logical font is created. The
  * font provider set as default is used.
  *
+ * \param priv font provider private data
  * \param lib ASS_Library instance
  * \param provider font provider instance
  * \param name font name (as specified in script)
  */
-typedef void    (*MatchFontsFunc)(ASS_Library *lib,
+typedef void    (*MatchFontsFunc)(void *priv,
+                                  ASS_Library *lib,
                                   ASS_FontProvider *provider,
                                   char *name);
 

--- a/libass/ass_fontselect.h
+++ b/libass/ass_fontselect.h
@@ -144,12 +144,14 @@ typedef void    (*SubstituteFontFunc)(void *priv, const char *name,
  * fallbacks.
  *
  * \param priv font provider private data
+ * \param lib ASS_Library instance
  * \param family original font family name (try matching a similar font) (never NULL)
  * \param codepoint Unicode codepoint (UTF-32)
  * \return output font family, allocated with malloc(), must be freed
  *         by caller.
  */
 typedef char   *(*GetFallbackFunc)(void *priv,
+                                   ASS_Library *lib,
                                    const char *family,
                                    uint32_t codepoint);
 

--- a/libass/ass_fontselect.h
+++ b/libass/ass_fontselect.h
@@ -274,12 +274,14 @@ ass_font_provider_add_font(ASS_FontProvider *provider,
  * \param path the path to the font file to read
  * \param postscript_name the PS name of the specific face to read (set either this or index)
  * \param index the face index to read, or -1 if not applicable
+ * \param require_family_name whether to try a fallback family name and fail if none found
  * \param info the struct to store results into
  * \return success
  *
  */
 bool ass_get_font_info(ASS_Library *lib, FT_Library ftlib, const char *path,
                        const char *postscript_name, int index,
+                       bool require_family_name,
                        ASS_FontProviderMetaData *info);
 
 /**


### PR DESCRIPTION
Fixes #457.

Referring back to my list of options in https://github.com/libass/libass/issues/457#issuecomment-742155639, I ended up choosing a combination of (1) and (2) to preserve maximum compatibility with Windows font names. After all, there had to be a reason @rcombs changed the font name reads in the first place!