### PR TITLE
Fix x86 cpuid

### DIFF
--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -75,9 +75,11 @@ ASS_Renderer *ass_renderer_init(ASS_Library *library)
     // images_root and related stuff is zero-filled in calloc
 
 #if CONFIG_ASM && ARCH_X86
-    if (has_avx2())
+    bool sse2, avx2;
+    ass_cpu_capabilities(&sse2, &avx2);
+    if (avx2)
         priv->engine = &ass_bitmap_engine_avx2;
-    else if (has_sse2())
+    else if (sse2)
         priv->engine = &ass_bitmap_engine_sse2;
     else
         priv->engine = &ass_bitmap_engine_c;

--- a/libass/ass_utils.c
+++ b/libass/ass_utils.c
@@ -40,6 +40,9 @@ void ass_cpu_capabilities(bool *sse2, bool *avx2)
     *sse2 = false;
     *avx2 = false;
 
+    if (!ass_has_cpuid())
+        return;
+
     uint32_t eax = 0, ebx, ecx, edx;
     ass_get_cpuid(&eax, &ebx, &ecx, &edx);
     uint32_t max_leaf = eax;

--- a/libass/ass_utils.c
+++ b/libass/ass_utils.c
@@ -35,33 +35,39 @@
 
 #include "x86/cpuid.h"
 
-int has_sse2(void)
+void ass_cpu_capabilities(bool *sse2, bool *avx2)
 {
-    uint32_t eax = 1, ebx, ecx, edx;
-    ass_get_cpuid(&eax, &ebx, &ecx, &edx);
-    return (edx >> 26) & 0x1;
-}
+    *sse2 = false;
+    *avx2 = false;
 
-int has_avx(void)
-{
-    uint32_t eax = 1, ebx, ecx, edx;
+    uint32_t eax = 0, ebx, ecx, edx;
     ass_get_cpuid(&eax, &ebx, &ecx, &edx);
-    if (!(ecx & (1 << 27))) // not OSXSAVE
-        return 0;
-    uint32_t misc = ecx;
-    ass_get_xgetbv(0, &eax, &edx);
-    if ((eax & 0x6) != 0x6)
-        return 0;
-    return (misc >> 28) & 0x1;
-}
+    uint32_t max_leaf = eax;
+    bool avx = false;
 
-int has_avx2(void)
-{
-    uint32_t eax = 7, ebx, ecx, edx;
-    ass_get_cpuid(&eax, &ebx, &ecx, &edx);
-    return (ebx >> 5) & has_avx();
-}
+    if (max_leaf >= 1) {
+        eax = 1;
+        ass_get_cpuid(&eax, &ebx, &ecx, &edx);
+        if (edx & (1 << 26))  // SSE2
+            *sse2 = true;
 
+        if (ecx & (1 << 27) &&  // OSXSAVE
+            ecx & (1 << 28)) {  // AVX
+            uint32_t xcr0l, xcr0h;
+            ass_get_xgetbv(0, &xcr0l, &xcr0h);
+            if (xcr0l & (1 << 1) &&  // XSAVE for XMM
+                xcr0l & (1 << 2))    // XSAVE for YMM
+                    avx = true;
+        }
+    }
+
+    if (max_leaf >= 7) {
+        eax = 7;
+        ass_get_cpuid(&eax, &ebx, &ecx, &edx);
+        if (avx && ebx & (1 << 5))  // AVX2
+            *avx2 = true;
+    }
+}
 #endif // ASM
 
 // Fallbacks

--- a/libass/ass_utils.h
+++ b/libass/ass_utils.h
@@ -51,9 +51,7 @@
 #define FEATURE_MASK(feat) (((uint32_t) 1) << (feat))
 
 #if CONFIG_ASM && ARCH_X86
-int has_sse2(void);
-int has_avx(void);
-int has_avx2(void);
+void ass_cpu_capabilities(bool *sse2, bool *avx2);
 #endif
 
 typedef struct {

--- a/libass/x86/blend_bitmaps.asm
+++ b/libass/x86/blend_bitmaps.asm
@@ -1,5 +1,5 @@
 ;******************************************************************************
-;* add_bitmaps.asm: SSE2 and x86 add_bitmaps
+;* blend_bitmaps.asm: SSE2 and AVX2 bitmap blending
 ;******************************************************************************
 ;* Copyright (C) 2013 rcombs <rcombs@rcombs.me>
 ;*

--- a/libass/x86/cpuid.asm
+++ b/libass/x86/cpuid.asm
@@ -23,6 +23,30 @@
 SECTION .text
 
 ;------------------------------------------------------------------------------
+; uint32_t has_cpuid( void );
+;------------------------------------------------------------------------------
+
+INIT_XMM
+cglobal has_cpuid, 0, 0, 0
+%if ARCH_X86_64
+    mov eax, 1
+%else
+    pushfd
+    pop ecx
+    mov eax, ecx
+    xor eax, 0x00200000
+    push eax
+    popfd
+    pushfd
+    pop eax
+    xor eax, ecx
+    and eax, 0x00200000 ; non-zero if bit is writable
+    push ecx            ; Restore original EFLAGS
+    popfd
+%endif
+    RET
+
+;------------------------------------------------------------------------------
 ; void get_cpuid( uint32_t *eax, uint32_t *ebx, uint32_t *ecx, uint32_t *edx);
 ;------------------------------------------------------------------------------
 

--- a/libass/x86/cpuid.asm
+++ b/libass/x86/cpuid.asm
@@ -1,5 +1,5 @@
 ;******************************************************************************
-;* add_bitmaps.asm: SSE2 and x86 add_bitmaps
+;* cpuid.asm: check for cpu capabilities
 ;******************************************************************************
 ;* Copyright (C) 2013 rcombs <rcombs@rcombs.me>
 ;*

--- a/libass/x86/cpuid.h
+++ b/libass/x86/cpuid.h
@@ -21,6 +21,7 @@
 
 #include <stdint.h>
 
+uint32_t ass_has_cpuid( void );
 void ass_get_cpuid( uint32_t *eax, uint32_t *ebx, uint32_t *ecx, uint32_t *edx);
 void ass_get_xgetbv( uint32_t op, uint32_t *eax, uint32_t *edx );
 


### PR DESCRIPTION
As discussed in #603 we need to check for cpuid support and if it is supported for the highest leaf available to avoid crashes and bogus results respectively.

The content of `ass_cpu_capabilities` is mostly copied from #400 and #559 but instead of using bitflags and moving it into a new / into the bitmap header it for now remains in `ass_utils`. It can be moved and switched to bitflags with the checkasm- and aarch64-related refactoring.

I'm still not 100% sure why x86_64 supposedly always supports cpuid, but gcc and [ffmpeg](https://github.com/FFmpeg/FFmpeg/commit/d05f808dc90a55f2a6eabe6ff62eb3a056e428d3) assume this *(x264 appears to have copied the check from ffmpeg; LAME only has 32bit assembly afaict)* and Zapeth’s guess about an implicit dependency SSE or so seems plausible.