### PR TITLE
[WiP] Introduce LayoutResX/Y script headers

### DIFF
--- a/libass/ass.c
+++ b/libass/ass.c
@@ -406,6 +406,10 @@ void ass_process_force_style(ASS_Track *track)
             track->PlayResX = atoi(token);
         else if (!ass_strcasecmp(*fs, "PlayResY"))
             track->PlayResY = atoi(token);
+        else if (!ass_strcasecmp(*fs, "LayoutResX"))
+            track->LayoutResX = atoi(token);
+        else if (!ass_strcasecmp(*fs, "LayoutResY"))
+            track->LayoutResY = atoi(token);
         else if (!ass_strcasecmp(*fs, "Timer"))
             track->Timer = ass_atof(token);
         else if (!ass_strcasecmp(*fs, "WrapStyle"))
@@ -681,6 +685,12 @@ static int process_info_line(ASS_Track *track, char *str)
     } else if (!strncmp(str, "PlayResY:", 9)) {
         check_duplicate_info_line(track, SINFO_PLAYRESY, "PlayResY");
         track->PlayResY = atoi(str + 9);
+    } else if (!strncmp(str, "LayoutResX:", 11)) {
+        check_duplicate_info_line(track, SINFO_LAYOUTRESX, "LayoutResX");
+        track->LayoutResX = atoi(str + 11);
+    } else if (!strncmp(str, "LayoutResY:", 11)) {
+        check_duplicate_info_line(track, SINFO_LAYOUTRESY, "LayoutResY");
+        track->LayoutResY = atoi(str + 11);
     } else if (!strncmp(str, "Timer:", 6)) {
         check_duplicate_info_line(track, SINFO_TIMER, "Timer");
         track->Timer = ass_atof(str + 6);
@@ -1573,10 +1583,15 @@ void ass_lazy_track_init(ASS_Library *lib, ASS_Track *track)
     if (track->PlayResX > 0 && track->PlayResY > 0)
         return;
     if (track->PlayResX <= 0 && track->PlayResY <= 0) {
-        ass_msg(lib, MSGL_WARN,
-               "Neither PlayResX nor PlayResY defined. Assuming 384x288");
-        track->PlayResX = 384;
-        track->PlayResY = 288;
+        if (track->LayoutResX > 0 && track->LayoutResY > 0) {
+            track->PlayResX = track->LayoutResX;
+            track->PlayResY = track->LayoutResY;
+        } else {
+            ass_msg(lib, MSGL_WARN,
+                   "Neither PlayResX nor PlayResY defined. Assuming 384x288");
+            track->PlayResX = 384;
+            track->PlayResY = 288;
+        }
     } else {
         if (track->PlayResY <= 0 && track->PlayResX == 1280) {
             track->PlayResY = 1024;

--- a/libass/ass.h
+++ b/libass/ass.h
@@ -24,7 +24,7 @@
 #include <stdarg.h>
 #include "ass_types.h"
 
-#define LIBASS_VERSION 0x01502001
+#define LIBASS_VERSION 0x01502002
 
 #ifdef __cplusplus
 extern "C" {

--- a/libass/ass_priv.h
+++ b/libass/ass_priv.h
@@ -41,8 +41,10 @@ typedef enum {
     SINFO_SCALEDBORDER = 1 << 5,
     SINFO_COLOURMATRIX = 1 << 6,
     SINFO_KERNING      = 1 << 7,
+    SINFO_LAYOUTRESX   = 1 << 8,
+    SINFO_LAYOUTRESY   = 1 << 9,
     // for legacy detection
-    GENBY_FFMPEG       = 1 << 8
+    GENBY_FFMPEG       = 1 << 10
     // max 32 enumerators
 } ScriptInfo;
 

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -959,6 +959,19 @@ static ASS_Style *handle_selective_style_overrides(ASS_Renderer *render_priv,
     return new;
 }
 
+static inline ASS_Vector get_layout_res(ASS_Renderer *render_priv)
+{
+    ASS_Track *track = render_priv->track;
+    if (track->LayoutResX > 0 && track->LayoutResY > 0)
+        return (ASS_Vector) { track->LayoutResX, track->LayoutResY };
+
+    ASS_Settings *settings = &render_priv->settings;
+    if (settings->storage_width > 0 && settings->storage_height > 0)
+        return (ASS_Vector) { settings->storage_width, settings->storage_height };
+
+    return (ASS_Vector) { track->PlayResX, track->PlayResY };
+}
+
 static void init_font_scale(ASS_Renderer *render_priv)
 {
     ASS_Settings *settings_priv = &render_priv->settings;
@@ -968,10 +981,7 @@ static void init_font_scale(ASS_Renderer *render_priv)
         font_scr_h = render_priv->fit_height;
 
     render_priv->font_scale = font_scr_h / render_priv->track->PlayResY;
-    if (settings_priv->storage_height)
-        render_priv->blur_scale = font_scr_h / settings_priv->storage_height;
-    else
-        render_priv->blur_scale = font_scr_h / render_priv->track->PlayResY;
+    render_priv->blur_scale = font_scr_h / get_layout_res(render_priv).y;
     if (render_priv->track->ScaledBorderAndShadow)
         render_priv->border_scale =
             font_scr_h / render_priv->track->PlayResY;
@@ -2852,8 +2862,6 @@ static bool
 ass_start_frame(ASS_Renderer *render_priv, ASS_Track *track,
                 long long now)
 {
-    ASS_Settings *settings_priv = &render_priv->settings;
-
     if (!render_priv->settings.frame_width
         && !render_priv->settings.frame_height)
         return false;               // library not initialized
@@ -2890,13 +2898,12 @@ ass_start_frame(ASS_Renderer *render_priv, ASS_Track *track,
 
     // PAR correction
     double par = render_priv->settings.par;
-    if (par == 0.) {
-        if (render_priv->orig_width && render_priv->orig_height &&
-            settings_priv->storage_width && settings_priv->storage_height) {
+    if (par == 0 || (track->LayoutResX > 0 && track->LayoutResY > 0)) {
+        if (render_priv->orig_width && render_priv->orig_height) {
             double dar = ((double) render_priv->orig_width) /
                          render_priv->orig_height;
-            double sar = ((double) settings_priv->storage_width) /
-                         settings_priv->storage_height;
+            ASS_Vector layout_res = get_layout_res(render_priv);
+            double sar = (double) layout_res.x / layout_res.y;
             par = dar / sar;
         } else
             par = 1.0;

--- a/libass/ass_types.h
+++ b/libass/ass_types.h
@@ -207,6 +207,9 @@ typedef struct ass_track {
     ASS_Library *library;
     ASS_ParserPriv *parser_priv;
 
+    int LayoutResX;
+    int LayoutResY;
+
     // New fields can be added here in new ABI-compatible library releases.
 } ASS_Track;
 


### PR DESCRIPTION
This is my follow-up to the relevant IRC discussion: how I think resolution-independence should be achieved. Also I think this can be a good place for a more persistent discussion on the matter.

Main points of this ASS extension:
- New script headers `LayoutResX` and `LayoutResY` with the same semantics as `PlayResX` and `PlayResY`.
- Lone `LayoutResX` or `LayoutResY` is ignored. This is suboptimal, but introduction of new failure modes would be hard, especially outside libass. Alternatively we can derive missing dimension based on some fixed ratio (16&times;9?) similar to `PlayResXY`.
- Correctly paired `LayoutResX` and `LayoutResY` override video size in all internal calculations.