### PR TITLE
compare: fix _mkdir include on Windows

### DIFF
--- a/compare/compare.c
+++ b/compare/compare.c
@@ -24,6 +24,7 @@
 #include <string.h>
 
 #if defined(_WIN32) && !defined(__CYGWIN__)
+#include <direct.h>
 #define mkdir(path, mode) _mkdir(path)
 #endif
 


### PR DESCRIPTION
Without this `_mkdir` is undeclared on Windows:
```
  CC       compare-compare.o
compare.c: In function 'main':
compare.c:27:27: warning: implicit declaration of function '_mkdir'; did you mean 'mkdir'? [-Wimplicit-function-declaration]
   27 | #define mkdir(path, mode) _mkdir(path)
      |                           ^~~~~~
compare.c:620:17: note: in expansion of macro 'mkdir'
  620 |             if (mkdir(output, 0755)) {
      |                 ^~~~~
  CCLD     compare.exe
```