### PR TITLE
WCHAR - wchar_t distinction

### DIFF
--- a/libass/ass_directwrite.c
+++ b/libass/ass_directwrite.c
@@ -482,7 +482,7 @@ static char *get_utf8_name(IDWriteLocalizedStrings *names, int k)
     if (length >= (UINT32) -1 || length + (size_t) 1 > SIZE_MAX / sizeof(wchar_t))
         goto cleanup;
 
-    temp_name = (wchar_t *) malloc((length + 1) * sizeof(wchar_t));
+    temp_name = malloc((length + 1) * sizeof(wchar_t));
     if (!temp_name)
         goto cleanup;
 
@@ -495,7 +495,7 @@ static char *get_utf8_name(IDWriteLocalizedStrings *names, int k)
     if (!size_needed)
         goto cleanup;
 
-    mbName = (char *) malloc(size_needed);
+    mbName = malloc(size_needed);
     if (!mbName)
         goto cleanup;
 
@@ -616,7 +616,7 @@ static void add_font_face(IDWriteFontFace *face, ASS_FontProvider *provider,
             goto cleanup;
     }
 
-    FontPrivate *font_priv = (FontPrivate *) calloc(1, sizeof(*font_priv));
+    FontPrivate *font_priv = calloc(1, sizeof(*font_priv));
     if (!font_priv)
         goto cleanup;
 
