### PR TITLE
use utf16le encoded path to open file or dir on windows.

### DIFF
--- a/libass/ass.h
+++ b/libass/ass.h
@@ -24,7 +24,7 @@
 #include <stdarg.h>
 #include "ass_types.h"
 
-#define LIBASS_VERSION 0x01502000
+#define LIBASS_VERSION 0x01502001
 
 #ifdef __cplusplus
 extern "C" {
@@ -258,6 +258,10 @@ void ass_library_done(ASS_Library *priv);
  * Optional directory that will be scanned for fonts recursively.  The fonts
  * found are used for font lookup.
  * NOTE: A valid font directory is not needed to support embedded fonts.
+ * On Microsoft Windows, when using WIN32-APIs,
+ * fonts_dir must either be in UTF-8 or the encoding accpeted by fopen
+ * with UTF-8 taking precedence if both versions are valid and exist.
+ * On all other systems there is no need for special considerations like that.
  *
  * \param priv library handle
  * \param fonts_dir directory with additional fonts
@@ -474,7 +478,7 @@ void ass_get_available_font_providers(ASS_Library *priv,
  * If the requested fontprovider does not exist or fails to initialize, the
  * behavior is the same as when ASS_FONTPROVIDER_NONE was passed.
  * \param config path to fontconfig configuration file, or NULL.  Only relevant
- * if fontconfig is used.
+ * if fontconfig is used. The encoding must match the one accepted by fontconfig.
  * \param update whether fontconfig cache should be built/updated now.  Only
  * relevant if fontconfig is used.
  *
@@ -664,6 +668,10 @@ void ass_flush_events(ASS_Track *track);
  * \param fname file name
  * \param codepage encoding (iconv format)
  * \return newly allocated track or NULL on failure
+ * NOTE: On Microsoft Windows, when using WIN32-APIs,
+ * fname must either be in UTF-8 or the encoding accpeted by fopen
+ * with UTF-8 taking precedence if both versions are valid and exist.
+ * On all other systems there is no need for special considerations like that.
 */
 ASS_Track *ass_read_file(ASS_Library *library, char *fname,
                          char *codepage);
@@ -683,6 +691,10 @@ ASS_Track *ass_read_memory(ASS_Library *library, char *buf,
  * \param fname file name
  * \param codepage encoding (iconv format)
  * \return 0 on success
+ * NOTE: On Microsoft Windows, when using WIN32-APIs,
+ * fname must either be in UTF-8 or the encoding accpeted by fopen
+ * with UTF-8 taking precedence if both versions are valid and exist.
+ * On all other systems there is no need for special considerations like that.
  */
 int ass_read_styles(ASS_Track *track, char *fname, char *codepage);
 

--- a/libass/ass_library.h
+++ b/libass/ass_library.h
@@ -39,5 +39,8 @@ struct ass_library {
 };
 
 char *read_file(struct ass_library *library, char *fname, size_t *bufsize);
+#if defined(_WIN32) && !defined(__CYGWIN__)
+char *read_wide_named_file(struct ass_library *library, wchar_t *wpath, size_t *bufsize);
+#endif
 
 #endif                          /* LIBASS_LIBRARY_H */

--- a/libass/ass_utils.c
+++ b/libass/ass_utils.c
@@ -511,3 +511,34 @@ ASS_Style *lookup_style_strict(ASS_Track *track, char *name, size_t len)
     return NULL;
 }
 
+#if defined(_WIN32) && !defined(__CYGWIN__)
+wchar_t *ass_convert_to_utf16le(const char *str, UINT in_code_page, size_t *out_strlen)
+{
+    int wlen = MultiByteToWideChar(in_code_page, MB_ERR_INVALID_CHARS, str, -1, NULL, 0);
+    if (!wlen)
+        return NULL;
+    wchar_t *wstr = malloc(sizeof(wchar_t) * wlen);
+    if (!MultiByteToWideChar(in_code_page, MB_ERR_INVALID_CHARS, str, -1, wstr, wlen)) {
+        free(wstr);
+        return NULL;
+    }
+    if (out_strlen)
+        *out_strlen = wlen - 1;
+    return wstr;
+}
+
+char *ass_convert_from_utf16le(const wchar_t *wstr, UINT out_code_page, size_t *out_wstrlen)
+{
+    int len = WideCharToMultiByte(out_code_page, 0, wstr, -1, NULL, 0, NULL, NULL);
+    if (!len)
+        return NULL;
+    char *str = malloc(len);
+    if (!WideCharToMultiByte(out_code_page, 0, wstr, -1, str, len, NULL, NULL)) {
+        free(str);
+        return NULL;
+    }
+    if (out_wstrlen)
+        *out_wstrlen = len - 1;
+    return str;
+}
+#endif

--- a/libass/ass_utils.h
+++ b/libass/ass_utils.h
@@ -213,4 +213,10 @@ static inline int mystrtoi32(char **p, int base, int32_t *res)
     return *p != start;
 }
 
+#if defined(_WIN32) && !defined(__CYGWIN__)
+#include <windows.h>
+wchar_t *ass_convert_to_utf16le(const char *str, UINT in_code_page, size_t *out_strlen);
+char *ass_convert_from_utf16le(const wchar_t *wstr, UINT out_code_page, size_t *out_wstrlen);
+#endif
+
 #endif                          /* LIBASS_UTILS_H */


### PR DESCRIPTION
An alternative implementation of #526, some suggestions from #526 are referenced.