### PR TITLE
fontselect: handle the case where FT_Get_Postscript_Name returns NULL

### DIFF
--- a/libass/ass_fontselect.c
+++ b/libass/ass_fontselect.c
@@ -336,6 +336,8 @@ get_font_info(FT_Library lib, FT_Face face, const char *fallback_family_name,
     info->width  = 100;     // FIXME, should probably query the OS/2 table
 
     info->postscript_name = (char *)FT_Get_Postscript_Name(face);
+    if (!info->postscript_name)
+        info->postscript_name = "";
 
     if (num_family) {
         info->families = calloc(sizeof(char *), num_family);


### PR DESCRIPTION
Unfortunately, FT_Get_Postscript_Name, which is supposed to return the
PostScript name of a given font, seems to return NULL for some fonts. This
leads to crashes because ass_face_open() operates under the assumption that
the PostScript name is not NULL. This patch address the issue by using an
empty string when FT_Get_Postscript_Name returns NULL.

BUG=#554