### PR TITLE
fontselect: use language from track for fallback selection

### DIFF
--- a/libass/ass.c
+++ b/libass/ass.c
@@ -884,7 +884,12 @@ static int process_info_line(ASS_Track *track, char *str)
         char *p = str + 9;
         while (*p && ass_isspace(*p)) p++;
         free(track->Language);
-        track->Language = strndup(p, 2);
+        track->Language = strdup(p);
+        if (track->Language) {
+            char *end = track->Language + strlen(track->Language);
+            rskip_spaces(&end, track->Language);
+            *end = 0;
+        }
     } else if (!strncmp(str, "ScriptType:", 11)) {
         check_duplicate_info_line(track, SINFO_SCRIPTTYPE, "ScriptType");
         parse_script_type(track, str + 11);

--- a/libass/ass_cache.c
+++ b/libass/ass_cache.c
@@ -58,7 +58,11 @@ static bool font_key_move(void *dst, void *src)
 
     *d = *s;
     d->family.str = ass_copy_string(s->family);
-    return d->family.str;
+    if (d->family.str)
+        d->locale.str = ass_copy_string(s->locale);
+    if (!d->locale.str)
+        free((char *)d->family.str);
+    return d->family.str && d->locale.str;
 }
 
 static void font_destruct(void *key, void *value)

--- a/libass/ass_cache_template.h
+++ b/libass/ass_cache_template.h
@@ -52,6 +52,7 @@
 
 START(font, ass_font_desc )
     STRING(family)
+    STRING(locale)
     GENERIC(unsigned, bold)
     GENERIC(unsigned, italic)
     GENERIC(int, vertical)  // @font vertical layout

--- a/libass/ass_coretext.c
+++ b/libass/ass_coretext.c
@@ -29,6 +29,10 @@
 
 #include "ass_coretext.h"
 
