### PR TITLE
Fix div by zero in fix_glyph_scaling

### DIFF
--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -1855,6 +1855,10 @@ fix_glyph_scaling(ASS_Renderer *priv, GlyphInfo *glyph)
         // to freetype. Normalize scale_y to 1.0.
         ft_size = glyph->scale_y * glyph->font_size;
     }
+
+    if (!ft_size || !glyph->font_size)
+        return;
+
     double mul = glyph->font_size / ft_size;
     glyph->scale_fix = 1 / mul;
     glyph->scale_x *= mul;


### PR DESCRIPTION
Fixes #630  and a misrendering with hinting and `\fscy0`.

Afaict early exiting `fix_glyph_scaling` should give correct values and the rendering results do match my expectations.
However, for some reason this apparently changes the count of glyphs being loaded and errors occuring when loading glyphs in `ass_font_get_glyph` for `HINTING_NONE`. Using ` compare and an additional message before loading the glyph:

**WITHOUT PATCH**

HINTING_NONE:
```
libass: DEBUG: Try loading glyph 36 from face 0
```

HINTING_NATIVE:
```
libass: DEBUG: Try loading glyph 36 from face 0
libass: DEBUG: Try loading glyph 36 from face 0
libass: Error loading glyph, index 36
```

HINTING_LIGHT or HINTING_NORMAL:
```
libass: DEBUG: Try loading glyph 36 from face 0
libass: DEBUG: Try loading glyph 36 from face 0
```

**WITH PATCH**

HINTING_NONE or HINTING_NATIVE:
```
libass: DEBUG: Try loading glyph 36 from face 0
libass: DEBUG: Try loading glyph 36 from face 0
libass: Error loading glyph, index 36
```

HINTING_LIGHT or HINTING_NORMAL:
```
libass: DEBUG: Try loading glyph 36 from face 0
libass: DEBUG: Try loading glyph 36 from face 0
```

.

**With ASS sample:**
```
[Script Info]
Title: Default Aegisub file
ScriptType: v4.00+
ScaledBorderAndShadow: yes
YCbCr Matrix: None
PlayResX: 1280
PlayResY: 720

[V4+ Styles]
Style: Default,DejaVu Sans,0,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,2,0,2,10,10,10,1

[Events]
Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
Dialogue: 0,0:00:00.00,0:00:05.00,Default,,0,0,0,,{\fs27}AAA
Dialogue: 0,0:00:00.00,0:00:05.00,Default,,0,0,0,,{\fs27}A{\fs}A{\fs27}A
Dialogue: 0,0:00:00.00,0:00:05.00,Default,,0,0,0,,{\fs27}A{\fscy0}A{\fscy}A
Dialogue: 0,0:00:00.00,0:00:05.00,Default,,0,0,0,,{\fs27}A{\fs0\fscy0}A{\fs27\fscy}A
Dialogue: 0,0:00:00.00,0:00:05.00,Default,,0,0,0,,{\fs27}AAA
```
