### PR TITLE
Add GDI Font Matching Fallback

### DIFF
--- a/libass/dwrite_c.h
+++ b/libass/dwrite_c.h
@@ -699,6 +699,10 @@ DECLARE_INTERFACE_(IDWriteGdiInterop,IUnknown)
     STDMETHOD(CreateFontFromLOGFONT)(THIS_
                                      LOGFONTW const *logFont,
                                      IDWriteFont **font) PURE;
+
+    STDMETHOD(CreateFontFaceFromHdc)(THIS_
+                                     HDC logFont,
+                                     IDWriteFontFace **fontFace) PURE;
     /* rest dropped */
     END_INTERFACE
 };
@@ -707,6 +711,7 @@ DECLARE_INTERFACE_(IDWriteGdiInterop,IUnknown)
 #define IDWriteGdiInterop_AddRef(This) (This)->lpVtbl->AddRef(This)
 #define IDWriteGdiInterop_Release(This) (This)->lpVtbl->Release(This)
 #define IDWriteGdiInterop_CreateFontFromLOGFONT(This,logFont,font) (This)->lpVtbl->CreateFontFromLOGFONT(This,logFont,font)
+#define IDWriteGdiInterop_CreateFontFaceFromHdc(This,hdc,fontFace) (This)->lpVtbl->CreateFontFaceFromHdc(This,hdc,fontFace)
 #endif /*COBJMACROS*/
 
 DEFINE_GUID(IID_IDWriteFactory, 0xb859ee5a,0xd838,0x4b5b,0xa2,0xe8,0x1a,0xdc,0x7d,0x93,0xdb,0x48);


### PR DESCRIPTION
This PR attempts to solve Font Manager related issues by introducing a font matching fallback through `CreateFontIndirect`.  
Note that this is a draft PR for the following reasons:
 - [ ] Figure out why does CreateFontFaceFromHdc throws an Access Violation even though SelectObject appears to be valid.
 - [ ] Remove all the `ass_msg` debug logging. 
 - [ ] Check if it really fixes font manager issues.

Currently font managers such as fontbase write directly their values to registry in a way which directwrite is not able to find through their own methods, so when any user tries to load a font throught fontbase for example, the font appears  
To bypass the issue, Aegisub has a GDI font selection patch that overrides libass directwrite font selection behavior.--

This PR's inspiration came mainly from this Chromium [patch](https://codereview.chromium.org/228763008/patch/1/10002).