+#ifndef __has_builtin
+#define __has_builtin 0
+#endif
+
 #define SAFE_CFRelease(x) do { if (x) CFRelease(x); } while (0)
 
 static const ASS_FontMapping font_substitutions[] = {

--- a/libass/ass_coretext.c
+++ b/libass/ass_coretext.c
@@ -250,8 +250,7 @@ cleanup:
 static char *get_fallback(void *priv, ASS_Library *lib,
                           const char *family, uint32_t codepoint)
 {
-    CFStringRef name = CFStringCreateWithBytes(
-        0, (UInt8 *)family, strlen(family), kCFStringEncodingUTF8, false);
+    CFStringRef name = CFStringCreateWithCString(NULL, family, kCFStringEncodingUTF8);
     if (!name)
         return NULL;
 

--- a/libass/ass_font.c
+++ b/libass/ass_font.c
@@ -475,6 +475,7 @@ size_t ass_font_construct(void *key, void *value, void *priv)
     font->shaper_priv = NULL;
     font->n_faces = 0;
     font->desc.family = desc->family;
+    font->desc.locale = desc->locale;
     font->desc.bold = desc->bold;
     font->desc.italic = desc->italic;
     font->desc.vertical = desc->vertical;
@@ -696,6 +697,7 @@ void ass_font_clear(ASS_Font *font)
             FT_Done_Face(font->faces[i]);
     }
     free((char *) font->desc.family.str);
+    free((char *) font->desc.locale.str);
 }
 
 /**

--- a/libass/ass_fontconfig.c
+++ b/libass/ass_fontconfig.c
@@ -32,16 +32,8 @@
 
 #define MAX_NAME 100
 
-typedef struct fc_locale_private {
-    ASS_StringView locale;
-    FcFontSet *fallbacks;
-    FcCharSet *fallback_chars;
-} ProviderLocale;
-
 typedef struct fc_private {
     FcConfig *config;
-    size_t nb_locales;
-    ProviderLocale **locales;
 } ProviderPrivate;
 
 static bool check_postscript(void *priv)
@@ -81,16 +73,6 @@ static void destroy(void *priv)
 {
     ProviderPrivate *fc = (ProviderPrivate *)priv;
 
-    for (size_t i = 0; i < fc->nb_locales; i++) {
-        if (fc->locales[i]->fallback_chars)
-            FcCharSetDestroy(fc->locales[i]->fallback_chars);
-        if (fc->locales[i]->fallbacks)
-            FcFontSetDestroy(fc->locales[i]->fallbacks);
-        if (fc->locales[i]->locale.str)
-            free((char*)fc->locales[i]->locale.str);
-        free(fc->locales[i]);
-    }
-    free(fc->locales);
     FcConfigDestroy(fc->config);
     free(fc);
 }
@@ -202,165 +184,78 @@ static void scan_fonts(FcConfig *config, ASS_FontProvider *provider)
     }
 }
 
-static void cache_fallbacks(ProviderPrivate *fc, ProviderLocale *pLoc)
-{
-    FcResult result;
-
-    if (pLoc->fallbacks)
-        return;
-
-    // Create a suitable pattern
-    FcPattern *pat = FcPatternCreate();
-    FcPatternAddString(pat, FC_FAMILY, (const FcChar8 *)"sans-serif");
-    FcPatternAddBool(pat, FC_OUTLINE, FcTrue);
-    FcConfigSubstitute (fc->config, pat, FcMatchPattern);
-    FcDefaultSubstitute (pat);
-
-    // FC_LANG is automatically set according to locale, but this results
-    // in strange sorting sometimes, so remove the attribute completely.
-    FcPatternDel(pat, FC_LANG);
-
-    if (pLoc->locale.len)
-        FcPatternAddString(pat, FC_LANG, (const FcChar8 *)pLoc->locale.str);
-
-    // Sort installed fonts and eliminate duplicates; this can be very
-    // expensive.
-    pLoc->fallbacks = FcFontSort(fc->config, pat, FcTrue, &pLoc->fallback_chars,
-            &result);
-
-    // If this fails, just add an empty set
-    if (result != FcResultMatch)
-        pLoc->fallbacks = FcFontSetCreate();
-
-    FcPatternDestroy(pat);
-}
-
-static ProviderLocale *get_locale(ProviderPrivate *fc, ASS_StringView localeName)
-{
-    for (size_t i = 0; i < fc->nb_locales; i++) {
-        if (!ass_string_equal(fc->locales[i]->locale, localeName))
-            return fc->locales[i];
-    }
-
-    ProviderLocale *ret = calloc(1, sizeof(ProviderLocale));
-    if (!ret)
-        return NULL;
-
-    ret->locale = localeName;
-    if (!(ret->locale.str = ass_copy_string(localeName)))
-        goto fail;
-
-    if (!ASS_REALLOC_ARRAY(fc->locales, fc->nb_locales + 1))
-        goto fail;
-
-    fc->locales[fc->nb_locales++] = ret;
-
-    return ret;
-
-fail:
-    free((char*)ret->locale.str);
-    free(ret);
-
-    return NULL;
-}
-
 static char *get_fallback(void *priv, ASS_Library *lib,
-                          const char *family, uint32_t codepoint, ASS_StringView localeName)
+                          const char *family, uint32_t codepoint, ASS_StringView locale)
 {
     ProviderPrivate *fc = (ProviderPrivate *)priv;
     FcResult result;
-
-    ProviderLocale *pLoc = get_locale(fc, localeName);
-    if (!pLoc)
-        return NULL;
-
-    cache_fallbacks(fc, pLoc);
-
-    if (!pLoc->fallbacks || pLoc->fallbacks->nfont == 0)
-        return NULL;
-
-    if (codepoint == 0) {
-        char *family = NULL;
-        result = FcPatternGetString(pLoc->fallbacks->fonts[0], FC_FAMILY, 0,
-                (FcChar8 **)&family);
-        if (result == FcResultMatch) {
-            return strdup(family);
-        } else {
-            return NULL;
-        }
-    }
-
-    // fallback_chars is the union of all available charsets, so
-    // if we can't find the glyph in there, the system does not
-    // have any font to render this glyph.
-    if (FcCharSetHasChar(pLoc->fallback_chars, codepoint) == FcFalse)
-        return NULL;
-
-    for (int j = 0; j < pLoc->fallbacks->nfont; j++) {
-        FcPattern *pattern = pLoc->fallbacks->fonts[j];
-
-        FcCharSet *charset;
-        result = FcPatternGetCharSet(pattern, FC_CHARSET, 0, &charset);
-
-        if (result == FcResultMatch && FcCharSetHasChar(charset,
-                    codepoint)) {
-            char *family = NULL;
-            result = FcPatternGetString(pattern, FC_FAMILY, 0,
-                    (FcChar8 **)&family);
-            if (result == FcResultMatch) {
-                return strdup(family);
-            } else {
-                return NULL;
-            }
-        }
-    }
-
-    // we shouldn't get here
-    return NULL;
-}
-
-static void get_substitutions(void *priv, const char *name,
-                              ASS_FontProviderMetaData *meta)
-{
-    ProviderPrivate *fc = (ProviderPrivate *)priv;
+    char *ret = NULL;
 
     FcPattern *pat = FcPatternCreate();
     if (!pat)
-        return;
+        return NULL;
 
-    FcPatternAddString(pat, FC_FAMILY, (const FcChar8 *)name);
-    FcPatternAddString(pat, FC_FAMILY, (const FcChar8 *)"__libass_delimiter");
+    if (locale.len) {
+        FcLangSet *ls = FcLangSetCreate();
+        if (!ls)
+            goto cleanup;
+
+        FcLangSetAdd(ls, (const FcChar8 *)locale.str);
+        FcPatternAddLangSet(pat, FC_LANG, ls);
+
+        FcLangSetDestroy(ls);
+    }
+
+    if (codepoint) {
+        FcCharSet *cs = FcCharSetCreate();
+        if (!cs)
+            goto cleanup;
+
+        FcCharSetAddChar(cs, codepoint);
+        FcPatternAddCharSet(pat, FC_CHARSET, cs);
+
+        FcCharSetDestroy(cs);
+    }
+
+    FcPatternAddString(pat, FC_FAMILY, (const FcChar8 *)family);
     FcPatternAddBool(pat, FC_OUTLINE, FcTrue);
     if (!FcConfigSubstitute(fc->config, pat, FcMatchPattern))
         goto cleanup;
 
-    // read and strdup fullnames
-    meta->n_fullname = 0;
-    meta->fullnames = calloc(MAX_NAME, sizeof(char *));
-    if (!meta->fullnames)
-        goto cleanup;
+    FcDefaultSubstitute(pat);
 
-    char *alias = NULL;
-    while (FcPatternGetString(pat, FC_FAMILY, meta->n_fullname,
-                (FcChar8 **)&alias) == FcResultMatch
-                && meta->n_fullname < MAX_NAME
-                && strcmp(alias, "__libass_delimiter") != 0) {
-        alias = strdup(alias);
-        if (!alias)
-            goto cleanup;
-        meta->fullnames[meta->n_fullname] = alias;
-        meta->n_fullname++;
+    if (!locale.len) {
+        // FC_LANG is automatically set according to locale, but this results
+        // in locale-specific fonts being used for text from other languages,
+        // which can look pretty bad (e.g. HannotateTC-W5 being used for English).
+        // We remove it here to use language-independent lookup instead if no language
+        // was specified by the file or the caller.
+        // Callers can pass in the system locale as a fallback behind a user setting
+        // if they want to.
+        FcPatternDel(pat, FC_LANG);
+    }
+
+    FcPattern *match = FcFontMatch(fc->config, pat, &result);
+    if (match) {
+        FcChar8 *got_family = NULL;
+        result = FcPatternGetString(match, FC_FAMILY, 0, &got_family);
+        if (got_family)
+            ret = strdup((char *)got_family);
+
+        FcPatternDestroy(match);
     }
 
 cleanup:
-    FcPatternDestroy(pat);
+    if (pat)
+        FcPatternDestroy(pat);
+
+    return ret;
 }
 
 static ASS_FontProviderFuncs fontconfig_callbacks = {
     .check_postscript   = check_postscript,
     .check_glyph        = check_glyph,
     .destroy_provider   = destroy,
-    .get_substitutions  = get_substitutions,
     .get_fallback       = get_fallback,
 };
 

--- a/libass/ass_fontconfig.c
+++ b/libass/ass_fontconfig.c
@@ -199,7 +199,7 @@ static void cache_fallbacks(ProviderPrivate *fc)
 
     // Create a suitable pattern
     FcPattern *pat = FcPatternCreate();
-    FcPatternAddString(pat, FC_FAMILY, (FcChar8 *)"sans-serif");
+    FcPatternAddString(pat, FC_FAMILY, (const FcChar8 *)"sans-serif");
     FcPatternAddBool(pat, FC_OUTLINE, FcTrue);
     FcConfigSubstitute (fc->config, pat, FcMatchPattern);
     FcDefaultSubstitute (pat);
@@ -280,8 +280,8 @@ static void get_substitutions(void *priv, const char *name,
     if (!pat)
         return;
 
-    FcPatternAddString(pat, FC_FAMILY, (FcChar8 *)name);
-    FcPatternAddString(pat, FC_FAMILY, (FcChar8 *)"__libass_delimiter");
+    FcPatternAddString(pat, FC_FAMILY, (const FcChar8 *)name);
+    FcPatternAddString(pat, FC_FAMILY, (const FcChar8 *)"__libass_delimiter");
     FcPatternAddBool(pat, FC_OUTLINE, FcTrue);
     if (!FcConfigSubstitute(fc->config, pat, FcMatchPattern))
         goto cleanup;

--- a/libass/ass_fontselect.c
+++ b/libass/ass_fontselect.c
@@ -919,7 +919,7 @@ char *ass_font_select(ASS_FontSelector *priv,
         if (!search_family || !*search_family)
             search_family = "Arial";
         char *fallback_family = default_provider->funcs.get_fallback(
-                default_provider->priv, priv->library, search_family, code);
+                default_provider->priv, priv->library, search_family, code, font->desc.locale);
 
         if (fallback_family) {
             res = select_font(priv, fallback_family, true, bold, italic,

--- a/libass/ass_fontselect.h
+++ b/libass/ass_fontselect.h
@@ -32,6 +32,7 @@ typedef struct ass_font_stream ASS_FontStream;
 #include "ass_types.h"
 #include "ass.h"
 #include "ass_font.h"
+#include "ass_utils.h"
 
 typedef struct font_provider ASS_FontProvider;
 
@@ -148,13 +149,15 @@ typedef void    (*SubstituteFontFunc)(void *priv, const char *name,
  * \param lib ASS_Library instance
  * \param family original font family name (try matching a similar font) (never NULL)
  * \param codepoint Unicode codepoint (UTF-32)
+ * \param locale BCP47 locale to use for the lookup, or NULL for system default
  * \return output extended font family, allocated with malloc(), must be freed
  *         by caller.
  */
 typedef char   *(*GetFallbackFunc)(void *priv,
                                    ASS_Library *lib,
                                    const char *family,
-                                   uint32_t codepoint);
+                                   uint32_t codepoint,
+                                   ASS_StringView locale);
 
 typedef struct font_provider_funcs {
     GetDataFunc         get_data;               /* optional/mandatory */

--- a/libass/ass_parse.c
+++ b/libass/ass_parse.c
@@ -111,6 +111,8 @@ void ass_update_font(RenderContext *state)
         val = 0;                // normal
     desc.italic = val;
 
+    desc.locale = state->locale;
+
     ass_cache_dec_ref(state->font);
     state->font = ass_font_new(state->renderer, &desc);
 }

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -1935,10 +1935,16 @@ wrap_lines_smart(RenderContext *state, double max_text_width)
     ASS_Renderer *render_priv = state->renderer;
     TextInfo *text_info = state->text_info;
     if (render_priv->track->parser_priv->feature_flags & FEATURE_MASK(ASS_FEATURE_WRAP_UNICODE)) {
+        const char *ubrk_lang = render_priv->track->Language;
+
+        if (ubrk_lang && ubrk_lang[0] && ubrk_lang[1] && ubrk_lang[2] &&
+            ubrk_lang[2] != '-')
+            ubrk_lang = NULL;
+
         unibrks = text_info->breaks;
         set_linebreaks_utf32(
             text_info->event_text, text_info->length,
-            render_priv->track->Language, unibrks);
+            ubrk_lang, unibrks);
 #if UNIBREAK_VERSION < 0x0500UL
         // Prior to 5.0 libunibreaks always ended text with LINE_BREAKMUSTBREAK, matching
         // Unicode spec, but messing with our text-overflow detection.
