### PR TITLE
Fix buffer overrun in rasterizer

### DIFF
--- a/libass/ass_bitmap.h
+++ b/libass/ass_bitmap.h
@@ -34,6 +34,7 @@ typedef void (*FillHalfplaneTileFunc)(uint8_t *buf, ptrdiff_t stride,
 typedef void (*FillGenericTileFunc)(uint8_t *buf, ptrdiff_t stride,
                                     const struct segment *line, size_t n_lines,
                                     int winding);
+typedef void (*MergeTileFunc)(uint8_t *buf, ptrdiff_t stride, const uint8_t *tile);
 
 typedef void (*BitmapBlendFunc)(uint8_t *dst, intptr_t dst_stride,
                                 uint8_t *src, intptr_t src_stride,
@@ -67,6 +68,7 @@ typedef struct {
     FillSolidTileFunc fill_solid;
     FillHalfplaneTileFunc fill_halfplane;
     FillGenericTileFunc fill_generic;
+    MergeTileFunc merge_tile;
 
     // blend functions
     BitmapBlendFunc add_bitmaps, imul_bitmaps;

--- a/libass/ass_func_template.h
+++ b/libass/ass_func_template.h
@@ -30,6 +30,8 @@ void DECORATE(fill_generic_tile16)(uint8_t *buf, ptrdiff_t stride,
 void DECORATE(fill_generic_tile32)(uint8_t *buf, ptrdiff_t stride,
                                    const struct segment *line, size_t n_lines,
                                    int winding);
+void DECORATE(merge_tile16)(uint8_t *buf, ptrdiff_t stride, const uint8_t *tile);
+void DECORATE(merge_tile32)(uint8_t *buf, ptrdiff_t stride, const uint8_t *tile);
 
 void DECORATE(add_bitmaps)(uint8_t *dst, intptr_t dst_stride,
                            uint8_t *src, intptr_t src_stride,
@@ -97,11 +99,13 @@ const BitmapEngine DECORATE(bitmap_engine) = {
     .fill_solid = DECORATE(fill_solid_tile32),
     .fill_halfplane = DECORATE(fill_halfplane_tile32),
     .fill_generic = DECORATE(fill_generic_tile32),
+    .merge_tile = DECORATE(merge_tile32),
 #else
     .tile_order = 4,
     .fill_solid = DECORATE(fill_solid_tile16),
     .fill_halfplane = DECORATE(fill_halfplane_tile16),
     .fill_generic = DECORATE(fill_generic_tile16),
+    .merge_tile = DECORATE(merge_tile16),
 #endif
 
     .add_bitmaps = DECORATE(add_bitmaps),

--- a/libass/ass_rasterizer.c
+++ b/libass/ass_rasterizer.c
@@ -674,8 +674,7 @@ static bool rasterizer_fill_level(const BitmapEngine *engine, RasterizerData *rs
         else
             engine->fill_halfplane(rst->tile, width, line1->a, line1->b, line1->c,
                                    flags1 & FLAG_REVERSE ? -line1->scale : line1->scale);
-        // XXX: better to use max instead of add
-        engine->add_bitmaps(buf, stride, rst->tile, width, width, height);
+        engine->merge_tile(buf, stride, rst->tile);
         rst->size[index] = offs;
         return true;
     }

--- a/libass/ass_rasterizer.c
+++ b/libass/ass_rasterizer.c
@@ -51,7 +51,7 @@ static inline int ilog2(uint32_t n)
 }
 
 
-bool rasterizer_init(RasterizerData *rst, int tile_order, int outline_error)
+bool rasterizer_init(const BitmapEngine *engine, RasterizerData *rst, int outline_error)
 {
     rst->outline_error = outline_error;
     rst->linebuf[0] = rst->linebuf[1] = NULL;
@@ -59,7 +59,9 @@ bool rasterizer_init(RasterizerData *rst, int tile_order, int outline_error)
     rst->size[1] = rst->capacity[1] = 0;
     rst->n_first = 0;
 
-    rst->tile = ass_aligned_alloc(32, 1 << (2 * tile_order), false);
+    unsigned align = 1 << engine->align_order;
+    unsigned size = 1 << (2 * engine->tile_order);
+    rst->tile = ass_aligned_alloc(align, size, false);
     return rst->tile;
 }
 

--- a/libass/ass_rasterizer.h
+++ b/libass/ass_rasterizer.h
@@ -56,7 +56,7 @@ typedef struct {
     uint8_t *tile;
 } RasterizerData;
 
-bool rasterizer_init(RasterizerData *rst, int tile_order, int outline_error);
+bool rasterizer_init(const BitmapEngine *engine, RasterizerData *rst, int outline_error);
 void rasterizer_done(RasterizerData *rst);
 
 /**

--- a/libass/ass_rasterizer_c.c
+++ b/libass/ass_rasterizer_c.c
@@ -377,3 +377,24 @@ void ass_fill_generic_tile32_c(uint8_t *buf, ptrdiff_t stride,
         buf += stride;
     }
 }
+
+
+void ass_merge_tile16_c(uint8_t *buf, ptrdiff_t stride, const uint8_t *tile)
+{
+    for (int y = 0; y < 16; y++) {
+        for (int x = 0; x < 16; x++)
+            buf[x] = FFMAX(buf[x], tile[x]);
+        buf += stride;
+        tile += 16;
+    }
+}
+
+void ass_merge_tile32_c(uint8_t *buf, ptrdiff_t stride, const uint8_t *tile)
+{
+    for (int y = 0; y < 32; y++) {
+        for (int x = 0; x < 32; x++)
+            buf[x] = FFMAX(buf[x], tile[x]);
+        buf += stride;
+        tile += 32;
+    }
+}

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -85,8 +85,7 @@ ASS_Renderer *ass_renderer_init(ASS_Library *library)
     priv->engine = &ass_bitmap_engine_c;
 #endif
 
-    if (!rasterizer_init(&priv->rasterizer, priv->engine->tile_order,
-                         RASTERIZER_PRECISION))
+    if (!rasterizer_init(priv->engine, &priv->rasterizer, RASTERIZER_PRECISION))
         goto fail;
 
     priv->cache.font_cache = ass_font_cache_create();


### PR DESCRIPTION
Found buffer overrun (since assembly overhaul, I think) in rasterizer, but instead of an easy fix decided to go the long way and complete longstanding TODO.