### PR TITLE
[Abandoned] Add support for OpenType Variable Fonts

### DIFF
--- a/libass/ass_fontselect.c
+++ b/libass/ass_fontselect.c
@@ -668,8 +668,11 @@ static bool matches_full_or_postscript_name(ASS_FontInfo *f,
 
     if (check_postscript(f))
         return matches_postscript_name;
-    else
-        return matches_fullname;
+
+    if (matches_postscript_name)
+        return matches_postscript_name;
+
+    return matches_fullname;
 }
 
 /**


### PR DESCRIPTION
For the Multiple Masters, each named instance has its own PostScript name,
so we have to consider it when comparing PostScript names.

BUG=#578
