### PR TITLE
Use x86 asm code if we’ve built it, regardless of C compiler

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -322,6 +322,9 @@ AM_CONDITIONAL([DIRECTWRITE], [test "x$directwrite" = xtrue])
 ## Define C Macros not relating to libraries
 AM_COND_IF([ASM], [
     AC_DEFINE(CONFIG_ASM, 1, [ASM enabled])
+    AM_COND_IF([X86], [
+        AC_DEFINE(ARCH_X86, 1, [targeting a 32- or 64-bit x86 host architecture])
+    ])
 ], [
     AC_DEFINE(CONFIG_ASM, 0, [ASM enabled])
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -214,34 +214,34 @@ can_asm=false
 AS_IF([test "x$enable_asm" != xno], [
     AS_CASE([$host],
         [i?86-*], [
-            INTEL=true
             AS=nasm
+            X86=true
             BITS=32
             BITTYPE=32
             ASFLAGS="$ASFLAGS -DARCH_X86_64=0"
         ],
         [x86_64-*-gnux32|amd64-*-gnux32], [
             AS=nasm
-            INTEL=true
-            X64=true
+            X86=true
+            X86_64=true
             BITS=64
             BITTYPE=x32
             ASFLAGS="$ASFLAGS -DARCH_X86_64=1"
         ],
         [x86_64-*|amd64-*], [
             AS=nasm
-            INTEL=true
-            X64=true
+            X86=true
+            X86_64=true
             BITS=64
             BITTYPE=64
             ASFLAGS="$ASFLAGS -DARCH_X86_64=1"
         ],
         [ # default
-            INTEL=false
+            X86=false
             AC_MSG_NOTICE([Assembly optimizations are not yet supported on this architecture; disabling.])
         ]
     )
-    AS_IF([test "x$INTEL" = xtrue], [
+    AS_IF([test "x$X86" = xtrue], [
         AC_CHECK_PROG([nasm_check], [$AS], [yes])
         AS_IF([test "x$nasm_check" != xyes], [
             AC_MSG_WARN(nasm was not found; ASM functions are disabled.)
@@ -306,8 +306,8 @@ AC_SUBST([PKG_REQUIRES_PRIVATE], [${pkg_requires}])
 
 ## Setup conditionals for use in Makefiles
 AM_CONDITIONAL([ASM], [test "x$can_asm" = xtrue])
-AM_CONDITIONAL([INTEL], [test "x$INTEL" = xtrue])
-AM_CONDITIONAL([X64], [test "x$X64" = xtrue])
+AM_CONDITIONAL([X86], [test "x$X86" = xtrue])
+AM_CONDITIONAL([X86_64], [test "x$X86_64" = xtrue])
 
 AM_CONDITIONAL([ENABLE_LARGE_TILES], [test "x$enable_large_tiles" = xyes])
 

--- a/configure.ac
+++ b/configure.ac
@@ -216,7 +216,6 @@ AS_IF([test "x$enable_asm" != xno], [
         [i?86-*], [
             INTEL=true
             AS=nasm
-            X86=true
             BITS=32
             BITTYPE=32
             ASFLAGS="$ASFLAGS -DARCH_X86_64=0"
@@ -308,7 +307,6 @@ AC_SUBST([PKG_REQUIRES_PRIVATE], [${pkg_requires}])
 ## Setup conditionals for use in Makefiles
 AM_CONDITIONAL([ASM], [test "x$can_asm" = xtrue])
 AM_CONDITIONAL([INTEL], [test "x$INTEL" = xtrue])
-AM_CONDITIONAL([X86], [test "x$X86" = xtrue])
 AM_CONDITIONAL([X64], [test "x$X64" = xtrue])
 
 AM_CONDITIONAL([ENABLE_LARGE_TILES], [test "x$enable_large_tiles" = xyes])

--- a/libass/Makefile.am
+++ b/libass/Makefile.am
@@ -14,8 +14,8 @@ nasm_verbose_0 = @echo "  NASM    " $@;
 .asm.lo:
 	$(nasm_verbose)$(LIBTOOL) $(AM_V_lt) --tag=CC --mode=compile $(top_srcdir)/ltnasm.sh $(AS) $(ASFLAGS) -I$(srcdir)/ -Dprivate_prefix=ass -o $@ $<
 
-SRC_INTEL = x86/rasterizer.asm x86/blend_bitmaps.asm x86/be_blur.asm x86/blur.asm x86/cpuid.asm \
-            x86/cpuid.h
+SRC_X86 = x86/rasterizer.asm x86/blend_bitmaps.asm x86/be_blur.asm x86/blur.asm x86/cpuid.asm \
+          x86/cpuid.h
 
 SRC_FONTCONFIG = ass_fontconfig.c ass_fontconfig.h
 SRC_DIRECTWRITE = ass_directwrite.c ass_directwrite.h ass_directwrite_info_template.h dwrite_c.h
@@ -48,8 +48,8 @@ libass_la_SOURCES += $(SRC_CORETEXT)
 endif
 
 if ASM
-if INTEL
-libass_la_SOURCES += $(SRC_INTEL)
+if X86
+libass_la_SOURCES += $(SRC_X86)
 endif
 endif
 

--- a/libass/ass_bitmap.c
+++ b/libass/ass_bitmap.c
@@ -42,7 +42,7 @@
 #undef ALIGN
 #undef DECORATE
 
-#if (defined(__i386__) || defined(__x86_64__)) && CONFIG_ASM
+#if CONFIG_ASM && ARCH_X86
 
 #define ALIGN           4
 #define DECORATE(func)  ass_##func##_sse2

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -74,7 +74,7 @@ ASS_Renderer *ass_renderer_init(ASS_Library *library)
     priv->ftlibrary = ft;
     // images_root and related stuff is zero-filled in calloc
 
-#if (defined(__i386__) || defined(__x86_64__)) && CONFIG_ASM
+#if CONFIG_ASM && ARCH_X86
     if (has_avx2())
         priv->engine = &ass_bitmap_engine_avx2;
     else if (has_sse2())

--- a/libass/ass_utils.c
+++ b/libass/ass_utils.c
@@ -31,7 +31,7 @@
 #include "ass_utils.h"
 #include "ass_string.h"
 
-#if (defined(__i386__) || defined(__x86_64__)) && CONFIG_ASM
+#if CONFIG_ASM && ARCH_X86
 
 #include "x86/cpuid.h"
 

--- a/libass/ass_utils.h
+++ b/libass/ass_utils.h
@@ -50,7 +50,7 @@
 
 #define FEATURE_MASK(feat) (((uint32_t) 1) << (feat))
 
-#if (defined(__i386__) || defined(__x86_64__)) && CONFIG_ASM
+#if CONFIG_ASM && ARCH_X86
 int has_sse2(void);
 int has_avx(void);
 int has_avx2(void);

--- a/libass/x86/cpuid.h
+++ b/libass/x86/cpuid.h
@@ -16,8 +16,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#ifndef INTEL_CPUID_H
-#define INTEL_CPUID_H
+#ifndef LIBASS_X86_CPUID_H
+#define LIBASS_X86_CPUID_H
 
 #include <stdint.h>
 


### PR DESCRIPTION
We detect x86* and enable building asm code in `configure`. However, we don’t actually use that code unless we detect x86* via the C compiler’s predefined macros.

Perhaps the best thing to do would be to set a `CONFIG_X86` flag in `configure` and check that. Shall we do that?

If not, here’s a patch that checks more macros to add support for:
  * Microsoft Visual C++ (`_M_IX86`/`_M_X64`)
  * Intel C++ Compiler for Windows (`_M_IX86`/`_M_X64`)
  * Oracle Developer Studio (contrasts `__i386__` with `__x86_64` and sets `__i386` on both)

Subject to C99/C11/dependency support, this also supports:
  * Digital Mars (`_M_IX86`, no 64-bit target)
  * Watcom C/C++ (`_M_IX86`, no 64-bit target; defines `_M_IX86` also for 16-bit, but the `CONFIG_ASM` guard will block that)
  * Stratus VOS/OpenVOS (`__i386`, no 64-bit target)

Inspired by https://github.com/ShiftMediaProject/libass/commit/9a92b600710e37beeb5aff55b5e5c8162c270d38 mentioned in https://github.com/libass/libass/pull/330#issuecomment-903386563.