### PR TITLE
Don’t try to look up glyphs for invisible control characters

### DIFF
--- a/libass/ass_font.c
+++ b/libass/ass_font.c
@@ -486,13 +486,6 @@ int ass_font_get_index(ASS_FontSelector *fontsel, ASS_Font *font,
         return 0;
     }
 
-    // try with the requested face
-    if (*face_index < font->n_faces) {
-        face = font->faces[*face_index];
-        index = FT_Get_Char_Index(face, ass_font_index_magic(face, symbol));
-    }
-
-    // not found in requested face, try all others
     for (i = 0; i < font->n_faces && index == 0; ++i) {
         face = font->faces[i];
         index = FT_Get_Char_Index(face, ass_font_index_magic(face, symbol));

--- a/libass/ass_fontselect.c
+++ b/libass/ass_fontselect.c
@@ -954,8 +954,8 @@ char *ass_font_select(ASS_FontSelector *priv,
                 italic, res, *index, *postscript_name ? *postscript_name : "(none)");
     else
         ass_msg(priv->library, MSGL_WARN,
-                "fontselect: failed to find any fallback for font: "
-                "(%s, %d, %d)", family, bold, italic);
+                "fontselect: failed to find any fallback with glyph 0x%X for font: "
+                "(%s, %d, %d)", code, family, bold, italic);
 
     return res;
 }

--- a/libass/ass_shaper.c
+++ b/libass/ass_shaper.c
@@ -842,19 +842,22 @@ void ass_shaper_find_runs(ASS_Shaper *shaper, ASS_Renderer *render_priv,
     // find appropriate fonts for the shape runs
     for (i = 0; i < len; i++) {
         GlyphInfo *info = glyphs + i;
-        if (!info->drawing_text.str) {
-            // set size and get glyph index
+        if (!info->drawing_text.str && !info->skip) {
+            // get font face and glyph index
             ass_font_get_index(render_priv->fontselect, info->font,
                     info->symbol, &info->face_index, &info->glyph_index);
         }
         if (i > 0) {
             GlyphInfo *last = glyphs + i - 1;
             if ((last->font != info->font ||
-                    last->face_index != info->face_index ||
+                    (!info->skip &&
+                        last->face_index != info->face_index) ||
                     last->script != info->script ||
                     info->starts_new_run ||
                     last->flags != info->flags))
                 shape_run++;
+            else if (info->skip)
+                info->face_index = last->face_index;
         }
         info->shape_run_id = shape_run;
     }

--- a/libass/ass_shaper.c
+++ b/libass/ass_shaper.c
@@ -792,6 +792,28 @@ void ass_shaper_set_kerning(ASS_Shaper *shaper, bool kern)
 }
 
 /**
+  * \brief Remove all zero-width invisible characters from the text.
+  */
+static void ass_shaper_skip_characters(GlyphInfo *glyphs, size_t len)
+{
+    for (int i = 0; i < len; i++) {
+        // Skip direction override control characters
+        if ((glyphs[i].symbol <= 0x202e && glyphs[i].symbol >= 0x202a)
+                || (glyphs[i].symbol <= 0x200f && glyphs[i].symbol >= 0x200b)
+                || (glyphs[i].symbol <= 0x206f && glyphs[i].symbol >= 0x2060)
+                || (glyphs[i].symbol <= 0xfe0f && glyphs[i].symbol >= 0xfe00)
+                || (glyphs[i].symbol <= 0xe01ef && glyphs[i].symbol >= 0xe0100)
+                || (glyphs[i].symbol <= 0x180f && glyphs[i].symbol >= 0x180b)
+                || glyphs[i].symbol == 0x061c
+                || glyphs[i].symbol == 0xfeff
+                || glyphs[i].symbol == 0x00ad
+                || glyphs[i].symbol == 0x034f) {
+            glyphs[i].skip = true;
+        }
+    }
+}
+
+/**
  * \brief Find shape runs according to the event's selected fonts
  */
 void ass_shaper_find_runs(ASS_Shaper *shaper, ASS_Renderer *render_priv,
@@ -801,6 +823,7 @@ void ass_shaper_find_runs(ASS_Shaper *shaper, ASS_Renderer *render_priv,
     int shape_run = 0;
 
     ass_shaper_determine_script(shaper, glyphs, len);
+    ass_shaper_skip_characters(glyphs, len);
 
     // find appropriate fonts for the shape runs
     for (i = 0; i < len; i++) {
@@ -865,32 +888,6 @@ void ass_shaper_set_bidi_brackets(ASS_Shaper *shaper, bool match_brackets)
 #endif
 
 /**
-  * \brief Remove all zero-width invisible characters from the text.
-  * \param text_info text
-  */
-static void ass_shaper_skip_characters(TextInfo *text_info)
-{
-    int i;
-    GlyphInfo *glyphs = text_info->glyphs;
-
-    for (i = 0; i < text_info->length; i++) {
-        // Skip direction override control characters
-        if ((glyphs[i].symbol <= 0x202e && glyphs[i].symbol >= 0x202a)
-                || (glyphs[i].symbol <= 0x200f && glyphs[i].symbol >= 0x200b)
-                || (glyphs[i].symbol <= 0x206f && glyphs[i].symbol >= 0x2060)
-                || (glyphs[i].symbol <= 0xfe0f && glyphs[i].symbol >= 0xfe00)
-                || (glyphs[i].symbol <= 0xe01ef && glyphs[i].symbol >= 0xe0100)
-                || (glyphs[i].symbol <= 0x180f && glyphs[i].symbol >= 0x180b)
-                || glyphs[i].symbol == 0x061c
-                || glyphs[i].symbol == 0xfeff
-                || glyphs[i].symbol == 0x00ad
-                || glyphs[i].symbol == 0x034f) {
-            glyphs[i].skip = true;
-        }
-    }
-}
-
-/**
  * \brief Shape an event's text. Calculates directional runs and shapes them.
  * \param text_info event's text
  * \return success, when 0
@@ -937,7 +934,6 @@ bool ass_shaper_shape(ASS_Shaper *shaper, TextInfo *text_info)
     switch (shaper->shaping_level) {
     case ASS_SHAPING_SIMPLE:
         shape_fribidi(shaper, glyphs, text_info->length);
-        ass_shaper_skip_characters(text_info);
         return true;
     case ASS_SHAPING_COMPLEX:
     default:

--- a/libass/ass_shaper.c
+++ b/libass/ass_shaper.c
@@ -885,7 +885,6 @@ static void ass_shaper_skip_characters(TextInfo *text_info)
                 || glyphs[i].symbol == 0xfeff
                 || glyphs[i].symbol == 0x00ad
                 || glyphs[i].symbol == 0x034f) {
-            glyphs[i].symbol = 0;
             glyphs[i].skip = true;
         }
     }


### PR DESCRIPTION
Supersedes and closes #508.

Implements stupid simple logic that seems to match Uniscribe/VSFilter somewhat, but perhaps not fully. At the very least, this should be a clear improvement over our current behaviour.