### PR TITLE
ci/gha: bump to ubuntu-latest and dedicated "oldlib"-build

### DIFF
--- a/.github/workflows/ghci.yml
+++ b/.github/workflows/ghci.yml
@@ -36,6 +36,12 @@ jobs:
             cc: gcc
             docker_image: alpine:latest
             shell: '/usr/bin/docker exec dockerciimage sh -e {0}'
+          # Add docker-build with minimum version of dependencies
+          - os: ubuntu-latest
+            cc: gcc
+            docker_image: oldlibs
+            docker_pullprefix: 'ghcr.io/theoneric/libass-containers/'
+            shell: '/usr/bin/docker exec dockerciimage sh -e {0}'
           # Add a Windows build (MinGW-gcc via MSYS2) with no extras
           - os: windows-2019
             msystem: MINGW32
@@ -64,11 +70,13 @@ jobs:
         if: matrix.docker_image
         shell: bash
         run: |
-          # Note: With this setup everything inside the container will be run as root
-          docker pull "${{ matrix.docker_image }}"
+          # Note: Many containers default to the root user
+          docker pull "${{ matrix.docker_pullprefix }}${{ matrix.docker_image }}"
           docker create --name dockerciimage \
             -v "/home/runner/work:/home/runner/work" --workdir "$PWD"  \
-            --entrypoint "tail" "${{ matrix.docker_image }}" "-f" "/dev/null"
+            --entrypoint "tail" \
+            "${{ matrix.docker_pullprefix }}${{ matrix.docker_image }}" \
+            "-f" "/dev/null"
           docker start dockerciimage
 
       - name: Setup MSys2
@@ -99,6 +107,9 @@ jobs:
               apk add nasm ${{ matrix.cc }} musl-dev \
                       make automake autoconf libtool pkgconf \
                       fontconfig-dev freetype-dev fribidi-dev harfbuzz-dev
+              ;;
+            oldlibs)
+              : # Everything is preinstalled
               ;;
             *)
               sudo apt-get update #&& sudo apt-get upgrade

--- a/.github/workflows/ghci.yml
+++ b/.github/workflows/ghci.yml
@@ -12,22 +12,23 @@ jobs:
       ${{ matrix.cc }}${{ matrix.api && ', ' }}${{ matrix.api }})
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-10.15]
+        os: [ubuntu-latest, macos-10.15]
         cc: [gcc, clang]
+        docker_image: ['']
         exclude:
           - os: macos-10.15
             cc: gcc
         include:
           # Enable distcheck for one build
-          - os: ubuntu-18.04
+          - os: ubuntu-latest
             cc: gcc
             do_distc: yes
           # Run Coverity on a clang build; Coverity's gcc causes issues
-          - os: ubuntu-18.04
+          - os: ubuntu-latest
             cc: clang
             do_coverity: yes
           # Add a tcc build
-          - os: ubuntu-18.04
+          - os: ubuntu-latest
             cc: tcc
             ld: tcc
           # Build in an Alpine Docker image

--- a/.github/workflows/ghci.yml
+++ b/.github/workflows/ghci.yml
@@ -31,12 +31,12 @@ jobs:
           - os: ubuntu-latest
             cc: tcc
             ld: tcc
-          # Build in an Alpine Docker image
+          # Add docker-build on Alpine
           - os: ubuntu-latest
             cc: gcc
             docker_image: alpine:latest
             shell: '/usr/bin/docker exec dockerciimage sh -e {0}'
-          # Add an additional Windows build (MinGW-gcc via MSYS2) with no extras
+          # Add a Windows build (MinGW-gcc via MSYS2) with no extras
           - os: windows-2019
             msystem: MINGW32
             cc: gcc
@@ -102,7 +102,8 @@ jobs:
               ;;
             *)
               sudo apt-get update #&& sudo apt-get upgrade
-              sudo apt-get install -y \
+              sudo apt-get install -y --no-install-recommends \
+                   autoconf automake make libtool \
                    libfontconfig1-dev libfreetype6-dev libfribidi-dev \
                    libharfbuzz-dev nasm ${{ matrix.cc }}
               ;;

--- a/configure.ac
+++ b/configure.ac
@@ -338,8 +338,9 @@ AM_COND_IF([ENABLE_LARGE_TILES], [
 AS_IF([test -e "${srcdir}/.git"], [
     AC_PATH_PROG([git_bin], [git])
     AS_IF([test -n "$git_bin"], [
-        tmp="$("$git_bin" -C "$srcdir" describe --tags --long --always --dirty --broken --abbrev=40 2>/dev/null)"
-        test "$?" -eq 0 || tmp="failed to get commit"
+        tmp="$("$git_bin" -C "$srcdir" describe --tags --long --always --broken --abbrev=40 2>/dev/null)" \
+        || tmp="$("$git_bin" -C "$srcdir" describe --tags --long --always --dirty --abbrev=40 2>/dev/null)" \
+        || tmp="failed to determine (>= AC_PACKAGE_VERSION)"
         srcversion_string="commit: $tmp"
     ], [
         srcversion_string="custom after: AC_PACKAGE_VERSION"

--- a/configure.ac
+++ b/configure.ac
@@ -72,8 +72,8 @@ PKG_CHECK_MODULES([FREETYPE], [freetype2 >= 9.17.3], [
     AC_DEFINE(CONFIG_FREETYPE, 1, [found freetype2 via pkg-config])
 ])
 
-PKG_CHECK_MODULES([FRIBIDI], [fribidi >= 0.19.0], [
-    pkg_requires="fribidi >= 0.19.0, ${pkg_requires}"
+PKG_CHECK_MODULES([FRIBIDI], [fribidi >= 0.19.1], [
+    pkg_requires="fribidi >= 0.19.1, ${pkg_requires}"
     CFLAGS="$CFLAGS $FRIBIDI_CFLAGS"
     LIBS="$LIBS $FRIBIDI_LIBS"
     AC_DEFINE(CONFIG_FRIBIDI, 1, [found fribidi via pkg-config])


### PR DESCRIPTION
First commit as suggested by astiob, though I'm not sure how far back the extra `--dirty` step works.
The "oldlib" container has almost the minimum version of all direct dependencies:
  - FreeType2 `2.3.6`(external) - `9.17.3`(internal)
  - HarfBuzz `1.2.3`
  - Fontconfig `2.10.92`
  - FriBidi `0.19.1` *(I couldn't find a tarball for `0.19.0` and there's no tag for it either; though the diff shows configure.ac used 0.19.0 at some point)*

As well as:
  - automake 1.11
  - autoconf 2.64
  - gcc 6.3
  - Debian Stretch's default version of `libpng` and `libexpat`, the latter being a transitive dependency

`docker_fetch` and `docker_image` allow to easily extend this to more purpose-built containers both from the same or other build-repo.
The build-recipe and binary for the container can be found here: https://github.com/TheOneric/libass-containers