### PR TITLE
RFC: move IRC channel to libera

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Source code is available from our [GitHub repository](https://github.com/libass/
 
 Contact
 =======
-Please use the [issue tracker](https://github.com/libass/libass/issues?state=open) to report bugs or feature requests. We have an IRC channel, too. Talk to us on [irc.freenode.net/#libass](irc://irc.freenode.net/libass).
+Please use the [issue tracker](https://github.com/libass/libass/issues?state=open) to report bugs or feature requests. We have an IRC channel, too. Talk to us on [irc.libera.chat/#libass](irc://irc.libera.chat/libass).
 
 Related Links
 =============


### PR DESCRIPTION
Due to a change in effective control about the freenode network, most of its volunteer operators have left and founded [libera](https://www.oftc.net/) instead *(see eg this [resignation letter](https://fuchsnet.ch/freenode-resign-letter.txt) and eg [here](https://gist.github.com/joepie91/df80d8d36cd9d1bde46ba018af497409) and [here](https://lwn.net/Articles/856543) for more links with/and info)*.
This led many project to follow, eg [Wikimedia](https://meta.wikimedia.org/w/index.php?title=Wikimedia_Forum&type=revision&diff=21476411&oldid=21475994&diffmode=source), [Gentoo](https://www.gentoo.org/news/2021/05/23/Moving-to-Libera.html),   [Jellyfin](https://jellyfin.org/contact/#irc), [musl](https://musl.libc.org/), [SourceHut](https://sourcehut.org/blog/2021-05-19-liberachat/), [Void Linux](https://voidlinux.org/news/2021/05/libera.html), [curl](https://curl.se/docs/irc.html), [PostgreSQL](https://www.postgresql.org/about/news/migration-of-postgresql-irc-channels-2216/), [Ubuntu](https://lists.ubuntu.com/archives/ubuntu-irc/2021-May/001922.html), [CentOS](https://lists.centos.org/pipermail/centos-devel/2021-May/076920.html) and [LXC](https://discuss.linuxcontainers.org/t/lxc-now-using-libera-as-its-irc-network-live-chats/11178) have moved or are moving to libera. FFmpeg has an [RFC patch](https://ffmpeg.org/pipermail/ffmpeg-devel/2021-May/280581.html) to move and the channel on libera is already registered, but the project hasn't yet finally decided where to move. Some also have chosen to move to [OFTC](https://www.oftc.net/) *(all official Debian channels were already on OFTC before this)*.

Apart from the events detailed in the resignation letters and the mass-exodus, with freenode (now) being privately-owned and seemingly effectively controlled by a single individual, while libera is now backed by a registered nonprofit and prior freenode operators gives me more confidence in the future of libera than freenode.

I thus suggest we move our channel to libera.
To register as a project and claim the channel-namespace on libera, we need to send a request as described here: https://libera.chat/chanreg#project-registration . To do this, everyone who should be granted IRC-OP access would need to register with NickServ on libera first. Currently `#libass` already exists as an unregistered channel without OPs on libera and mia already set up the gh-mpv bot for it. *(The `#libass` channel on OFTC was empty when I checked.)*

Ideally we would update the topic of the freenode channel to point to its new location when moving, but only wm4 and zgreg *(grigorig on GH?)* can set the topic of the freenode channel. *(though [reports like this](https://www.devever.net/~hl/freenode_abuse) and the following [freenode-policy change](https://github.com/freenode/web-7.0/commit/1194a3e71a427a669ccdddee22006416d46eeb43) cast some doubt whether this would be honoured)*

