### PR TITLE
Regression tests in make check, sanitisers in CI

### DIFF
--- a/.github/workflows/ghci.yml
+++ b/.github/workflows/ghci.yml
@@ -130,11 +130,13 @@ jobs:
           > /tmp/windowsapp.specs
 
       - name: configure
-        env:
-          CC: "${{ matrix.cc }}\
+        run: |
+          export CC="${{ matrix.cc }}\
             ${{ matrix.extra_cflags && ' ' }}${{ matrix.extra_cflags }}"
-          LD: "${{ matrix.ld }}"
-        run: ./autogen.sh && ./configure
+          export LD="${{ matrix.ld }}"
+
+          ./autogen.sh
+          ./configure
 
       - name: compile
         if: matrix.do_distc != 'yes'

--- a/.github/workflows/ghci.yml
+++ b/.github/workflows/ghci.yml
@@ -44,7 +44,8 @@ jobs:
             docker_image: oldlibs
             docker_pullprefix: 'ghcr.io/theoneric/libass-containers/'
             shell: '/usr/bin/docker exec dockerciimage sh -e {0}'
-            # various regression test fail, supposedly due to older deps
+            # Crash Tests detect (false?) leaks in Fontconfig, and
+            # various regression test fail, assumed due to older deps
             skip_tests: yes
           # Add a Windows build (MinGW-gcc via MSYS2) with no extras
           - os: windows-2019
@@ -61,6 +62,8 @@ jobs:
             extra_cflags: -DWINAPI_FAMILY=WINAPI_FAMILY_APP -specs=/tmp/windowsapp.specs
             shell: 'msys2 {0}'
             package_prefix: mingw-w64-ucrt-x86_64
+            # FIXME: UBSAN triggers on regression/karaoke/357-k-and-kf-desynced.ass
+            skip_tests: yes
 
     defaults:
       run:
@@ -128,13 +131,48 @@ jobs:
               ;;
             *)
               sudo apt-get update #&& sudo apt-get upgrade
+              ubver="$(apt-cache search libubsan | awk '/^libubsan[0-9]* / {print substr($1, 9)}' | sort -rn | head -n1)"
+              asver="$(apt-cache search libasan | awk '/^libasan[0-9]* / {print substr($1, 8)}' | sort -rn | head -n1)"
               sudo apt-get install -y --no-install-recommends \
                    autoconf automake make libtool \
                    libfontconfig1-dev libfreetype6-dev libfribidi-dev \
                    libharfbuzz-dev nasm ${{ matrix.cc }} \
-                   libpng-dev
+                   libpng-dev libubsan"$ubver" libasan"$asver"
               ;;
           esac
+
+      - name: Determine Sanitizer Flags
+        id: sanitizer
+        run: |
+          aflags="-fsanitize=address"
+          uflags="-fsanitize=undefined -fsanitize=float-cast-overflow"
+          if [ "${{ startsWith(matrix.cc, 'clang') }}" = "true" ] ; then
+            # Clang's UBSAN exits with code zero even if issues were found
+            # This options will instead force an SIGILL, but remove a report being printed
+            # see https://reviews.llvm.org/D35085
+            uflags="$uflags -fsanitize-undefined-trap-on-error"
+          fi
+
+          # UBSAN: Alpine and MSys2 doesn't ship the UBSAN library,
+          #        but when SIGILL'ing the lib is not needed
+          # ASAN:  Not supported with musl and in Windows
+          case "${{ matrix.docker_image || matrix.os }}" in
+            alpine*|windows-*)
+              flags="$uflags -fsanitize-undefined-trap-on-error" ;;
+            *)
+              flags="$aflags $uflags" ;;
+          esac
+
+          if [ -n "$flags" ] ; then
+            flags="$flags -fno-sanitize-recover=all"
+          fi
+
+          if [ "${{ matrix.cc }}" = "tcc" ] || [ "${{ matrix.skip_tests }}" = "yes" ] ; then
+            flags=""
+          fi
+
+          echo "SANFLAGS=$flags"
+          echo "::set-output name=flags::${flags}"
 
       - name: Customize compiler
         if: matrix.api == 'app' && matrix.cc == 'gcc'
@@ -147,7 +185,8 @@ jobs:
       - name: configure
         run: |
           export CC="${{ matrix.cc }}\
-            ${{ matrix.extra_cflags && ' ' }}${{ matrix.extra_cflags }}"
+            ${{ matrix.extra_cflags && ' ' }}${{ matrix.extra_cflags }}\
+            ${{ steps.sanitizer.outputs.flags && ' ' }}${{ steps.sanitizer.outputs.flags }}"
           export LD="${{ matrix.ld }}"
           export ART_SAMPLES="${{ env.ART_SAMPLES }}"
 

--- a/.github/workflows/ghci.yml
+++ b/.github/workflows/ghci.yml
@@ -13,11 +13,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-10.15]
+        os: [ubuntu-latest, macos-latest]
         cc: [gcc, clang]
         docker_image: ['']
         exclude:
-          - os: macos-10.15
+          - os: macos-latest
             cc: gcc
         include:
           # Enable distcheck for one build

--- a/.github/workflows/ghci.yml
+++ b/.github/workflows/ghci.yml
@@ -37,12 +37,15 @@ jobs:
             cc: gcc
             docker_image: alpine:latest
             shell: '/usr/bin/docker exec dockerciimage sh -e {0}'
