### PR TITLE
fontselect: remove path length limit

### DIFF
--- a/libass/ass_fontselect.c
+++ b/libass/ass_fontselect.c
@@ -171,22 +171,33 @@ static void load_fonts_from_dir(ASS_Library *library, const char *dir)
     DIR *d = opendir(dir);
     if (!d)
         return;
+    size_t dirlen = strlen(dir);
+    size_t namemax = 0;
+    char *namebuf = NULL;
     while (1) {
         struct dirent *entry = readdir(d);
         if (!entry)
             break;
         if (entry->d_name[0] == '.')
             continue;
-        char fullname[4096];
-        snprintf(fullname, sizeof(fullname), "%s/%s", dir, entry->d_name);
+        size_t namelen = dirlen + strlen(entry->d_name) + 2;
+        if (namelen > namemax) {
+            size_t newlen = FFMAX(2048, namelen + 256);
+            if (ASS_REALLOC_ARRAY(namebuf, newlen))
+                namemax = newlen;
+            else
+                continue;
+        }
+        snprintf(namebuf, namemax, "%s/%s", dir, entry->d_name);
         size_t bufsize = 0;
-        ass_msg(library, MSGL_INFO, "Loading font file '%s'", fullname);
-        void *data = read_file(library, fullname, &bufsize);
+        ass_msg(library, MSGL_INFO, "Loading font file '%s'", namebuf);
+        void *data = read_file(library, namebuf, &bufsize);
         if (data) {
             ass_add_font(library, entry->d_name, data, bufsize);
             free(data);
         }
     }
+    free(namebuf);
     closedir(d);
 }
 


### PR DESCRIPTION
There's no portable hard limit but `SIZE_MAX`. *(On POSIX systems `PATH_MAX` gives a soft limit, as a floor of which all applicatons on the system are expected to accept etc, but paths may theoretically also be longer; also `PATH_MAX` may be too large for the stack)*