### PR TITLE
directwrite: fix `match_fonts`

### DIFF
--- a/libass/ass_directwrite.c
+++ b/libass/ass_directwrite.c
@@ -697,20 +697,27 @@ static void match_fonts(void *priv, ASS_Library *lib,
         return;
 
     hr = IDWriteFont_GetFontFamily(font, &fontFamily);
+    IDWriteFont_Release(font);
     if (FAILED(hr) || !fontFamily)
-        goto cleanup;
+        return;
 
-    add_font(font, fontFamily, provider);
+    UINT32 n = IDWriteFontFamily_GetFontCount(fontFamily);
+    for (UINT32 i = 0; i < n; i++) {
+        hr = IDWriteFontFamily_GetFont(fontFamily, i, &font);
+        if (FAILED(hr))
+            continue;
+
+        // Simulations for bold or oblique are sometimes synthesized by
+        // DirectWrite. We are only interested in physical fonts.
+        if (IDWriteFont_GetSimulations(font) != 0) {
+            IDWriteFont_Release(font);
+            continue;
+        }
+
+        add_font(font, fontFamily, provider);
+    }
 
     IDWriteFontFamily_Release(fontFamily);
-
-    return;
-
-cleanup:
-    if (font)
-        IDWriteFont_Release(font);
-    if (fontFamily)
-        IDWriteFontFamily_Release(fontFamily);
 }
 
 static void get_substitutions(void *priv, const char *name,


### PR DESCRIPTION
`match_fonts` is supposed to add all the fonts with the same family name for fontselect. The previous PR adds only one font, which leads to font with multiple styles cannot be correctly selected.