### PR TITLE
autotools: Fix static library for mingw

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -77,6 +77,12 @@ PKG_CHECK_MODULES([FRIBIDI], [fribidi >= 0.19.1], [
     CFLAGS="$CFLAGS $FRIBIDI_CFLAGS"
     LIBS="$LIBS $FRIBIDI_LIBS"
     AC_DEFINE(CONFIG_FRIBIDI, 1, [found fribidi via pkg-config])
+    if test "$enable_static" = "no"; then
+        static_fribidi=no
+    else
+        static_fribidi=yes
+    fi
+    AM_CONDITIONAL([STATIC_FRIBIDI], [ test "$static_fribidi" = yes ])
 ])
 
 PKG_CHECK_MODULES([HARFBUZZ], [harfbuzz >= 1.2.3], [

--- a/libass/Makefile.am
+++ b/libass/Makefile.am
@@ -1,3 +1,11 @@
+if STATIC_FRIBIDI
+extra_CPPFLAGS = -DFRIBIDI_LIB_STATIC
+else
+extra_CPPFLAGS =
+endif
+
+AM_CPPFLAGS = $(extra_CPPFLAGS)
+
 AM_CFLAGS = -std=gnu99 -Wall -Wextra -Wno-sign-compare -Wno-unused-parameter \
             -Werror-implicit-function-declaration -Wstrict-prototypes        \
             -Wpointer-arith -Wredundant-decls -Wno-missing-field-initializers\


### PR DESCRIPTION
This change defines FRIBIDI_LIB_STATIC while building static library
if fribidi present. Otherwise, libass static library imports fribidi
APIs with dllimport attribute.