### PR TITLE
RFC: render: support explicitly tagging a line as TS or dialogue

### DIFF
--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -1060,8 +1060,14 @@ init_render_context(ASS_Renderer *render_priv, ASS_Event *event)
     render_priv->state.effect_skip_timing = 0;
 
     apply_transition_effects(render_priv, event);
-    render_priv->state.explicit = render_priv->state.evt_type != EVENT_NORMAL ||
-                                  event_has_hard_overrides(event->Text);
+
+#define EXPLICIT_DIALOGUE_MARKER "{dialogue}"
+#define EXPLICIT_TS_MARKER "{ts}"
+
+    render_priv->state.explicit = !strncmp(event->Text, EXPLICIT_DIALOGUE_MARKER, sizeof(EXPLICIT_DIALOGUE_MARKER) - 1) ? 0 :
+                                  !strncmp(event->Text, EXPLICIT_TS_MARKER, sizeof(EXPLICIT_TS_MARKER) - 1) ? 1 :
+                                  (render_priv->state.evt_type != EVENT_NORMAL ||
+                                   event_has_hard_overrides(event->Text));
 
     reset_render_context(render_priv, NULL);
     render_priv->state.alignment = render_priv->state.style->Alignment;


### PR DESCRIPTION
Some sub authors had commented on wanting to be able to use e.g. clips without making libass think a line was dialogue, or tag a margin-positioned line as TS if it's expected to align with explicitly-positioned ones. This is a simple implementation of that.

This is done via a comment at the start of the line, and only has meaning when selective overrides are enabled, so it should be safe to add.

Do we use `explicit` for anything that this might give unexpected results for? (i.e. anything where this might cause changes in rendering even without selective overrides enabled?)