### PR TITLE
font: use iconv to handle non-unicode cmap microsoft fonts.

### DIFF
--- a/libass/ass_shaper.c
+++ b/libass/ass_shaper.c
@@ -283,7 +283,9 @@ get_glyph_nominal(hb_font_t *font, void *font_data, hb_codepoint_t unicode,
     FT_Face face = font_data;
     struct ass_shaper_metrics_data *metrics_priv = user_data;
 
-    *glyph = FT_Get_Char_Index(face, ass_font_index_magic(face, unicode));
+    *glyph = ass_font_index_magic(face, unicode);
+    if (*glyph)
+        *glyph = FT_Get_Char_Index(face, *glyph);
     if (!*glyph)
         return false;
 
@@ -300,7 +302,9 @@ get_glyph_variation(hb_font_t *font, void *font_data, hb_codepoint_t unicode,
     FT_Face face = font_data;
     struct ass_shaper_metrics_data *metrics_priv = user_data;
 
-    *glyph = FT_Face_GetCharVariantIndex(face, ass_font_index_magic(face, unicode), variation);
+    *glyph = ass_font_index_magic(face, unicode);
+    if (*glyph)
+        *glyph = FT_Face_GetCharVariantIndex(face, *glyph, variation);
     if (!*glyph)
         return false;
 
@@ -794,7 +798,9 @@ static void shape_fribidi(ASS_Shaper *shaper, GlyphInfo *glyphs, size_t len)
         GlyphInfo *info = glyphs + i;
         FT_Face face = info->font->faces[info->face_index];
         info->symbol = shaper->event_text[i];
-        info->glyph_index = FT_Get_Char_Index(face, ass_font_index_magic(face, shaper->event_text[i]));
+        info->glyph_index = ass_font_index_magic(face, shaper->event_text[i]);
+        if (info->glyph_index)
+            info->glyph_index = FT_Get_Char_Index(face, info->glyph_index);
     }
 
     free(joins);


### PR DESCRIPTION
To resolve #531.
In case of non-Unicode cmap fonts, convert unicode code point(a UCS-4 code unit) to corresponding multibyte charset bytes, then assemble those bytes into a uint32_t, assuming those bytes present a prefix-zero-bytes-omitted big-endian integer. Freetype can make use of the converted code point to find correct glyph by non-Unicode cmap.

It introduces a dependency of `libiconv`. On Windows, `WideCharToMultiByte` is available to avoid libiconv if needed.

And I have just tested this patch on samples from #531 and #575, which covers BIG5 and SHIFT-JIS. For other encodings, I think it should work but I can't confirm. So further testing is needed.

#531 testing screenshot: 
![fix1](https://user-images.githubusercontent.com/12186841/148731387-96eb3f1e-45f4-44b3-9fad-6d9ce24f8f8e.png)

#575 testing screenshot: 
![fix2](https://user-images.githubusercontent.com/12186841/148731485-6abdcae8-2475-426c-9565-92fe214301ba.png)
