### PR TITLE
Use a libtool-wrapper script for NASM

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 ACLOCAL_AMFLAGS = -I m4
-EXTRA_DIST = libass.pc.in Changelog
+EXTRA_DIST = libass.pc.in Changelog ltnasm.sh
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = libass.pc

--- a/libass/Makefile.am
+++ b/libass/Makefile.am
@@ -12,7 +12,7 @@ nasm_verbose_ = $(nasm_verbose_$(AM_DEFAULT_VERBOSITY))
 nasm_verbose_0 = @echo "  NASM    " $@;
 
 .asm.lo:
-	$(nasm_verbose)$(LIBTOOL) $(AM_V_lt) --tag=CC --mode=compile $(AS) $(ASFLAGS) -I$(srcdir)/ -o $@ $< -prefer-non-pic
+	$(nasm_verbose)$(LIBTOOL) $(AM_V_lt) --tag=CC --mode=compile $(top_srcdir)/ltnasm.sh $(AS) $(ASFLAGS) -I$(srcdir)/ -o $@ $<
 
 SRC_INTEL = x86/rasterizer.asm x86/blend_bitmaps.asm x86/be_blur.asm x86/blur.asm x86/cpuid.asm \
             x86/cpuid.h

--- a/ltnasm.sh
+++ b/ltnasm.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+# Translate libtool supplied C-compiler options for NASM.
+# libtool treats NASM like the C compiler, and may supply -f… options
+# which are interpreted as the output file format by NASM, causing errors.
+# Notably libtool will set -DPIC -fPIC and -fno-common;
+# we want to use -DPIC by translating it to -DPIC=1, but remove everything else
+#
+# Theoretically the way the filtering is done here in a plain POSIX shell script,
+# does mess up if there were spaces in any argument. However this will never happen
+# since neither our filenames nor options do not contain spaces and source paths
+# are not allowed to contain spaces by configure.
+
+cmd=""
+while [ "$#" -gt 0 ] ; do
+    case "$1" in
+        # NASM accepts both -f format and -fformat,
+        # we always use the former, and libtool supplied
+        # C-compiler options will always use the latter.
+        -f) cmd="$cmd $1" ;;
+        -f*) : ;;
+        -DPIC) cmd="$cmd -DPIC=1" ;;
+        *) cmd="$cmd $1" ;;
+    esac
+    shift
+done
+
+exec $cmd


### PR DESCRIPTION
Closes #539; NetBSD was also affected.

Patch was tested on the following systems *(`y`: test successful; `-`: not tested,)*
|     *OS*     |  *Family*  |  ix86 | amd64 |
| ------------ |:----------:|:-----:| -----:|
| Alpine 3.14  | Linux-musl |   y   |   -   |
| Debian 11    | Linux-glibc|   y   |   y   |
| Haiku R1B3   |  BeOS-like |   y   |   y   |
| NetBSD 9.2   |    *BSD    |   -   |   y   |
| OpenIndiana  |   illumos/Solaris  |  y   |   y   |


@brad0 tested an earlier version on OpenBSD and our GHA CI will test on MacOS and Windows.