+            art_reg_skip: 'font_nonunicode'
           # Add docker-build with minimum version of dependencies
           - os: ubuntu-latest
             cc: gcc
             docker_image: oldlibs
             docker_pullprefix: 'ghcr.io/theoneric/libass-containers/'
             shell: '/usr/bin/docker exec dockerciimage sh -e {0}'
+            # various regression test fail, supposedly due to older deps
+            skip_tests: yes
           # Add a Windows build (MinGW-gcc via MSYS2) with no extras
           - os: windows-2019
             msystem: MINGW32
@@ -63,9 +66,18 @@ jobs:
       run:
         shell: ${{ matrix.shell || 'bash' }}
 
+    env:
+      ART_SAMPLES: ext_art-samples
+
     steps:
       - name: checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+
+      - name: download test samples
+        uses: actions/checkout@v3
+        with:
+          repository: libass/libass-tests
+          path: ${{ env.ART_SAMPLES }}
 
       - name: Start Docker
         if: matrix.docker_image
@@ -102,12 +114,14 @@ jobs:
               pacman --noconfirm -S \
                       automake autoconf libtool nasm make \
                       $pre-pkg-config $pre-gcc \
-                      $pre-fribidi $pre-freetype $pre-harfbuzz $pre-fontconfig
+                      $pre-fribidi $pre-freetype $pre-harfbuzz $pre-fontconfig \
+                      $pre-libpng
               ;;
             alpine:*)
               apk add nasm ${{ matrix.cc }} musl-dev \
                       make automake autoconf libtool pkgconf \
-                      fontconfig-dev freetype-dev fribidi-dev harfbuzz-dev
+                      fontconfig-dev freetype-dev fribidi-dev harfbuzz-dev \
+                      libpng-dev
               ;;
             oldlibs)
               : # Everything is preinstalled
@@ -117,7 +131,8 @@ jobs:
               sudo apt-get install -y --no-install-recommends \
                    autoconf automake make libtool \
                    libfontconfig1-dev libfreetype6-dev libfribidi-dev \
-                   libharfbuzz-dev nasm ${{ matrix.cc }}
+                   libharfbuzz-dev nasm ${{ matrix.cc }} \
+                   libpng-dev
               ;;
           esac
 
@@ -134,17 +149,23 @@ jobs:
           export CC="${{ matrix.cc }}\
             ${{ matrix.extra_cflags && ' ' }}${{ matrix.extra_cflags }}"
           export LD="${{ matrix.ld }}"
+          export ART_SAMPLES="${{ env.ART_SAMPLES }}"
 
           ./autogen.sh
-          ./configure
-
-      - name: compile
-        if: matrix.do_distc != 'yes'
-        run: make -j 2
+          ./configure --enable-compare --enable-fuzz
 
       - name: distcheck
         if: matrix.do_distc == 'yes'
         run: make -j 2 distcheck
+
+      - name: compile
+        run: make -j 2
+
+      - name: run tests
+        if: matrix.skip_tests != 'yes'
+        run: |
+          ART_REG_SKIP="${{ matrix.art_reg_skip }}" make -j 1 check
+
 
       - name: Coverity scan
         if: >

--- a/Makefile.am
+++ b/Makefile.am
@@ -14,3 +14,28 @@ noinst_PROGRAMS =
 
 include libass/Makefile_library.am
 include Makefile_util.am
+
+# Tests
+if ENABLE_FUZZ
+check: check-art-fuzz
+.PHONY: check-art-fuzz
+check-art-fuzz: fuzz/fuzz
+	@if [ -z '$(ART_SAMPLES)' ] ; then \
+		echo "ART_SAMPLES location not set; cannot run regression tests!"; \
+	else \
+		cd '$(ART_SAMPLES)'/crash/ ; \
+		./run-all.sh '$(abs_top_builddir)'/fuzz/fuzz ; \
+	fi
+endif
+
+if ENABLE_COMPARE
+check: check-art-compare
+.PHONY: check-art-compare
+check-art-compare: compare/compare
+	@if [ -z '$(ART_SAMPLES)' ] ; then \
+		echo "ART_SAMPLES location not set; cannot run regression tests!"; \
+	else \
+		cd '$(ART_SAMPLES)'/regression/ ; \
+		./run-all.sh '$(abs_top_builddir)'/compare/compare ; \
+	fi
+endif

--- a/configure.ac
+++ b/configure.ac
@@ -37,6 +37,8 @@ AC_ARG_ENABLE([asm], AS_HELP_STRING([--disable-asm],
 AC_ARG_ENABLE([large-tiles], AS_HELP_STRING([--enable-large-tiles],
     [use larger tiles in the rasterizer (better performance, slightly worse quality) @<:@default=disabled@:>@]))
 
+AC_ARG_VAR([ART_SAMPLES],
+    [Path to the root of libass' regression testing sample repository. If set, it is used in make check.])
 AC_ARG_VAR([FUZZ_LDFLAGS],
     [Optional special linking flags only used for the fuzzer binary.])
 AC_ARG_VAR([FUZZ_CPPFLAGS],


### PR DESCRIPTION
UBSAN seems to have found something in our UWP build on `regression/karaoke/357-k-and-kf-desynced.ass`, thus the UWP failure. As MSys2 doesn't ship the supporting UBSAN library, there's no report indicating what the problem is though *(using `-fsanitize-undefined-trap-on-error` will cause SIGILLs (for Windows exit code 132) when something is found and allows the sanitiser to function without the library)*.
It would be good if someone can look into UBSAN’s findings; I don't see a way for me to investigate this myself. If nobody can, I'll probably just have to disable sanitisers for UWP.