@@ -815,7 +815,7 @@ static void add_font(IDWriteFont *font, IDWriteFontFamily *fontFamily,
     if (!get_font_info_IDWriteFont(font, fontFamily, &meta))
         goto cleanup;
 
-    FontPrivate *font_priv = (FontPrivate *) calloc(1, sizeof(*font_priv));
+    FontPrivate *font_priv = calloc(1, sizeof(*font_priv));
     if (!font_priv)
         goto cleanup;
     font_priv->font = font;
@@ -1086,7 +1086,7 @@ ASS_FontProvider *ass_directwrite_add_provider(ASS_Library *lib,
         goto cleanup;
     }
 
-    priv = (ProviderPrivate *)calloc(sizeof(*priv), 1);
+    priv = calloc(sizeof(*priv), 1);
     if (!priv)
         goto cleanup;
 

--- a/libass/ass_directwrite.c
+++ b/libass/ass_directwrite.c
@@ -28,7 +28,7 @@
 #include "ass_directwrite.h"
 #include "ass_utils.h"
 
-#define FALLBACK_DEFAULT_FONT L"Arial"
+#define FALLBACK_DEFAULT_FONT u"Arial"
 
 static const ASS_FontMapping font_substitutions[] = {
     {"sans-serif", "Arial"},
@@ -457,7 +457,7 @@ static void destroy_font(void *data)
     free(priv);
 }
 
-static int encode_utf16(wchar_t *chars, uint32_t codepoint)
+static int encode_utf16(WCHAR *chars, uint32_t codepoint)
 {
     if (codepoint < 0x10000) {
         chars[0] = codepoint;
@@ -471,7 +471,7 @@ static int encode_utf16(wchar_t *chars, uint32_t codepoint)
 
 static char *get_utf8_name(IDWriteLocalizedStrings *names, int k)
 {
-    wchar_t *temp_name = NULL;
+    WCHAR *temp_name = NULL;
     char *mbName = NULL;
 
     UINT32 length;
@@ -479,10 +479,10 @@ static char *get_utf8_name(IDWriteLocalizedStrings *names, int k)
     if (FAILED(hr))
         goto cleanup;
 
-    if (length >= (UINT32) -1 || length + (size_t) 1 > SIZE_MAX / sizeof(wchar_t))
+    if (length >= (UINT32) -1 || length + (size_t) 1 > SIZE_MAX / sizeof(WCHAR))
         goto cleanup;
 
-    temp_name = malloc((length + 1) * sizeof(wchar_t));
+    temp_name = malloc((length + 1) * sizeof(WCHAR));
     if (!temp_name)
         goto cleanup;
 
@@ -520,13 +520,13 @@ static char *get_fallback(void *priv, ASS_Library *lib,
 
     hr = IDWriteFactory_CreateTextFormat(dw_factory, FALLBACK_DEFAULT_FONT, NULL,
             DWRITE_FONT_WEIGHT_MEDIUM, DWRITE_FONT_STYLE_NORMAL,
-            DWRITE_FONT_STRETCH_NORMAL, 1.0f, L"", &text_format);
+            DWRITE_FONT_STRETCH_NORMAL, 1.0f, u"", &text_format);
     if (FAILED(hr)) {
         return NULL;
     }
 
     // Encode codepoint as UTF-16
-    wchar_t char_string[2];
+    WCHAR char_string[2];
     int char_len = encode_utf16(char_string, codepoint);
 
     // Create a text_layout, a high-level text rendering facility, using
@@ -736,7 +736,7 @@ static int CALLBACK font_enum_proc(const ENUMLOGFONTW *lpelf,
     if (!SelectObject(hdc, hFont))
         goto cleanup;
 
-    wchar_t selected_name[LF_FACESIZE];
+    WCHAR selected_name[LF_FACESIZE];
     if (!GetTextFaceW(hdc, LF_FACESIZE, selected_name))
         goto cleanup;
     if (wcsncmp(selected_name, lpelf->elfLogFont.lfFaceName, LF_FACESIZE)) {
@@ -935,7 +935,7 @@ static void match_fonts(void *priv, ASS_Library *lib,
             DWRITE_FONT_PROPERTY property = {
                 property_ids[i],
                 lf.lfFaceName,
-                L"",
+                u"",
             };
 
             IDWriteFontSet *filteredSet;

--- a/libass/ass_directwrite_info_template.h
+++ b/libass/ass_directwrite_info_template.h
@@ -40,7 +40,7 @@ static bool NAME(FONT_TYPE)(FONT_TYPE *font,
 
     if (exists) {
         meta->n_fullname = IDWriteLocalizedStrings_GetCount(fontNames);
-        meta->fullnames = (char **) calloc(meta->n_fullname, sizeof(char *));
+        meta->fullnames = calloc(meta->n_fullname, sizeof(char *));
         if (!meta->fullnames) {
             IDWriteLocalizedStrings_Release(fontNames);
             return false;
@@ -69,7 +69,7 @@ static bool NAME(FONT_TYPE)(FONT_TYPE *font,
         return false;
 
     meta->n_family = IDWriteLocalizedStrings_GetCount(familyNames);
-    meta->families = (char **) calloc(meta->n_family, sizeof(char *));
+    meta->families = calloc(meta->n_family, sizeof(char *));
     if (!meta->families) {
         IDWriteLocalizedStrings_Release(familyNames);
         return false;

--- a/test/test.c
+++ b/test/test.c
@@ -77,7 +77,7 @@ static void write_png(char *fname, image_t *img)
 
     png_set_bgr(png_ptr);
 
-    row_pointers = (png_byte **) malloc(img->height * sizeof(png_byte *));
+    row_pointers = malloc(img->height * sizeof(png_byte *));
     for (k = 0; k < img->height; k++)
         row_pointers[k] = img->buffer + img->stride * k;
 
@@ -118,7 +118,7 @@ static image_t *gen_image(int width, int height)
     img->width = width;
     img->height = height;
     img->stride = width * 3;
-    img->buffer = (unsigned char *) calloc(1, height * width * 3);
+    img->buffer = calloc(1, height * width * 3);
     memset(img->buffer, 63, img->stride * img->height);
     //for (int i = 0; i < height * width * 3; ++i)
     // img->buffer[i] = (i/3/50) % 100;


### PR DESCRIPTION
Concept for a more throughout `WCHAR`-`wchar_t` distinction likely required for midipix as discussed in #583.
Uses C11's `u"..."` prefix for `WCHAR *`-literals, which MinGW (currently) accepts even with `-std=gnu99`, and replaces the `wchar_t`-API `wcsncmp` with Microsoft's `CompareStringOrdinal`.
Not actually tested beyond compilation, feel free to force-push this branch if you prefer.