### PR TITLE
Set storage size in all utilities

### DIFF
--- a/compare/compare.c
+++ b/compare/compare.c
@@ -570,7 +570,7 @@ fail:
     free(pos);
     const char *fmt =
         "Usage: %s ([-i] <input-dir>)+ [-o <output-dir>] [-s <scale:1-8>] [-p <pass-level:0-3>]\n";
-    printf(fmt, argv[0]);
+    printf(fmt, argv[0] ? argv[0] : "compare");
     return NULL;
 }
 

--- a/profile/profile.c
+++ b/profile/profile.c
@@ -68,7 +68,8 @@ int main(int argc, char *argv[])
     const int frame_h = 720;
 
     if (argc < 5) {
-        printf("usage: %s <subtitle file> <start time> <fps> <end time>\n", argv[0]);
+        printf("usage: %s <subtitle file> <start time> <fps> <end time>\n",
+               argv[0] ? argv[0] : "profile");
         exit(1);
     }
     char *subfile = argv[1];

--- a/profile/profile.c
+++ b/profile/profile.c
@@ -57,6 +57,7 @@ static void init(int frame_w, int frame_h)
         exit(1);
     }
 
+    ass_set_storage_size(ass_renderer, frame_w, frame_h);
     ass_set_frame_size(ass_renderer, frame_w, frame_h);
     ass_set_fonts(ass_renderer, NULL, "Sans", 1, NULL, 1);
 }

--- a/test/test.c
+++ b/test/test.c
@@ -199,7 +199,7 @@ int main(int argc, char *argv[])
     if (argc != 4 && argc != 6) {
         printf("usage: %s <image file> <subtitle file> <time> "
                "[<storage width> <storage height>]\n",
-                argv[0]);
+                argv[0] ? argv[0] : "test");
         exit(1);
     }
     char *imgfile = argv[1];

--- a/test/test.c
+++ b/test/test.c
@@ -107,6 +107,7 @@ static void init(int frame_w, int frame_h)
         exit(1);
     }
 
+    ass_set_storage_size(ass_renderer, frame_w, frame_h);
     ass_set_frame_size(ass_renderer, frame_w, frame_h);
     ass_set_fonts(ass_renderer, NULL, "sans-serif",
                   ASS_FONTPROVIDER_AUTODETECT, NULL, 1);
@@ -192,16 +193,26 @@ static void print_font_providers(ASS_Library *ass_library)
 
 int main(int argc, char *argv[])
 {
-    const int frame_w = 1280;
-    const int frame_h = 720;
+    int frame_w = 1280;
+    int frame_h = 720;
 
-    if (argc < 4) {
-        printf("usage: %s <image file> <subtitle file> <time>\n", argv[0]);
+    if (argc != 4 && argc != 6) {
+        printf("usage: %s <image file> <subtitle file> <time> "
+               "[<storage width> <storage height>]\n",
+                argv[0]);
         exit(1);
     }
     char *imgfile = argv[1];
     char *subfile = argv[2];
     double tm = strtod(argv[3], 0);
+    if (argc == 6) {
+        frame_w = atoi(argv[4]);
+        frame_h = atoi(argv[5]);
+        if (frame_w <= 0 || frame_h <= 0) {
+            printf("storage size must be non-zero and positive!\n");
+            exit(1);
+        }
+    }
 
     print_font_providers(ass_library);
 


### PR DESCRIPTION
As programs provided with the library's source code they also serve
as examples for how to correctly use the API, which usually means
setting a storage size.

 - compare already sets the storage size.
 - profile can continue using a fixed size, it never outputs the rendering.
 - test already had issues before if either the guesses storage size was
incorrect or the frame size didn't match the intended aspect ratio.
To fixt both, add new optional arguments for storage and frame size.

Also fix rare `printf("%s", NULL);` bugs.