### PR TITLE
Cherry-Pick Format fixes

### DIFF
--- a/libass/ass_drawing.c
+++ b/libass/ass_drawing.c
@@ -257,7 +257,7 @@ bool ass_drawing_parse(ASS_Outline *outline, ASS_Rect *cbox,
 
     if (lib)
         ass_msg(lib, MSGL_V,
-                "Parsed drawing with %d points and %d segments",
+                "Parsed drawing with %zu points and %zu segments",
                 outline->n_points, outline->n_segments);
 
     drawing_free_tokens(tokens);

--- a/libass/ass_font.c
+++ b/libass/ass_font.c
@@ -474,7 +474,7 @@ int ass_font_get_index(ASS_FontSelector *fontsel, ASS_Font *font,
         int face_idx;
         ass_msg(font->library, MSGL_INFO,
                 "Glyph 0x%X not found, selecting one more "
-                "font for (%s, %d, %d)", symbol, font->desc.family,
+                "font for (%.*s, %d, %d)", symbol, (int) font->desc.family.len, font->desc.family.str,
                 font->desc.bold, font->desc.italic);
         face_idx = *face_index = add_face(fontsel, font, symbol);
         if (face_idx >= 0) {
@@ -491,8 +491,8 @@ int ass_font_get_index(ASS_FontSelector *fontsel, ASS_Font *font,
             }
             if (index == 0) {
                 ass_msg(font->library, MSGL_ERR,
-                        "Glyph 0x%X not found in font for (%s, %d, %d)",
-                        symbol, font->desc.family, font->desc.bold,
+                        "Glyph 0x%X not found in font for (%.*s, %d, %d)",
+                        symbol, (int) font->desc.family.len, font->desc.family.str, font->desc.bold,
                         font->desc.italic);
             }
         }

--- a/libass/ass_utils.h
+++ b/libass/ass_utils.h
@@ -104,6 +104,9 @@ int numpad2align(int val);
 unsigned ass_utf8_get_char(char **str);
 unsigned ass_utf8_put_char(char *dest, uint32_t ch);
 void ass_utf16be_to_utf8(char *dst, size_t dst_size, uint8_t *src, size_t src_size);
+#ifdef __GNUC__
+    __attribute__ ((format (printf, 3, 4)))
+#endif
 void ass_msg(ASS_Library *priv, int lvl, const char *fmt, ...);
 int lookup_style(ASS_Track *track, char *name);
 ASS_Style *lookup_style_strict(ASS_Track *track, char *name, size_t len);


### PR DESCRIPTION
This just cherry-picks the second and third commit (currently 4893db52623c85d37a7548401fc5738429de5537 and fbb12d1e0a948947e825ac85e758ca3c437bc34e) from rcombs' #506 so they can be included in 0.15.2.