### PR TITLE
Unsafe leftshifts and float cast overflows

### DIFF
--- a/libass/ass_drawing.c
+++ b/libass/ass_drawing.c
@@ -19,8 +19,6 @@
 #include "config.h"
 #include "ass_compat.h"
 
-#include <ft2build.h>
-#include FT_OUTLINE_H
 #include <math.h>
 #include <stdbool.h>
 #include <limits.h>

--- a/libass/ass_parse.c
+++ b/libass/ass_parse.c
@@ -768,10 +768,10 @@ char *parse_tags(ASS_Renderer *render_priv, char *p, char *end, double pwr,
         } else if (tag("be")) {
             double dval;
             if (nargs) {
-                int val;
+                int32_t val;
                 dval = argtod(*args);
                 // VSFilter always adds +0.5, even if the value is negative
-                val = (int) (render_priv->state.be * (1 - pwr) + dval * pwr + 0.5);
+                val = dtoi32(render_priv->state.be * (1 - pwr) + dval * pwr + 0.5);
                 // Clamp to a safe upper limit, since high values need excessive CPU
                 val = (val < 0) ? 0 : val;
                 val = (val > MAX_BE) ? MAX_BE : val;
@@ -816,7 +816,7 @@ char *parse_tags(ASS_Renderer *render_priv, char *p, char *end, double pwr,
             if (render_priv->state.effect_timing)
                 render_priv->state.effect_skip_timing +=
                     render_priv->state.effect_timing;
-            render_priv->state.effect_timing = val * 10;
+            render_priv->state.effect_timing = dtoi32(val * 10);
         } else if (tag("shad")) {
             double val, xval, yval;
             if (nargs) {

--- a/libass/ass_parse.c
+++ b/libass/ass_parse.c
@@ -36,13 +36,6 @@ struct arg {
     char *start, *end;
 };
 
-static inline int argtoi(struct arg arg)
-{
-    int value;
-    mystrtoi(&arg.start, &value);
-    return value;
-}
-
 static inline int32_t argtoi32(struct arg arg)
 {
     int32_t value;
@@ -230,7 +223,7 @@ static bool parse_vector_clip(ASS_Renderer *render_priv,
 
     int scale = 1;
     if (nargs == 2)
-        scale = argtoi(args[0]);
+        scale = argtoi32(args[0]);
 
     struct arg text = args[nargs - 1];
     render_priv->state.clip_drawing_text.str = text.start;
@@ -367,11 +360,11 @@ char *parse_tags(ASS_Renderer *render_priv, char *p, char *end, double pwr,
                 render_priv->state.fay = 0.;
         } else if (complex_tag("iclip")) {
             if (nargs == 4) {
-                int x0, y0, x1, y1;
-                x0 = argtoi(args[0]);
-                y0 = argtoi(args[1]);
-                x1 = argtoi(args[2]);
-                y1 = argtoi(args[3]);
+                int32_t x0, y0, x1, y1;
+                x0 = argtoi32(args[0]);
+                y0 = argtoi32(args[1]);
+                x1 = argtoi32(args[2]);
+                y1 = argtoi32(args[3]);
                 render_priv->state.clip_x0 =
                     render_priv->state.clip_x0 * (1 - pwr) + x0 * pwr;
                 render_priv->state.clip_x1 =
@@ -545,7 +538,7 @@ char *parse_tags(ASS_Renderer *render_priv, char *p, char *end, double pwr,
             }
             // FIXME: simplify
         } else if (tag("an")) {
-            int val = argtoi(*args);
+            int32_t val = argtoi32(*args);
             if ((render_priv->state.parsed_tags & PARSED_A) == 0) {
                 if (val >= 1 && val <= 9)
                     render_priv->state.alignment = numpad2align(val);
@@ -555,7 +548,7 @@ char *parse_tags(ASS_Renderer *render_priv, char *p, char *end, double pwr,
                 render_priv->state.parsed_tags |= PARSED_A;
             }
         } else if (tag("a")) {
-            int val = argtoi(*args);
+            int32_t val = argtoi32(*args);
             if ((render_priv->state.parsed_tags & PARSED_A) == 0) {
                 if (val >= 1 && val <= 11)
                     // take care of a vsfilter quirk:
@@ -583,7 +576,7 @@ char *parse_tags(ASS_Renderer *render_priv, char *p, char *end, double pwr,
                 render_priv->state.pos_y = v2;
             }
         } else if (complex_tag("fade") || complex_tag("fad")) {
-            int a1, a2, a3;
+            int32_t a1, a2, a3;
             int32_t t1, t2, t3, t4;
             if (nargs == 2) {
                 // 2-argument version (\fad, according to specs)
@@ -596,9 +589,9 @@ char *parse_tags(ASS_Renderer *render_priv, char *p, char *end, double pwr,
                 t4 = -1;
             } else if (nargs == 7) {
                 // 7-argument version (\fade)
-                a1 = argtoi(args[0]);
-                a2 = argtoi(args[1]);
-                a3 = argtoi(args[2]);
+                a1 = argtoi32(args[0]);
+                a2 = argtoi32(args[1]);
+                a3 = argtoi32(args[2]);
                 t1 = argtoi32(args[3]);
                 t2 = argtoi32(args[4]);
                 t3 = argtoi32(args[5]);
@@ -691,11 +684,11 @@ char *parse_tags(ASS_Renderer *render_priv, char *p, char *end, double pwr,
             }
         } else if (complex_tag("clip")) {
             if (nargs == 4) {
-                int x0, y0, x1, y1;
-                x0 = argtoi(args[0]);
-                y0 = argtoi(args[1]);
-                x1 = argtoi(args[2]);
-                y1 = argtoi(args[3]);
+                int32_t x0, y0, x1, y1;
+                x0 = argtoi32(args[0]);
+                y0 = argtoi32(args[1]);
+                x1 = argtoi32(args[2]);
+                y1 = argtoi32(args[3]);
                 render_priv->state.clip_x0 =
                     render_priv->state.clip_x0 * (1 - pwr) + x0 * pwr;
                 render_priv->state.clip_x1 =
@@ -786,13 +779,13 @@ char *parse_tags(ASS_Renderer *render_priv, char *p, char *end, double pwr,
             } else
                 render_priv->state.be = 0;
         } else if (tag("b")) {
-            int val = argtoi(*args);
+            int32_t val = argtoi32(*args);
             if (!nargs || !(val == 0 || val == 1 || val >= 100))
                 val = render_priv->state.style->Bold;
             render_priv->state.bold = val;
             update_font(render_priv);
         } else if (tag("i")) {
-            int val = argtoi(*args);
+            int32_t val = argtoi32(*args);
             if (!nargs || !(val == 0 || val == 1))
                 val = render_priv->state.style->Italic;
             render_priv->state.italic = val;
@@ -838,7 +831,7 @@ char *parse_tags(ASS_Renderer *render_priv, char *p, char *end, double pwr,
             render_priv->state.shadow_x = xval;
             render_priv->state.shadow_y = yval;
         } else if (tag("s")) {
-            int val = argtoi(*args);
+            int32_t val = argtoi32(*args);
             if (!nargs || !(val == 0 || val == 1))
                 val = render_priv->state.style->StrikeOut;
             if (val)
@@ -846,7 +839,7 @@ char *parse_tags(ASS_Renderer *render_priv, char *p, char *end, double pwr,
             else
                 render_priv->state.flags &= ~DECO_STRIKETHROUGH;
         } else if (tag("u")) {
-            int val = argtoi(*args);
+            int32_t val = argtoi32(*args);
             if (!nargs || !(val == 0 || val == 1))
                 val = render_priv->state.style->Underline;
             if (val)
@@ -857,18 +850,18 @@ char *parse_tags(ASS_Renderer *render_priv, char *p, char *end, double pwr,
             double val = argtod(*args);
             render_priv->state.pbo = val;
         } else if (tag("p")) {
-            int val = argtoi(*args);
+            int32_t val = argtoi32(*args);
             val = (val < 0) ? 0 : val;
             render_priv->state.drawing_scale = val;
         } else if (tag("q")) {
-            int val = argtoi(*args);
+            int32_t val = argtoi32(*args);
             if (!nargs || !(val >= 0 && val <= 3))
                 val = render_priv->track->WrapStyle;
             render_priv->state.wrap_style = val;
         } else if (tag("fe")) {
-            int val;
+            int32_t val;
             if (nargs)
-                val = argtoi(*args);
+                val = argtoi32(*args);
             else
                 val = render_priv->state.style->Encoding;
             render_priv->state.font_encoding = val;

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -662,7 +662,8 @@ static void blend_vector_clip(ASS_Renderer *render_priv, ASS_Image *head)
     ol_key.u.drawing.text = render_priv->state.clip_drawing_text;
 
     double m[3][3] = {{0}};
-    double w = render_priv->font_scale / (1 << (render_priv->state.clip_drawing_scale - 1));
+    int32_t scale_base = lshiftwrapi(1, render_priv->state.clip_drawing_scale - 1);
+    double w = scale_base > 0 ? (render_priv->font_scale / scale_base) : 0;
     m[0][0] = render_priv->font_scale_x * w;
     m[1][1] = w;
     m[2][2] = 1;
@@ -1105,7 +1106,8 @@ get_outline_glyph(ASS_Renderer *priv, GlyphInfo *info)
             return;
         }
 
-        double w = priv->font_scale / (1 << (info->drawing_scale - 1));
+        int32_t scale_base = lshiftwrapi(1, info->drawing_scale - 1);
+        double w = scale_base > 0 ? (priv->font_scale / scale_base) : 0;
         scale.x = info->scale_x * w;
         scale.y = info->scale_y * w;
         desc = 64 * info->drawing_pbo;

--- a/libass/ass_utils.h
+++ b/libass/ass_utils.h
@@ -182,6 +182,12 @@ static inline int double_to_d22(double x)
     return lrint(x * 0x400000);
 }
 
+static inline int32_t lshiftwrapi(int32_t i, int32_t shift)
+{
+    // '0u +' to avoid automatic integer promotion causing UB
+    return (0u + (uint32_t)i) << (shift & 31);
+}
+
 static inline int mystrtod(char **p, double *res)
 {
     char *start = *p;

--- a/libass/ass_utils.h
+++ b/libass/ass_utils.h
@@ -182,14 +182,6 @@ static inline int double_to_d22(double x)
     return lrint(x * 0x400000);
 }
 
-static inline int mystrtoi(char **p, int *res)
-{
-    char *start = *p;
-    double temp_res = ass_strtod(*p, p);
-    *res = (int) (temp_res + (temp_res > 0 ? 0.5 : -0.5));
-    return *p != start;
-}
-
 static inline int mystrtod(char **p, double *res)
 {
     char *start = *p;

--- a/libass/ass_utils.h
+++ b/libass/ass_utils.h
@@ -190,14 +190,6 @@ static inline int mystrtoi(char **p, int *res)
     return *p != start;
 }
 
-static inline int mystrtoll(char **p, long long *res)
-{
-    char *start = *p;
-    double temp_res = ass_strtod(*p, p);
-    *res = (long long) (temp_res + (temp_res > 0 ? 0.5 : -0.5));
-    return *p != start;
-}
-
 static inline int mystrtod(char **p, double *res)
 {
     char *start = *p;


### PR DESCRIPTION
This needs some discussion wrt VSFilter-compatibility and could probably be expanded to cover more casts not found in the samples yet; see commit messages. Reproducing samples here: [612_more-ub-fixes.zip](https://github.com/libass/libass/files/8498916/612_more-ub-fixes.zip)
Also see here for the tests probing what happens in practice on x86 WIndows for the relevant UB: https://github.com/TheOneric/libass/runs/6033094405?check_suite_focus=true#step%3A7%3A115=


@MrSmile: I haven't encountered such a sample yet, but from a quick glance it seems like the leftshift in `quantize_blur` can potentially end up with assigning -1 to the `shadow_mask` if the radius is so large that `ord > 31`. Would that be a problem or did I miss some guards protecting from this scenario?

