### PR TITLE
Improve cache size accounting

### DIFF
--- a/libass/ass_cache.c
+++ b/libass/ass_cache.c
@@ -408,7 +408,7 @@ void *ass_cache_get(Cache *cache, void *key, void *priv)
     item->queue_next = NULL;
     item->ref_count = 2;
 
-    cache->cache_size += item->size;
+    cache->cache_size += item->size + (item->size == 1 ? 0 : CACHE_ITEM_SIZE);
     cache->items++;
     return value;
 }
@@ -452,7 +452,7 @@ void ass_cache_dec_ref(void *value)
         *item->prev = item->next;
 
         cache->items--;
-        cache->cache_size -= item->size;
+        cache->cache_size -= item->size + (item->size == 1 ? 0 : CACHE_ITEM_SIZE);
     }
     destroy_item(item->desc, item);
 }
@@ -479,7 +479,7 @@ void ass_cache_cut(Cache *cache, size_t max_size)
         *item->prev = item->next;
 
         cache->items--;
-        cache->cache_size -= item->size;
+        cache->cache_size -= item->size + (item->size == 1 ? 0 : CACHE_ITEM_SIZE);
         destroy_item(cache->desc, item);
     } while (cache->cache_size > max_size);
     if (cache->queue_first)

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -1544,6 +1544,11 @@ get_bitmap_glyph(RenderContext *state, GlyphInfo *info,
         *pos = *pos_o;
 }
 
+static inline size_t outline_size(const ASS_Outline* outline)
+{
+    return sizeof(ASS_Vector) * outline->n_points + outline->n_segments;
+}
+
 size_t ass_bitmap_construct(void *key, void *value, void *priv)
 {
     RenderContext *state = priv;
@@ -1567,7 +1572,8 @@ size_t ass_bitmap_construct(void *key, void *value, void *priv)
     ass_outline_free(&outline[0]);
     ass_outline_free(&outline[1]);
 
-    return sizeof(BitmapHashKey) + sizeof(Bitmap) + bitmap_size(bm);
+    return sizeof(BitmapHashKey) + sizeof(Bitmap) + bitmap_size(bm) +
+           sizeof(OutlineHashValue) + outline_size(&k->outline->outline[0]) + outline_size(&k->outline->outline[1]);
 }
 
 static void measure_text_on_eol(RenderContext *state, double scale, int cur_line,

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -2785,6 +2785,7 @@ size_t ass_composite_construct(void *key, void *value, void *priv)
         ass_fix_outline(&v->bm, &v->bm_o);
 
     return sizeof(CompositeHashKey) + sizeof(CompositeHashValue) +
+        k->bitmap_count * sizeof(BitmapRef) +
         bitmap_size(&v->bm) + bitmap_size(&v->bm_o) + bitmap_size(&v->bm_s);
 }
 


### PR DESCRIPTION
- Charge byte-based cashes for their CacheItems
  - Note: we could also improve accuracy here by charging for alignment overhead, but I'd expect that to be a fairly small (and mostly constant) overhead compared to the others here.
- Charge the composite cache for the BitmapRef objects it owns
- Charge the bitmap cache for its OutlineHashValue
  - The outline cache is also charged for this, but only per-glyph (not per-byte), and the bitmap cache can easily cause a large number of large outlines to be kept in memory far longer than the outline cache alone would.

The last commit is the most important here. On a sample with extensive use of the font "DINk", I see total memory allocated-and-persistent from ass_render_frame drop from 310MB to 180MB. This also results in the memory usage stabilizing at that value early in playback, rather than slowly growing over the duration.