### PR TITLE
Don't crash on negative Fontsize

### DIFF
--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -1991,7 +1991,7 @@ static bool parse_events(ASS_Renderer *render_priv, ASS_Event *event)
         info->effect_timing = render_priv->state.effect_timing;
         info->effect_skip_timing = render_priv->state.effect_skip_timing;
         info->font_size =
-            render_priv->state.font_size * render_priv->font_scale;
+            fabs(render_priv->state.font_size * render_priv->font_scale);
         info->be = render_priv->state.be;
         info->blur = render_priv->state.blur;
         info->shadow_x = render_priv->state.shadow_x;


### PR DESCRIPTION
See #610 for samples and VSFilter screenshots *(the assert fail in the `id:000159` samples is actuallly only fixed by #612 not this, which is why it is not listed in the commit)*.
Before this changes libass crashes if a Style with a negative `Fontsize` field is rendered either by failing an assert or if asserts are disabled by overflowing the stack. This brings the rendering closer in line with VSFilter and prevents crashes.

The change isn't fully correct though. Upon closer inspection the positive and negative fontsizes aren't quite identical in VSFilter (but would be with this change); the negative version is slightly **larger** than the positive one. I have no idea where this difference is coming from. At first glance the only bit affected by the sign of the fontsize in VSFilter is the `(LONG)(x+0.5)` rounding at the very beginning of `RTS.cpp` — but this should at most *reduce* the absolute value for negative sizes; here the opposite is observed. Any ideas what might be causing this?


For comparison, here are libass screenshots with v1 of the patch applied:
![libass-patched_01](https://user-images.githubusercontent.com/1668471/164998587-43a14c42-aac5-42c4-94fb-ec576d548a88.png)
![libass-patched_02](https://user-images.githubusercontent.com/1668471/164998605-080888c8-e44b-4bba-8871-4b3774010e0d.png)

