### PR TITLE
Make equations for \clip and \iclip complimentary

### DIFF
--- a/libass/ass_bitmap.c
+++ b/libass/ass_bitmap.c
@@ -395,16 +395,14 @@ void ass_add_bitmaps_c(uint8_t *dst, intptr_t dst_stride,
     }
 }
 
-void ass_sub_bitmaps_c(uint8_t *dst, intptr_t dst_stride,
-                       uint8_t *src, intptr_t src_stride,
-                       intptr_t width, intptr_t height)
+void ass_imul_bitmaps_c(uint8_t *dst, intptr_t dst_stride,
+                        uint8_t *src, intptr_t src_stride,
+                        intptr_t width, intptr_t height)
 {
-    short out;
     uint8_t* end = dst + dst_stride * height;
     while (dst < end) {
         for (unsigned j = 0; j < width; ++j) {
-            out = dst[j] - src[j];
-            dst[j] = FFMAX(out, 0);
+            dst[j] = (dst[j] * (255 - src[j]) + 255) >> 8;
         }
         dst += dst_stride;
         src += src_stride;

--- a/libass/ass_bitmap.h
+++ b/libass/ass_bitmap.h
@@ -69,7 +69,7 @@ typedef struct {
     FillGenericTileFunc fill_generic;
 
     // blend functions
-    BitmapBlendFunc add_bitmaps, sub_bitmaps;
+    BitmapBlendFunc add_bitmaps, imul_bitmaps;
     BitmapMulFunc mul_bitmaps;
 
     // be blur function

--- a/libass/ass_func_template.h
+++ b/libass/ass_func_template.h
@@ -34,9 +34,9 @@ void DECORATE(fill_generic_tile32)(uint8_t *buf, ptrdiff_t stride,
 void DECORATE(add_bitmaps)(uint8_t *dst, intptr_t dst_stride,
                            uint8_t *src, intptr_t src_stride,
                            intptr_t width, intptr_t height);
-void DECORATE(sub_bitmaps)(uint8_t *dst, intptr_t dst_stride,
-                           uint8_t *src, intptr_t src_stride,
-                           intptr_t width, intptr_t height);
+void DECORATE(imul_bitmaps)(uint8_t *dst, intptr_t dst_stride,
+                            uint8_t *src, intptr_t src_stride,
+                            intptr_t width, intptr_t height);
 void DECORATE(mul_bitmaps)(uint8_t *dst, intptr_t dst_stride,
                            uint8_t *src1, intptr_t src1_stride,
                            uint8_t *src2, intptr_t src2_stride,
@@ -105,7 +105,7 @@ const BitmapEngine DECORATE(bitmap_engine) = {
 #endif
 
     .add_bitmaps = DECORATE(add_bitmaps),
-    .sub_bitmaps = DECORATE(sub_bitmaps),
+    .imul_bitmaps = DECORATE(imul_bitmaps),
     .mul_bitmaps = DECORATE(mul_bitmaps),
 
     .be_blur = DECORATE(be_blur),

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -731,9 +731,9 @@ static void blend_vector_clip(ASS_Renderer *render_priv, ASS_Image *head)
 
             // Blend together
             memcpy(nbuffer, abuffer, ((ah - 1) * as) + aw);
-            render_priv->engine->sub_bitmaps(nbuffer + atop * as + aleft, as,
-                                             bbuffer + btop * bs + bleft, bs,
-                                             w, h);
+            render_priv->engine->imul_bitmaps(nbuffer + atop * as + aleft, as,
+                                              bbuffer + btop * bs + bleft, bs,
+                                              w, h);
         } else {
             // Regular clip
             if (ax + aw < bx || ay + ah < by || ax > bx + bw ||


### PR DESCRIPTION
There should be `clip_func(src, clip) = iclip_func(src, 255 - clip)`, but our blending equations don't follow that. Also our clip function `sub_bitmaps()` is incorrect in case of half-transparent source and can lead to aliasing. So I've fixed it at the cost of a slight performance drop.