@@ -1947,7 +1953,7 @@ wrap_lines_smart(RenderContext *state, double max_text_width)
         unibrks[text_info->length - 1] = is_line_breakable(
             text_info->event_text[text_info->length - 1],
             ' ',
-            render_priv->track->Language
+            ubrk_lang
         );
 #endif
     }

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -1077,6 +1077,8 @@ void ass_reset_render_context(RenderContext *state, ASS_Style *style)
 
     state->family.str = style->FontName;
     state->family.len = strlen(style->FontName);
+    state->locale.str = state->renderer->track->Language ? state->renderer->track->Language : "";
+    state->locale.len = strlen(state->locale.str);
     state->treat_family_as_pattern = style->treat_fontname_as_pattern;
     state->bold = style->Bold;
     state->italic = style->Italic;

--- a/libass/ass_render.h
+++ b/libass/ass_render.h
@@ -280,6 +280,7 @@ struct render_context {
     int treat_family_as_pattern;
     int wrap_style;
     int font_encoding;
+    ASS_StringView locale;
 
     // combination of ASS_OVERRIDE_BIT_* flags that apply right now
     unsigned overrides;

--- a/libass/ass_types.h
+++ b/libass/ass_types.h
@@ -274,7 +274,13 @@ typedef struct ass_track {
     int WrapStyle;
     int ScaledBorderAndShadow; // 0 or 1 (boolean)
     int Kerning; // 0 or 1 (boolean)
-    char *Language; // zero-terminated ISO-639-1 code
+    char *Language; // If non-null, zero-terminated BCP 47 code with restrictions:
+                    // - Must begin with a language code (which, as per BCP 47,
+                    //   must be a two-letter ISO 639-1 code if one is defined
+                    //   for the language being referred to)
+                    // - May optionally be followed by an ISO 3166-1 alpha-2 region code,
+                    //   after a hyphen
+                    // - Must contain no other subtags
     ASS_YCbCrMatrix YCbCrMatrix;
 
     int default_style;      // index of default style

--- a/test/test.c
+++ b/test/test.c
@@ -110,6 +110,8 @@ static void init(int frame_w, int frame_h)
     ass_set_storage_size(ass_renderer, frame_w, frame_h);
     ass_set_frame_size(ass_renderer, frame_w, frame_h);
     ass_set_fonts(ass_renderer, NULL, "sans-serif",
+                  getenv("ASS_TEST_FORCE_FONTCONFIG") ?
+                  ASS_FONTPROVIDER_FONTCONFIG :
                   ASS_FONTPROVIDER_AUTODETECT, NULL, 1);
 }
 


### PR DESCRIPTION
Closes #550.

We'll want to encourage players to set `track->Language` to any value they might have from file metadata. Demo mpv patch: https://gist.github.com/1619f3a49ee72b08aa4428b2a7cfa70c.

This doesn't remove the existing code that removes the default FC_LANG value on Fontconfig, as I'm still not entirely sure what cases that was referencing having issues with.