### PR TITLE
Cosmetic: refactor track features to bitflags

### DIFF
--- a/libass/ass_priv.h
+++ b/libass/ass_priv.h
@@ -61,9 +61,7 @@ struct parser_priv {
     // tracks [Script Info] headers set by the script
     uint32_t header_flags;
 
-#ifdef USE_FRIBIDI_EX_API
-    bool bidi_brackets;
-#endif
+    uint32_t feature_flags;
 };
 
 #endif /* LIBASS_PRIV_H */

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -2883,7 +2883,7 @@ ass_start_frame(ASS_Renderer *render_priv, ASS_Track *track,
     ass_shaper_set_level(render_priv->shaper, render_priv->settings.shaper);
 #ifdef USE_FRIBIDI_EX_API
     ass_shaper_set_bidi_brackets(render_priv->shaper,
-            track->parser_priv->bidi_brackets);
+            track->parser_priv->feature_flags & FEATURE_MASK(ASS_FEATURE_BIDI_BRACKETS));
 #endif
 
     // PAR correction

--- a/libass/ass_utils.h
+++ b/libass/ass_utils.h
@@ -48,6 +48,8 @@
 
 #define ASS_PI 3.14159265358979323846
 
+#define FEATURE_MASK(feat) (((uint32_t) 1) << (feat))
+
 #if (defined(__i386__) || defined(__x86_64__)) && CONFIG_ASM
 int has_sse2(void);
 int has_avx(void);


### PR DESCRIPTION
The idea was proposed and first implemented in #481 and is supposed to scale better when adding future boolean-features. If we want to add non-boolean features at some point this might need to be changed again.

The implementation differs from #481's and also does not include a `ass_track_get_feature_state` API, as there were open question regarding handling of meta-features and about future non-boolean features. As long as we only have boolean features and all are initialised to false, I don't think `ass_track_get_feature_state` is strictly necessary yet.