### PR TITLE
Add per-event multithreaded rendering

### DIFF
--- a/.github/workflows/ghci.yml
+++ b/.github/workflows/ghci.yml
@@ -255,7 +255,8 @@ jobs:
       - name: run tests
         if: matrix.skip_tests != 'yes'
         run: |
-          ART_REG_SKIP="${{ matrix.art_reg_skip }}" make -j 1 check
+          ART_REG_SKIP="${{ matrix.art_reg_skip }}" make -j 1 check \
+          || (cat test-suite.log; exit 1;)
 
 
       - name: Coverity scan

--- a/.github/workflows/ghci.yml
+++ b/.github/workflows/ghci.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     name: build(${{ matrix.msystem || matrix.docker_image || matrix.os }},
-      ${{ matrix.cc }}${{ matrix.api && ', ' }}${{ matrix.api }})
+      ${{ matrix.cc }}${{ matrix.api && ', ' }}${{ matrix.api }}${{ matrix.tsan && ', TSAN'}})
     strategy:
       fail-fast: false
       matrix:
@@ -22,6 +22,11 @@ jobs:
           - os: ubuntu-latest
             cc: clang
             do_coverity: yes
+          # Run one build with TSAN instead of ASAN
+          - os: ubuntu-latest
+            cc: clang
+            do_coverity: no
+            tsan: yes
           # Add a tcc build
           - os: ubuntu-latest
             cc: tcc
@@ -173,7 +178,15 @@ jobs:
       - name: Determine Sanitizer Flags
         id: sanitizer
         run: |
-          aflags="-fsanitize=address"
+          # ASAN and TSAN are not compatible
+          if [ "${{ matrix.tsan }}" = "yes" ] ; then
+            aflags=""
+            tflags="-fsanitize=thread"
+          else
+            aflags="-fsanitize=address"
+            tflags=""
+          fi
+
           uflags="-fsanitize=undefined -fsanitize=float-cast-overflow"
           if [ "${{ startsWith(matrix.cc, 'clang') }}" = "true" ] ; then
             # Clang's UBSAN exits with code zero even if issues were found
@@ -189,7 +202,7 @@ jobs:
             alpine*|windows-*)
               flags="$uflags -fsanitize-undefined-trap-on-error" ;;
             *)
-              flags="$aflags $uflags" ;;
+              flags="$aflags $tflags $uflags" ;;
           esac
 
           if [ -n "$flags" ] ; then

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 ACLOCAL_AMFLAGS = -I m4
 AM_CPPFLAGS = -I$(top_srcdir)/libass
-AM_CFLAGS = -std=gnu99 -Wall -Wextra -Wno-sign-compare -Wno-unused-parameter \
+AM_CFLAGS = -Wall -Wextra -Wno-sign-compare -Wno-unused-parameter \
             -Werror-implicit-function-declaration -Wstrict-prototypes        \
             -Wpointer-arith -Wredundant-decls -Wno-missing-field-initializers\
             -D_GNU_SOURCE

--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@ AM_PROG_CC_C_O
 AM_PROG_AS
 
 # Checks for header files.
-AC_CHECK_HEADERS_ONCE([iconv.h])
+AC_CHECK_HEADERS_ONCE([iconv.h stdatomic.h windows.h])
 
 # Checks for library functions.
 AC_CHECK_FUNCS([strdup strndup])
@@ -39,6 +39,10 @@ AC_ARG_ENABLE([require-system-font-provider], AS_HELP_STRING([--disable-require-
     [allow compilation even if no system font provider was found @<:@default=enabled:>@]))
 AC_ARG_ENABLE([asm], AS_HELP_STRING([--disable-asm],
     [disable compiling with ASM @<:@default=check@:>@]))
+AC_ARG_ENABLE([pthreads], AS_HELP_STRING([--disable-pthreads],
+    [disable threading support via pthreads @<:@default=check@:>@]))
+AC_ARG_ENABLE([w32threads], AS_HELP_STRING([--disable-w32threads],
+    [disable threading support via win32 threads @<:@default=check@:>@]))
 AC_ARG_ENABLE([large-tiles], AS_HELP_STRING([--enable-large-tiles],
     [use larger tiles in the rasterizer (better performance, slightly worse quality) @<:@default=disabled@:>@]))
 
@@ -76,6 +80,40 @@ AC_SEARCH_LIBS([lrint], [m], [
     AC_MSG_ERROR([Unable to locate math functions!])
 ])
 pkg_libs="$LIBS"
+
+AS_IF([test "x$enable_pthreads" = xyes && test "x$enable_w32threads" = xyes], [
+    AC_MSG_ERROR([both pthreads and w32threads were requested.])
+])
+
+AS_IF([(test "x$enable_pthreads" = xyes || test "x$enable_w32threads" = xyes) && test "x$ac_cv_header_stdatomic_h" != xyes], [
+    AC_MSG_ERROR([thread support was requested, but <stdatomic.h> was not found.])
+])
+
+threads_found=false
+
+AS_IF([test "x$enable_w32threads" != xno && test "x$ac_cv_header_stdatomic_h" = xyes], [
+    AS_IF([test "x$ac_cv_header_windows_h" = xyes], [
+        AC_DEFINE(CONFIG_W32THREAD, 1, [Have Win32 threads])
+        threads_found=true
+    ], [test "x$enable_w32threads" = xyes], [
+        AC_MSG_ERROR([win32 threading support was requested, but was not found.])
+    ])
+])
+
+AS_IF([test "x$threads_found" != xtrue && test "x$enable_pthreads" != xno && test "x$ac_cv_header_stdatomic_h" = xyes], [
+    AX_PTHREAD([
+        pkg_libs="$pkg_libs $PTHREAD_LIBS"
+        CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+        LIBS="$LIBS $PTHREAD_LIBS"
+        CC="$PTHREAD_CC"
+        AC_DEFINE(CONFIG_PTHREAD, 1, [Have POSIX threads])
+        threads_found=true
+    ], [
+        AS_IF([test "x$enable_pthreads" = xyes], [
+            AC_MSG_ERROR([pthread support was requested, but was not found.])
+        ])
+    ])
+])
 
 ## Check for libraries via pkg-config and add to pkg_requires as needed
 PKG_CHECK_MODULES([FREETYPE], [freetype2 >= 9.17.3], [
@@ -179,9 +217,7 @@ AS_IF([test "x$enable_coretext" != xno], [
 AS_IF([test "x$enable_directwrite" != xno], [
     # Linking to DirectWrite directly only works from Windows
     AC_MSG_CHECKING([for DIRECTWRITE])
-    AC_COMPILE_IFELSE([
-        AC_LANG_PROGRAM([[#include <windows.h>]], [[;]])
-    ], [
+    AS_IF([test "x$ac_cv_header_windows_h" = xyes], [
         directwrite=true
         AC_MSG_RESULT([yes])
         AC_MSG_CHECKING([for Win32 desktop APIs])

--- a/configure.ac
+++ b/configure.ac
@@ -13,10 +13,10 @@ AM_PROG_CC_C_O
 AM_PROG_AS
 
 # Checks for header files.
-AC_CHECK_HEADERS_ONCE([iconv.h stdatomic.h windows.h])
+AC_CHECK_HEADERS_ONCE([iconv.h sched.h stdatomic.h unistd.h windows.h])
 
 # Checks for library functions.
-AC_CHECK_FUNCS([strdup strndup])
+AC_CHECK_FUNCS([sched_getaffinity strdup strndup])
 
 # Query configuration parameters and set their description
 AC_ARG_ENABLE([test], AS_HELP_STRING([--enable-test],

--- a/configure.ac
+++ b/configure.ac
@@ -84,8 +84,8 @@ PKG_CHECK_MODULES([FREETYPE], [freetype2 >= 9.17.3], [
     LIBS="$LIBS $FREETYPE_LIBS"
 ])
 
-PKG_CHECK_MODULES([FRIBIDI], [fribidi >= 0.19.1], [
-    pkg_requires="fribidi >= 0.19.1, ${pkg_requires}"
+PKG_CHECK_MODULES([FRIBIDI], [fribidi >= 0.19.7], [
+    pkg_requires="fribidi >= 0.19.7, ${pkg_requires}"
     CFLAGS="$CFLAGS $FRIBIDI_CFLAGS"
     LIBS="$LIBS $FRIBIDI_LIBS"
 ])

--- a/libass/Makefile_library.am
+++ b/libass/Makefile_library.am
@@ -1,6 +1,6 @@
-LIBASS_LT_CURRENT = 11
-LIBASS_LT_REVISION = 2
-LIBASS_LT_AGE = 2
+LIBASS_LT_CURRENT = 12
+LIBASS_LT_REVISION = 0
+LIBASS_LT_AGE = 3
 
 .asm.lo:
 	$(nasm_verbose)$(LIBTOOL) $(AM_V_lt) --tag=CC --mode=compile $(top_srcdir)/ltnasm.sh $(AS) $(ASFLAGS) -I$(top_srcdir)/libass/ -Dprivate_prefix=ass -o $@ $<

--- a/libass/Makefile_library.am
+++ b/libass/Makefile_library.am
@@ -9,7 +9,7 @@ lib_LTLIBRARIES += libass/libass.la
 libass_libass_la_SOURCES = \
     libass/ass_utils.h libass/ass_utils.c \
     libass/ass_string.h libass/ass_string.c \
-    libass/ass_compat.h libass/ass_strtod.c \
+    libass/ass_compat.h  libass/ass_threading.h libass/ass_strtod.c \
     libass/ass_filesystem.h libass/ass_filesystem.c \
     libass/ass_types.h libass/ass.h libass/ass_priv.h libass/ass.c \
     libass/ass_library.h libass/ass_library.c \

--- a/libass/ass.h
+++ b/libass/ass.h
@@ -24,7 +24,7 @@
 #include <stdarg.h>
 #include "ass_types.h"
 
-#define LIBASS_VERSION 0x01702000
+#define LIBASS_VERSION 0x01702010
 
 #ifdef __cplusplus
 extern "C" {
@@ -387,6 +387,20 @@ void ass_renderer_done(ASS_Renderer *priv);
  * NOTE: frame size must be configured before an ASS_Renderer can be used.
  */
 void ass_set_frame_size(ASS_Renderer *priv, int w, int h);
+
+/**
+ * \brief Set the number of threads to use during rendering. Default is 0,
+ * meaning the number of available logical cores if known, otherwise 1.
+ * \param priv renderer handle
+ * \param threads number of threads
+ *
+ * \return number of threads that will be used (if 0 is passed, the autodetected
+ * count will be returned), or 0 if libass was built without threading support.
+ *
+ * Calling this function requires the log callback of the associated ASS_Library
+ * to be thread-safe, and opts out of internal locking around log calls.
+ */
+unsigned ass_set_threads(ASS_Renderer *priv, unsigned threads);
 
 /**
  * \brief Set the source image size in pixels.

--- a/libass/ass_cache.c
+++ b/libass/ass_cache.c
@@ -264,6 +264,37 @@ const CacheDesc outline_cache_desc = {
 };
 
 
+// font-face size metric cache
+static bool face_size_metrics_key_move(void *dst, void *src)
+{
+    FaceSizeMetricsHashKey *d = dst, *s = src;
+    if (!d)
+        return true;
+
+    *d = *s;
+    ass_cache_inc_ref(s->font);
+    return true;
+}
+
+static void face_size_metrics_destruct(void *key, void *value)
+{
+    FaceSizeMetricsHashKey *k = key;
+    ass_cache_dec_ref(k->font);
+}
+
+size_t ass_face_size_metrics_construct(void *key, void *value, void *priv);
+
+const CacheDesc face_size_metrics_cache_desc = {
+    .hash_func = face_size_metrics_hash,
+    .compare_func = face_size_metrics_compare,
+    .key_move_func = face_size_metrics_key_move,
+    .construct_func = ass_face_size_metrics_construct,
+    .destruct_func = face_size_metrics_destruct,
+    .key_size = sizeof(FaceSizeMetricsHashKey),
+    .value_size = sizeof(FT_Size_Metrics)
+};
+
+
 // glyph metric cache
 static bool glyph_metrics_key_move(void *dst, void *src)
 {
@@ -524,6 +555,11 @@ Cache *ass_outline_cache_create(void)
 Cache *ass_glyph_metrics_cache_create(void)
 {
     return ass_cache_create(&glyph_metrics_cache_desc);
+}
+
+Cache *ass_face_size_metrics_cache_create(void)
+{
+    return ass_cache_create(&face_size_metrics_cache_desc);
 }
 
 Cache *ass_bitmap_cache_create(void)

--- a/libass/ass_cache.c
+++ b/libass/ass_cache.c
@@ -83,10 +83,10 @@ const CacheDesc font_cache_desc = {
 static bool bitmap_key_move(void *dst, void *src)
 {
     BitmapHashKey *d = dst, *s = src;
-    if (d)
+    if (d) {
         *d = *s;
-    else
-        ass_cache_dec_ref(s->outline);
+        ass_cache_inc_ref(d->outline);
+    }
     return true;
 }
 
@@ -139,13 +139,13 @@ static bool composite_key_move(void *dst, void *src)
     CompositeHashKey *d = dst, *s = src;
     if (d) {
         *d = *s;
+        for (size_t i = 0; i < d->bitmap_count; i++) {
+            ass_cache_inc_ref(d->bitmaps[i].bm);
+            ass_cache_inc_ref(d->bitmaps[i].bm_o);
+        }
         return true;
     }
 
-    for (size_t i = 0; i < s->bitmap_count; i++) {
-        ass_cache_dec_ref(s->bitmaps[i].bm);
-        ass_cache_dec_ref(s->bitmaps[i].bm_o);
-    }
     free(s->bitmaps);
     return true;
 }
@@ -215,8 +215,6 @@ static bool outline_key_move(void *dst, void *src)
 {
     OutlineHashKey *d = dst, *s = src;
     if (!d) {
-        if (s->type == OUTLINE_GLYPH)
-            ass_cache_dec_ref(s->u.glyph.font);
         return true;
     }
 
@@ -227,6 +225,8 @@ static bool outline_key_move(void *dst, void *src)
     }
     if (s->type == OUTLINE_BORDER)
         ass_cache_inc_ref(s->u.border.outline);
+    else if (s->type == OUTLINE_GLYPH)
+        ass_cache_inc_ref(s->u.glyph.font);
     return true;
 }
 
@@ -368,7 +368,7 @@ void *ass_cache_get(Cache *cache, void *key, void *priv)
                 item->queue_next = NULL;
             }
             desc->key_move_func(NULL, key);
-            item->ref_count++;
+
             return (char *) item + CACHE_ITEM_SIZE;
         }
         item = item->next;
@@ -401,7 +401,7 @@ void *ass_cache_get(Cache *cache, void *key, void *priv)
     item->queue_prev = cache->queue_last;
     cache->queue_last = &item->queue_next;
     item->queue_next = NULL;
-    item->ref_count = 2;
+    item->ref_count = 1;
 
     cache->cache_size += item->size + (item->size == 1 ? 0 : CACHE_ITEM_SIZE);
     return value;

--- a/libass/ass_cache.c
+++ b/libass/ass_cache.c
@@ -61,7 +61,13 @@ static bool font_key_move(void *dst, void *src)
     return d->family.str;
 }
 
-static void font_destruct(void *key, void *value)
+static void font_key_destruct(void *k)
+{
+    ASS_FontDesc *key = k;
+    free((void *) key->family.str);
+}
+
+static void font_destruct(void *value)
 {
     ass_font_clear(value);
 }
@@ -72,8 +78,9 @@ const CacheDesc font_cache_desc = {
     .hash_func = font_hash,
     .compare_func = font_compare,
     .key_move_func = font_key_move,
+    .key_destruct_func = font_key_destruct,
     .construct_func = ass_font_construct,
-    .destruct_func = font_destruct,
+    .value_destruct_func = font_destruct,
     .key_size = sizeof(ASS_FontDesc),
     .value_size = sizeof(ASS_Font)
 };
@@ -90,11 +97,15 @@ static bool bitmap_key_move(void *dst, void *src)
     return true;
 }
 
-static void bitmap_destruct(void *key, void *value)
+static void bitmap_key_destruct(void *key)
 {
     BitmapHashKey *k = key;
-    ass_free_bitmap(value);
     ass_cache_dec_ref(k->outline);
+}
+
+static void bitmap_destruct(void *value)
+{
+    ass_free_bitmap(value);
 }
 
 size_t ass_bitmap_construct(void *key, void *value, void *priv);
@@ -103,8 +114,9 @@ const CacheDesc bitmap_cache_desc = {
     .hash_func = bitmap_hash,
     .compare_func = bitmap_compare,
     .key_move_func = bitmap_key_move,
+    .key_destruct_func = bitmap_key_destruct,
     .construct_func = ass_bitmap_construct,
-    .destruct_func = bitmap_destruct,
+    .value_destruct_func = bitmap_destruct,
     .key_size = sizeof(BitmapHashKey),
     .value_size = sizeof(Bitmap)
 };
@@ -150,18 +162,22 @@ static bool composite_key_move(void *dst, void *src)
     return true;
 }
 
-static void composite_destruct(void *key, void *value)
+static void composite_key_destruct(void *key)
 {
-    CompositeHashValue *v = value;
     CompositeHashKey *k = key;
-    ass_free_bitmap(&v->bm);
-    ass_free_bitmap(&v->bm_o);
-    ass_free_bitmap(&v->bm_s);
     for (size_t i = 0; i < k->bitmap_count; i++) {
         ass_cache_dec_ref(k->bitmaps[i].bm);
         ass_cache_dec_ref(k->bitmaps[i].bm_o);
     }
     free(k->bitmaps);
+}
+
+static void composite_destruct(void *value)
+{
+    CompositeHashValue *v = value;
+    ass_free_bitmap(&v->bm);
+    ass_free_bitmap(&v->bm_o);
+    ass_free_bitmap(&v->bm_s);
 }
 
 size_t ass_composite_construct(void *key, void *value, void *priv);
@@ -170,8 +186,9 @@ const CacheDesc composite_cache_desc = {
     .hash_func = composite_hash,
     .compare_func = composite_compare,
     .key_move_func = composite_key_move,
+    .key_destruct_func = composite_key_destruct,
     .construct_func = ass_composite_construct,
-    .destruct_func = composite_destruct,
+    .value_destruct_func = composite_destruct,
     .key_size = sizeof(CompositeHashKey),
     .value_size = sizeof(CompositeHashValue)
 };
@@ -230,12 +247,9 @@ static bool outline_key_move(void *dst, void *src)
     return true;
 }
 
-static void outline_destruct(void *key, void *value)
+static void outline_key_destruct(void *key)
 {
-    OutlineHashValue *v = value;
     OutlineHashKey *k = key;
-    ass_outline_free(&v->outline[0]);
-    ass_outline_free(&v->outline[1]);
     switch (k->type) {
     case OUTLINE_GLYPH:
         ass_cache_dec_ref(k->u.glyph.font);
@@ -251,6 +265,13 @@ static void outline_destruct(void *key, void *value)
     }
 }
 
+static void outline_destruct(void *value)
+{
+    OutlineHashValue *v = value;
+    ass_outline_free(&v->outline[0]);
+    ass_outline_free(&v->outline[1]);
+}
+
 size_t ass_outline_construct(void *key, void *value, void *priv);
 
 const CacheDesc outline_cache_desc = {
@@ -258,7 +279,8 @@ const CacheDesc outline_cache_desc = {
     .compare_func = outline_compare,
     .key_move_func = outline_key_move,
     .construct_func = ass_outline_construct,
-    .destruct_func = outline_destruct,
+    .key_destruct_func = outline_key_destruct,
+    .value_destruct_func = outline_destruct,
     .key_size = sizeof(OutlineHashKey),
     .value_size = sizeof(OutlineHashValue)
 };
@@ -276,7 +298,7 @@ static bool face_size_metrics_key_move(void *dst, void *src)
     return true;
 }
 
-static void face_size_metrics_destruct(void *key, void *value)
+static void face_size_metrics_key_destruct(void *key)
 {
     FaceSizeMetricsHashKey *k = key;
     ass_cache_dec_ref(k->font);
@@ -288,8 +310,8 @@ const CacheDesc face_size_metrics_cache_desc = {
     .hash_func = face_size_metrics_hash,
     .compare_func = face_size_metrics_compare,
     .key_move_func = face_size_metrics_key_move,
+    .key_destruct_func = face_size_metrics_key_destruct,
     .construct_func = ass_face_size_metrics_construct,
-    .destruct_func = face_size_metrics_destruct,
     .key_size = sizeof(FaceSizeMetricsHashKey),
     .value_size = sizeof(FT_Size_Metrics)
 };
@@ -307,7 +329,7 @@ static bool glyph_metrics_key_move(void *dst, void *src)
     return true;
 }
 
-static void glyph_metrics_destruct(void *key, void *value)
+static void glyph_metrics_key_destruct(void *key)
 {
     GlyphMetricsHashKey *k = key;
     ass_cache_dec_ref(k->font);
@@ -319,8 +341,8 @@ const CacheDesc glyph_metrics_cache_desc = {
     .hash_func = glyph_metrics_hash,
     .compare_func = glyph_metrics_compare,
     .key_move_func = glyph_metrics_key_move,
+    .key_destruct_func = glyph_metrics_key_destruct,
     .construct_func = ass_glyph_metrics_construct,
-    .destruct_func = glyph_metrics_destruct,
     .key_size = sizeof(GlyphMetricsHashKey),
     .value_size = sizeof(FT_Glyph_Metrics)
 };
@@ -496,7 +518,10 @@ static inline void destroy_item(const CacheDesc *desc, CacheItem *item)
 {
     assert(item->desc == desc);
     char *value = (char *) item + CACHE_ITEM_SIZE;
-    desc->destruct_func(value + align_cache(desc->value_size), value);
+    if (desc->key_destruct_func)
+        desc->key_destruct_func(value + align_cache(desc->value_size));
+    if (desc->value_destruct_func)
+        desc->value_destruct_func(value);
     free(item);
 }
 

--- a/libass/ass_cache.h
+++ b/libass/ass_cache.h
@@ -100,8 +100,6 @@ void *ass_cache_key(void *value);
 void ass_cache_inc_ref(void *value);
 void ass_cache_dec_ref(void *value);
 void ass_cache_cut(Cache *cache, size_t max_size);
-void ass_cache_stats(Cache *cache, size_t *size, unsigned *hits,
-                     unsigned *misses, unsigned *count);
 void ass_cache_empty(Cache *cache);
 void ass_cache_done(Cache *cache);
 Cache *ass_font_cache_create(void);

--- a/libass/ass_cache.h
+++ b/libass/ass_cache.h
@@ -52,7 +52,8 @@ typedef ass_hashcode (*HashFunction)(void *key, ass_hashcode hval);
 typedef bool (*HashCompare)(void *a, void *b);
 typedef bool (*CacheKeyMove)(void *dst, void *src);
 typedef size_t (*CacheValueConstructor)(void *key, void *value, void *priv);
-typedef void (*CacheItemDestructor)(void *key, void *value);
+typedef void (*CacheValueDestructor)(void *value);
+typedef void (*CacheKeyDestructor)(void *key);
 
 // cache hash keys
 
@@ -90,7 +91,8 @@ typedef struct
     HashCompare compare_func;
     CacheKeyMove key_move_func;
     CacheValueConstructor construct_func;
-    CacheItemDestructor destruct_func;
+    CacheKeyDestructor key_destruct_func;
+    CacheValueDestructor value_destruct_func;
     size_t key_size;
     size_t value_size;
 } CacheDesc;

--- a/libass/ass_cache.h
+++ b/libass/ass_cache.h
@@ -104,6 +104,7 @@ void ass_cache_empty(Cache *cache);
 void ass_cache_done(Cache *cache);
 Cache *ass_font_cache_create(void);
 Cache *ass_outline_cache_create(void);
+Cache *ass_face_size_metrics_cache_create(void);
 Cache *ass_glyph_metrics_cache_create(void);
 Cache *ass_bitmap_cache_create(void);
 Cache *ass_composite_cache_create(void);

--- a/libass/ass_cache.h
+++ b/libass/ass_cache.h
@@ -26,6 +26,7 @@
 #include "ass_bitmap.h"
 
 typedef struct cache Cache;
+typedef struct cache_client CacheClient;
 typedef uint64_t ass_hashcode;
 
 // cache values
@@ -94,8 +95,17 @@ typedef struct
     size_t value_size;
 } CacheDesc;
 
+typedef struct
+{
+    struct cache_client *first_client;
+} CacheClientSet;
+
 Cache *ass_cache_create(const CacheDesc *desc);
-void *ass_cache_get(Cache *cache, void *key, void *priv);
+bool ass_cache_client_set_init(CacheClientSet *set);
+void ass_cache_client_set_clear(CacheClientSet *set);
+void ass_cache_client_set_done(CacheClientSet *set);
+CacheClient *ass_cache_client_create(CacheClientSet *set);
+void *ass_cache_get(Cache *cache, CacheClient *client, void *key, void *priv);
 void *ass_cache_key(void *value);
 void ass_cache_inc_ref(void *value);
 void ass_cache_dec_ref(void *value);

--- a/libass/ass_cache.h
+++ b/libass/ass_cache.h
@@ -24,6 +24,7 @@
 #include "ass_font.h"
 #include "ass_outline.h"
 #include "ass_bitmap.h"
+#include "ass_threading.h"
 
 typedef struct cache Cache;
 typedef struct cache_client CacheClient;
@@ -100,6 +101,10 @@ typedef struct
 typedef struct
 {
     struct cache_client *first_client;
+
+#if ENABLE_THREADS
+    pthread_mutex_t mutex;
+#endif
 } CacheClientSet;
 
 Cache *ass_cache_create(const CacheDesc *desc);
@@ -111,6 +116,7 @@ void *ass_cache_get(Cache *cache, CacheClient *client, void *key, void *priv);
 void *ass_cache_key(void *value);
 void ass_cache_inc_ref(void *value);
 void ass_cache_dec_ref(void *value);
+void ass_cache_promote(CacheClientSet *set);
 void ass_cache_cut(Cache *cache, size_t max_size);
 void ass_cache_empty(Cache *cache);
 void ass_cache_done(Cache *cache);

--- a/libass/ass_cache_template.h
+++ b/libass/ass_cache_template.h
@@ -67,6 +67,12 @@ START(bitmap, bitmap_hash_key)
     VECTOR(matrix_z)
 END(BitmapHashKey)
 
+START(face_size_metrics, face_size_metrics_hash_key)
+    GENERIC(ASS_Font *, font)
+    GENERIC(double, size)
+    GENERIC(int, face_index)
+END(FaceSizeMetricsHashKey)
+
 START(glyph_metrics, glyph_metrics_hash_key)
     GENERIC(ASS_Font *, font)
     GENERIC(double, size)

--- a/libass/ass_font.c
+++ b/libass/ass_font.c
@@ -481,7 +481,6 @@ ASS_Font *ass_font_new(ASS_Renderer *render_priv, ASS_FontDesc *desc)
         return NULL;
     if (font->library)
         return font;
-    ass_cache_dec_ref(font);
     return NULL;
 }
 

--- a/libass/ass_font.c
+++ b/libass/ass_font.c
@@ -427,20 +427,23 @@ static int add_face(ASS_FontSelector *fontsel, ASS_Font *font, uint32_t ch)
     FT_Face face;
     int ret = -1;
 
+    ass_fontselect_lock(fontsel);
+
     if (font->n_faces == ASS_FONT_MAX_FACES)
-        return -1;
+        goto fail;
 
     path = ass_font_select(fontsel, font, &index,
             &postscript_name, &uid, &stream, ch);
 
     if (!path)
-        return -1;
+        goto fail;
 
     for (i = 0; i < font->n_faces; i++) {
         if (font->faces_uid[i] == uid) {
             ass_msg(font->library, MSGL_INFO,
                     "Got a font face that already is available! Skipping.");
-            return i;
+            ret = i;
+            goto fail;
         }
     }
 
@@ -453,7 +456,7 @@ static int add_face(ASS_FontSelector *fontsel, ASS_Font *font, uint32_t ch)
     }
 
     if (!face)
-        return -1;
+        goto fail;
 
     ass_charmap_magic(font->library, face);
     set_font_metrics(face);
@@ -468,6 +471,9 @@ static int add_face(ASS_FontSelector *fontsel, ASS_Font *font, uint32_t ch)
     ret = font->n_faces++;
 
 fail:
+
+    ass_fontselect_unlock(fontsel);
+
     return ret;
 }
 

--- a/libass/ass_font.c
+++ b/libass/ass_font.c
@@ -480,9 +480,9 @@ fail:
 /**
  * \brief Create a new ASS_Font according to "desc" argument
  */
-ASS_Font *ass_font_new(ASS_Renderer *render_priv, ASS_FontDesc *desc)
+ASS_Font *ass_font_new(struct render_context *context, ASS_FontDesc *desc)
 {
-    ASS_Font *font = ass_cache_get(render_priv->cache.font_cache, desc, render_priv);
+    ASS_Font *font = ass_cache_get(context->renderer->cache.font_cache, context->cache_client, desc, context->renderer);
     if (!font)
         return NULL;
     if (font->library)

--- a/libass/ass_font.c
+++ b/libass/ass_font.c
@@ -762,7 +762,6 @@ void ass_font_clear(ASS_Font *font)
         if (font->hb_fonts[i])
             hb_font_destroy(font->hb_fonts[i]);
     }
-    free((char *) font->desc.family.str);
 
 #if ENABLE_THREADS
     pthread_mutex_destroy(&font->mutex);

--- a/libass/ass_font.h
+++ b/libass/ass_font.h
@@ -30,6 +30,7 @@ typedef struct ass_font ASS_Font;
 #include "ass_fontselect.h"
 #include "ass_cache.h"
 #include "ass_outline.h"
+#include "ass_threading.h"
 
 #define VERTICAL_LOWER_BOUND 0x02f1
 
@@ -45,7 +46,7 @@ struct ass_font {
     int faces_uid[ASS_FONT_MAX_FACES];
     FT_Face faces[ASS_FONT_MAX_FACES];
     struct hb_font_t *hb_fonts[ASS_FONT_MAX_FACES];
-    int n_faces;
+    _Atomic uintptr_t n_faces;
 };
 
 void ass_charmap_magic(ASS_Library *library, FT_Face face);

--- a/libass/ass_font.h
+++ b/libass/ass_font.h
@@ -54,7 +54,7 @@ struct ass_font {
 };
 
 void ass_charmap_magic(ASS_Library *library, FT_Face face);
-ASS_Font *ass_font_new(ASS_Renderer *render_priv, ASS_FontDesc *desc);
+ASS_Font *ass_font_new(struct render_context *context, ASS_FontDesc *desc);
 void ass_face_set_size(FT_Face face, double size);
 int ass_face_get_weight(FT_Face face);
 FT_Long ass_face_get_style_flags(FT_Face face);

--- a/libass/ass_font.h
+++ b/libass/ass_font.h
@@ -47,6 +47,10 @@ struct ass_font {
     FT_Face faces[ASS_FONT_MAX_FACES];
     struct hb_font_t *hb_fonts[ASS_FONT_MAX_FACES];
     _Atomic uintptr_t n_faces;
+
+#if ENABLE_THREADS
+    pthread_mutex_t mutex;
+#endif
 };
 
 void ass_charmap_magic(ASS_Library *library, FT_Face face);
@@ -63,6 +67,9 @@ uint32_t ass_font_index_magic(FT_Face face, uint32_t symbol);
 bool ass_font_get_glyph(ASS_Font *font, int face_index, int index,
                         ASS_Hinting hinting);
 void ass_font_clear(ASS_Font *font);
+
+void ass_font_lock(ASS_Font *font);
+void ass_font_unlock(ASS_Font *font);
 
 bool ass_get_glyph_outline(ASS_Outline *outline, int32_t *advance,
                            FT_Face face, unsigned flags);

--- a/libass/ass_fontselect.c
+++ b/libass/ass_fontselect.c
@@ -101,6 +101,10 @@ struct font_selector {
 
     ASS_FontProvider *default_provider;
     ASS_FontProvider *embedded_provider;
+
+#if ENABLE_THREADS
+    pthread_mutex_t mutex;
+#endif
 };
 
 struct font_provider {
@@ -1114,6 +1118,11 @@ ass_fontselect_init(ASS_Library *library, FT_Library ftlibrary, size_t *num_emfo
 
     }
 
+#if ENABLE_THREADS
+    if (pthread_mutex_init(&priv->mutex, NULL) != 0)
+        goto fail;
+#endif
+
     return priv;
 
 fail:
@@ -1169,7 +1178,21 @@ void ass_fontselect_free(ASS_FontSelector *priv)
     free(priv->path_default);
     free(priv->family_default);
 
+#if ENABLE_THREADS
+    pthread_mutex_destroy(&priv->mutex);
+#endif
+
     free(priv);
+}
+
+void ass_fontselect_lock(ASS_FontSelector *priv)
+{
+    pthread_mutex_lock(&priv->mutex);
+}
+
+void ass_fontselect_unlock(ASS_FontSelector *priv)
+{
+    pthread_mutex_unlock(&priv->mutex);
 }
 
 void ass_map_font(const ASS_FontMapping *map, int len, const char *name,

--- a/libass/ass_fontselect.h
+++ b/libass/ass_fontselect.h
@@ -253,6 +253,9 @@ char *ass_font_select(ASS_FontSelector *priv,
                       int *uid, ASS_FontStream *data, uint32_t code);
 void ass_fontselect_free(ASS_FontSelector *priv);
 
+void ass_fontselect_lock(ASS_FontSelector *priv);
+void ass_fontselect_unlock(ASS_FontSelector *priv);
+
 // Font provider functions
 ASS_FontProvider *ass_font_provider_new(ASS_FontSelector *selector,
         ASS_FontProviderFuncs *funcs, void *data);

--- a/libass/ass_library.h
+++ b/libass/ass_library.h
@@ -22,6 +22,7 @@
 #include <stdarg.h>
 
 #include "ass_filesystem.h"
+#include "ass_threading.h"
 
 typedef struct {
     char *name;
@@ -38,6 +39,11 @@ struct ass_library {
     size_t num_fontdata;
     void (*msg_callback)(int, const char *, va_list, void *);
     void *msg_callback_data;
+
+#if ENABLE_THREADS
+    pthread_mutex_t log_mutex;
+    int thread_safe_cb;
+#endif
 };
 
 char *ass_load_file(struct ass_library *library, const char *fname, FileNameSource hint, size_t *bufsize);

--- a/libass/ass_parse.c
+++ b/libass/ass_parse.c
@@ -111,7 +111,7 @@ void ass_update_font(RenderContext *state)
         val = 0;                // normal
     desc.italic = val;
 
-    state->font = ass_font_new(state->renderer, &desc);
+    state->font = ass_font_new(state, &desc);
 }
 
 /**

--- a/libass/ass_parse.c
+++ b/libass/ass_parse.c
@@ -111,7 +111,6 @@ void ass_update_font(RenderContext *state)
         val = 0;                // normal
     desc.italic = val;
 
-    ass_cache_dec_ref(state->font);
     state->font = ass_font_new(state->renderer, &desc);
 }
 

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -1239,16 +1239,22 @@ size_t ass_outline_construct(void *key, void *value, void *priv)
     case OUTLINE_GLYPH:
         {
             GlyphHashKey *k = &outline_key->u.glyph;
+            ass_font_lock(k->font);
             ass_face_set_size(k->font->faces[k->face_index], k->size);
             if (!ass_font_get_glyph(k->font, k->face_index, k->glyph_index,
-                                    render_priv->settings.hinting))
+                                    render_priv->settings.hinting)) {
+                ass_font_unlock(k->font);
                 return 1;
+            }
             if (!ass_get_glyph_outline(&v->outline[0], &v->advance,
                                        k->font->faces[k->face_index],
-                                       k->flags))
+                                       k->flags)) {
+                ass_font_unlock(k->font);
                 return 1;
+            }
             ass_font_get_asc_desc(k->font, k->face_index,
                                   &v->asc, &v->desc);
+            ass_font_unlock(k->font);
             break;
         }
     case OUTLINE_DRAWING:

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -83,7 +83,11 @@ static bool render_context_init(RenderContext *state, ASS_Renderer *priv)
     if (!text_info_init(&state->text_info))
         return false;
 
-    if (!(state->shaper = ass_shaper_new(priv->cache.metrics_cache, priv->cache.face_size_metrics_cache)))
+    state->cache_client = ass_cache_client_create(&priv->cache.client_set);
+    if (!state->cache_client)
+        return false;
+
+    if (!(state->shaper = ass_shaper_new(priv->cache.metrics_cache, priv->cache.face_size_metrics_cache, state->cache_client)))
         return false;
 
     return ass_rasterizer_init(&priv->engine, &state->rasterizer, RASTERIZER_PRECISION);
@@ -144,6 +148,9 @@ ASS_Renderer *ass_renderer_init(ASS_Library *library)
     if (!priv->cache.font_cache || !priv->cache.bitmap_cache || !priv->cache.composite_cache || !priv->cache.outline_cache || !priv->cache.face_size_metrics_cache || !priv->cache.metrics_cache)
         goto fail;
 
+    if (!ass_cache_client_set_init(&priv->cache.client_set))
+        goto fail;
+
     priv->cache.glyph_max = GLYPH_CACHE_MAX;
     priv->cache.bitmap_max_size = BITMAP_CACHE_MAX_SIZE;
     priv->cache.composite_max_size = COMPOSITE_CACHE_MAX_SIZE;
@@ -178,20 +185,21 @@ void ass_renderer_done(ASS_Renderer *render_priv)
     ass_frame_unref(render_priv->images_root);
     ass_frame_unref(render_priv->prev_images_root);
 
+    render_context_done(&render_priv->state);
+
     ass_cache_done(render_priv->cache.composite_cache);
     ass_cache_done(render_priv->cache.bitmap_cache);
     ass_cache_done(render_priv->cache.outline_cache);
     ass_cache_done(render_priv->cache.face_size_metrics_cache);
     ass_cache_done(render_priv->cache.metrics_cache);
     ass_cache_done(render_priv->cache.font_cache);
+    ass_cache_client_set_done(&render_priv->cache.client_set);
 
     if (render_priv->fontselect)
         ass_fontselect_free(render_priv->fontselect);
     if (render_priv->ftlibrary)
         FT_Done_FreeType(render_priv->ftlibrary);
     free(render_priv->eimg);
-
-    render_context_done(&render_priv->state);
 
     free(render_priv->settings.default_font);
     free(render_priv->settings.default_family);
@@ -718,12 +726,12 @@ static void blend_vector_clip(RenderContext *state, ASS_Image *head)
 
     ASS_Vector pos;
     BitmapHashKey key;
-    key.outline = ass_cache_get(render_priv->cache.outline_cache, &ol_key, render_priv);
+    key.outline = ass_cache_get(render_priv->cache.outline_cache, state->cache_client, &ol_key, render_priv);
     if (!key.outline || !key.outline->valid ||
             !quantize_transform(m, &pos, NULL, true, &key)) {
         return;
     }
-    Bitmap *clip_bm = ass_cache_get(render_priv->cache.bitmap_cache, &key, state);
+    Bitmap *clip_bm = ass_cache_get(render_priv->cache.bitmap_cache, state->cache_client, &key, state);
     if (!clip_bm)
         return;
 
@@ -1176,7 +1184,7 @@ get_outline_glyph(RenderContext *state, GlyphInfo *info)
     if (info->drawing_text.str) {
         key.type = OUTLINE_DRAWING;
         key.u.drawing.text = info->drawing_text;
-        val = ass_cache_get(priv->cache.outline_cache, &key, priv);
+        val = ass_cache_get(priv->cache.outline_cache, state->cache_client, &key, priv);
         if (!val || !val->valid) {
             return;
         }
@@ -1200,7 +1208,7 @@ get_outline_glyph(RenderContext *state, GlyphInfo *info)
         k->italic = info->italic;
         k->flags = info->flags;
 
-        val = ass_cache_get(priv->cache.outline_cache, &key, priv);
+        val = ass_cache_get(priv->cache.outline_cache, state->cache_client, &key, priv);
         if (!val || !val->valid) {
             return;
         }
@@ -1413,7 +1421,7 @@ get_bitmap_glyph(RenderContext *state, GlyphInfo *info,
     if (!quantize_transform(m, pos, offset, first, &key)) {
         return;
     }
-    info->bm = ass_cache_get(render_priv->cache.bitmap_cache, &key, state);
+    info->bm = ass_cache_get(render_priv->cache.bitmap_cache, state->cache_client, &key, state);
     if (!info->bm || !info->bm->buffer) {
         info->bm = NULL;
     }
@@ -1532,12 +1540,12 @@ get_bitmap_glyph(RenderContext *state, GlyphInfo *info,
         }
     }
 
-    key.outline = ass_cache_get(render_priv->cache.outline_cache, &ol_key, render_priv);
+    key.outline = ass_cache_get(render_priv->cache.outline_cache, state->cache_client, &ol_key, render_priv);
     if (!key.outline || !key.outline->valid ||
             !quantize_transform(m, pos_o, offset, false, &key)) {
         return;
     }
-    info->bm_o = ass_cache_get(render_priv->cache.bitmap_cache, &key, state);
+    info->bm_o = ass_cache_get(render_priv->cache.bitmap_cache, state->cache_client, &key, state);
     if (!info->bm_o || !info->bm_o->buffer) {
         info->bm_o = NULL;
         *pos_o = *pos;
@@ -2618,7 +2626,7 @@ static void render_and_combine_glyphs(RenderContext *state,
         key.filter = info->filter;
         key.bitmap_count = info->bitmap_count;
         key.bitmaps = info->bitmaps;
-        CompositeHashValue *val = ass_cache_get(render_priv->cache.composite_cache, &key, render_priv);
+        CompositeHashValue *val = ass_cache_get(render_priv->cache.composite_cache, state->cache_client, &key, render_priv);
         if (!val)
             continue;
 

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -3128,6 +3128,7 @@ ass_start_frame(ASS_Renderer *render_priv, ASS_Track *track,
     render_priv->prev_images_root = render_priv->images_root;
     render_priv->images_root = NULL;
 
+    ass_cache_promote(&render_priv->cache.client_set);
     check_cache_limits(render_priv, &render_priv->cache);
 
     return true;

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -28,6 +28,11 @@
 #include <linebreak.h>
 #endif
 
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#endif
+
 #include "ass.h"
 #include "ass_outline.h"
 #include "ass_render.h"
@@ -166,6 +171,31 @@ ASS_Renderer *ass_renderer_init(ASS_Library *library)
     ass_shaper_info(library);
     priv->settings.shaper = ASS_SHAPING_COMPLEX;
 
+#if ENABLE_THREADS
+    priv->settings.threads = default_threads();
+
+    if (pthread_mutex_init(&priv->mutex, NULL) != 0)
+        goto thread_fail;
+
+    priv->mutex_inited = true;
+
+    if (pthread_cond_init(&priv->main_cond, NULL) != 0)
+        goto thread_fail;
+
+    priv->main_cond_inited = true;
+
+    if (pthread_cond_init(&priv->pool_cond, NULL) != 0)
+        goto thread_fail;
+
+    priv->pool_cond_inited = true;
+
+thread_fail:
+    if (!priv->pool_cond_inited) {
+        ass_msg(library, MSGL_WARN, "Failed to initialize threading functionality; disabling");
+        priv->thread_start_failed = 1;
+    }
+#endif
+
     ass_msg(library, MSGL_V, "Initialized");
 
     return priv;
@@ -177,10 +207,41 @@ fail:
     return NULL;
 }
 
+#if ENABLE_THREADS
+static void join_threads(ASS_Renderer *render_priv)
+{
+    if (render_priv->threads) {
+        pthread_mutex_lock(&render_priv->mutex);
+        render_priv->shutting_down = 1;
+        pthread_mutex_unlock(&render_priv->mutex);
+        pthread_cond_broadcast(&render_priv->pool_cond);
+
+        for (unsigned i = 0; i < render_priv->n_threads; i++)
+            pthread_join(render_priv->threads[i], NULL);
+
+        free(render_priv->threads);
+
+        render_priv->threads = NULL;
+        render_priv->n_threads = 0;
+    }
+}
+#endif
+
 void ass_renderer_done(ASS_Renderer *render_priv)
 {
     if (!render_priv)
         return;
+
+#if ENABLE_THREADS
+    join_threads(render_priv);
+
+    if (render_priv->mutex_inited)
+        pthread_mutex_destroy(&render_priv->mutex);
+    if (render_priv->main_cond_inited)
+        pthread_cond_destroy(&render_priv->main_cond);
+    if (render_priv->pool_cond_inited)
+        pthread_cond_destroy(&render_priv->pool_cond);
+#endif
 
     ass_frame_unref(render_priv->images_root);
     ass_frame_unref(render_priv->prev_images_root);
@@ -2825,6 +2886,21 @@ static void add_background(RenderContext *state, EventImages *event_images)
     }
 }
 
+static void setup_shaper(ASS_Shaper *shaper, ASS_Renderer *render_priv)
+{
+    ASS_Track *track = render_priv->track;
+
+    ass_shaper_set_kerning(shaper, track->Kerning);
+    ass_shaper_set_language(shaper, track->Language);
+    ass_shaper_set_level(shaper, render_priv->settings.shaper);
+#ifdef USE_FRIBIDI_EX_API
+    ass_shaper_set_bidi_brackets(shaper,
+            track->parser_priv->feature_flags & FEATURE_MASK(ASS_FEATURE_BIDI_BRACKETS));
+#endif
+    ass_shaper_set_whole_text_layout(shaper,
+            track->parser_priv->feature_flags & FEATURE_MASK(ASS_FEATURE_WHOLE_TEXT_LAYOUT));
+}
+
 /**
  * \brief Main ass rendering function, glues everything together
  * \param event event to render
@@ -2832,9 +2908,10 @@ static void add_background(RenderContext *state, EventImages *event_images)
  * Process event, appending resulting ASS_Image's to images_root.
  */
 static bool
-ass_render_event(RenderContext *state, ASS_Event *event,
-                 EventImages *event_images)
+ass_render_event(RenderContext *state, EventImages *event_images)
 {
+    ASS_Event *event = event_images->event;
+
     ASS_Renderer *render_priv = state->renderer;
     if (event->Style >= render_priv->track->n_styles) {
         ass_msg(render_priv->library, MSGL_WARN, "No style found");
@@ -2844,6 +2921,8 @@ ass_render_event(RenderContext *state, ASS_Event *event,
         ass_msg(render_priv->library, MSGL_WARN, "Empty event");
         return false;
     }
+
+    setup_shaper(state->shaper, render_priv);
 
     free_render_context(state);
     init_render_context(state, event);
@@ -3026,7 +3105,6 @@ ass_render_event(RenderContext *state, ASS_Event *event,
 
     render_and_combine_glyphs(state, device_x, device_y);
 
-    memset(event_images, 0, sizeof(*event_images));
     // VSFilter does *not* shift lines with a border > margin to be within the
     // frame, so negative values for top and left may occur
     event_images->top = device_y - text_info->lines[0].asc - text_info->border_top;
@@ -3039,7 +3117,6 @@ ass_render_event(RenderContext *state, ASS_Event *event,
         + 2 * text_info->border_x + 0.5;
     event_images->detect_collisions = state->detect_collisions;
     event_images->shift_direction = (valign == VALIGN_SUB) ? -1 : 1;
-    event_images->event = event;
     event_images->imgs = render_text(state);
 
     if (state->border_style == 4)
@@ -3051,6 +3128,63 @@ ass_render_event(RenderContext *state, ASS_Event *event,
     return true;
 }
 
+#if ENABLE_THREADS
+static void *run_thread(void *ptr)
+{
+    ASS_Renderer *priv = ptr;
+
+    RenderContext state = {0};
+
+    thread_set_name("libass/render");
+
+    bool success = render_context_init(&state, priv);
+
+    pthread_mutex_lock(&priv->mutex);
+
+    if (!success) {
+        ass_msg(priv->library, MSGL_WARN, "Thread setup failed; disabling");
+        priv->thread_start_failed = 1;
+        goto fail;
+    }
+
+    priv->started_threads++;
+
+    pthread_cond_broadcast(&priv->main_cond);
+
+    for (;;) {
+        while (!priv->shutting_down && priv->next_eimg >= priv->sent_eimgs)
+            pthread_cond_wait(&priv->pool_cond, &priv->mutex);
+
+        if (priv->shutting_down)
+            break;
+
+        pthread_mutex_unlock(&priv->mutex);
+
+        uintptr_t got_eimg;
+        while ((got_eimg = priv->next_eimg++) < priv->sent_eimgs) {
+            EventImages *imgs = priv->eimg + got_eimg;
+
+            ass_render_event(&state, imgs);
+
+            if (!--priv->processing_eimgs) {
+                pthread_cond_broadcast(&priv->main_cond);
+                break;
+            }
+        }
+
+        pthread_mutex_lock(&priv->mutex);
+    }
+
+fail:
+
+    pthread_mutex_unlock(&priv->mutex);
+
+    render_context_done(&state);
+
+    return NULL;
+}
+#endif
+
 /**
  * \brief Check cache limits and reset cache if they are exceeded
  */
@@ -3059,21 +3193,6 @@ static void check_cache_limits(ASS_Renderer *priv, CacheStore *cache)
     ass_cache_cut(cache->composite_cache, cache->composite_max_size);
     ass_cache_cut(cache->bitmap_cache, cache->bitmap_max_size);
     ass_cache_cut(cache->outline_cache, cache->glyph_max);
-}
-
-static void setup_shaper(ASS_Shaper *shaper, ASS_Renderer *render_priv)
-{
-    ASS_Track *track = render_priv->track;
-
-    ass_shaper_set_kerning(shaper, track->Kerning);
-    ass_shaper_set_language(shaper, track->Language);
-    ass_shaper_set_level(shaper, render_priv->settings.shaper);
-#ifdef USE_FRIBIDI_EX_API
-    ass_shaper_set_bidi_brackets(shaper,
-            track->parser_priv->feature_flags & FEATURE_MASK(ASS_FEATURE_BIDI_BRACKETS));
-#endif
-    ass_shaper_set_whole_text_layout(shaper,
-            track->parser_priv->feature_flags & FEATURE_MASK(ASS_FEATURE_WHOLE_TEXT_LAYOUT));
 }
 
 /**
@@ -3107,8 +3226,6 @@ ass_start_frame(ASS_Renderer *render_priv, ASS_Track *track,
             render_priv->fontselect, render_priv->num_emfonts);
     }
 
-    setup_shaper(render_priv->state.shaper, render_priv);
-
     // PAR correction
     double par = render_priv->settings.par;
     bool lr_track = track->LayoutResX > 0 && track->LayoutResY > 0;
@@ -3138,6 +3255,12 @@ static int cmp_event_layer(const void *p1, const void *p2)
 {
     ASS_Event *e1 = ((EventImages *) p1)->event;
     ASS_Event *e2 = ((EventImages *) p2)->event;
+    if (!e1 && !e2)
+        return 0;
+    if (e1 && !e2)
+        return -1;
+    if (!e1 && e2)
+        return 1;
     if (e1->Layer < e2->Layer)
         return -1;
     if (e1->Layer > e2->Layer)
@@ -3376,6 +3499,42 @@ static int ass_detect_change(ASS_Renderer *priv)
     return diff;
 }
 
+#if ENABLE_THREADS
+static bool start_threads(ASS_Renderer *priv)
+{
+    if (priv->n_threads != priv->settings.threads && !priv->thread_start_failed) {
+        join_threads(priv);
+
+        priv->shutting_down = 0;
+
+        if (priv->settings.threads <= 1)
+            return true;
+
+        if (!(priv->threads = calloc(priv->settings.threads, sizeof(pthread_t)))) {
+            ass_msg(priv->library, MSGL_ERR, "Allocation failure");
+            return false;
+        }
+
+        for (priv->n_threads = 0; priv->n_threads < priv->settings.threads; priv->n_threads++) {
+            if (pthread_create(&priv->threads[priv->n_threads], NULL, run_thread, priv) != 0) {
+                pthread_mutex_lock(&priv->mutex);
+                ass_msg(priv->library, MSGL_WARN, "Thread startup failure");
+                priv->thread_start_failed = 1;
+                pthread_mutex_unlock(&priv->mutex);
+                return true;
+            }
+        }
+
+        pthread_mutex_lock(&priv->mutex);
+        while (priv->started_threads < priv->n_threads && !priv->thread_start_failed)
+            pthread_cond_wait(&priv->main_cond, &priv->mutex);
+        pthread_mutex_unlock(&priv->mutex);
+    }
+
+    return true;
+}
+#endif
+
 /**
  * \brief render a frame
  * \param priv library handle
@@ -3407,8 +3566,34 @@ ASS_Image *ass_render_frame(ASS_Renderer *priv, ASS_Track *track,
                     realloc(priv->eimg,
                             priv->eimg_size * sizeof(EventImages));
             }
-            if (ass_render_event(&priv->state, event, priv->eimg + cnt))
-                cnt++;
+            priv->eimg[cnt++] = (EventImages){
+                .event = event,
+            };
+        }
+    }
+
+#if ENABLE_THREADS
+    if (!start_threads(priv))
+        return NULL;
+
+    if (priv->n_threads > 0 && !priv->thread_start_failed && cnt > 1) {
+        pthread_mutex_lock(&priv->mutex);
+        priv->sent_eimgs = 0;
+        priv->processing_eimgs = cnt;
+        priv->next_eimg = 0;
+        priv->sent_eimgs = cnt;
+
+        pthread_cond_broadcast(&priv->pool_cond);
+
+        while (priv->processing_eimgs)
+            pthread_cond_wait(&priv->main_cond, &priv->mutex);
+
+        pthread_mutex_unlock(&priv->mutex);
+    } else
+#endif
+    {
+        for (int i = 0; i < cnt; i++) {
+            ass_render_event(&priv->state, priv->eimg + i);
         }
     }
 

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -83,7 +83,7 @@ static bool render_context_init(RenderContext *state, ASS_Renderer *priv)
     if (!text_info_init(&state->text_info))
         return false;
 
-    if (!(state->shaper = ass_shaper_new(priv->cache.metrics_cache)))
+    if (!(state->shaper = ass_shaper_new(priv->cache.metrics_cache, priv->cache.face_size_metrics_cache)))
         return false;
 
     return ass_rasterizer_init(&priv->engine, &state->rasterizer, RASTERIZER_PRECISION);
@@ -139,8 +139,9 @@ ASS_Renderer *ass_renderer_init(ASS_Library *library)
     priv->cache.bitmap_cache = ass_bitmap_cache_create();
     priv->cache.composite_cache = ass_composite_cache_create();
     priv->cache.outline_cache = ass_outline_cache_create();
+    priv->cache.face_size_metrics_cache = ass_face_size_metrics_cache_create();
     priv->cache.metrics_cache = ass_glyph_metrics_cache_create();
-    if (!priv->cache.font_cache || !priv->cache.bitmap_cache || !priv->cache.composite_cache || !priv->cache.outline_cache || !priv->cache.metrics_cache)
+    if (!priv->cache.font_cache || !priv->cache.bitmap_cache || !priv->cache.composite_cache || !priv->cache.outline_cache || !priv->cache.face_size_metrics_cache || !priv->cache.metrics_cache)
         goto fail;
 
     priv->cache.glyph_max = GLYPH_CACHE_MAX;
@@ -180,6 +181,7 @@ void ass_renderer_done(ASS_Renderer *render_priv)
     ass_cache_done(render_priv->cache.composite_cache);
     ass_cache_done(render_priv->cache.bitmap_cache);
     ass_cache_done(render_priv->cache.outline_cache);
+    ass_cache_done(render_priv->cache.face_size_metrics_cache);
     ass_cache_done(render_priv->cache.metrics_cache);
     ass_cache_done(render_priv->cache.font_cache);
 

--- a/libass/ass_render.h
+++ b/libass/ass_render.h
@@ -303,6 +303,7 @@ typedef struct {
     Cache *outline_cache;
     Cache *bitmap_cache;
     Cache *composite_cache;
+    Cache *face_size_metrics_cache;
     Cache *metrics_cache;
     size_t glyph_max;
     size_t bitmap_max_size;

--- a/libass/ass_render.h
+++ b/libass/ass_render.h
@@ -213,6 +213,7 @@ struct render_context {
     TextInfo text_info;
     ASS_Shaper *shaper;
     RasterizerData rasterizer;
+    CacheClient *cache_client;
 
     ASS_Event *event;
     ASS_Style *style;
@@ -305,6 +306,7 @@ typedef struct {
     Cache *composite_cache;
     Cache *face_size_metrics_cache;
     Cache *metrics_cache;
+    CacheClientSet client_set;
     size_t glyph_max;
     size_t bitmap_max_size;
     size_t composite_max_size;

--- a/libass/ass_render_api.c
+++ b/libass/ass_render_api.c
@@ -31,6 +31,7 @@ static void ass_reconfigure(ASS_Renderer *priv)
     ASS_Settings *settings = &priv->settings;
 
     priv->render_id++;
+    ass_cache_promote(&priv->cache.client_set); // Just in case
     ass_cache_empty(priv->cache.composite_cache);
     ass_cache_empty(priv->cache.bitmap_cache);
     ass_cache_empty(priv->cache.outline_cache);

--- a/libass/ass_render_api.c
+++ b/libass/ass_render_api.c
@@ -65,6 +65,22 @@ void ass_set_frame_size(ASS_Renderer *priv, int w, int h)
     }
 }
 
+unsigned ass_set_threads(ASS_Renderer *priv, unsigned threads)
+{
+#if ENABLE_THREADS
+    priv->library->thread_safe_cb = 1;
+
+    if (threads == 0)
+        threads = default_threads();
+
+    priv->settings.threads = threads;
+
+    return threads;
+#else
+    return 0;
+#endif
+}
+
 void ass_set_storage_size(ASS_Renderer *priv, int w, int h)
 {
     if (w <= 0 || h <= 0 || w > FFMIN(INT_MAX, SIZE_MAX) / h)

--- a/libass/ass_shaper.c
+++ b/libass/ass_shaper.c
@@ -221,8 +221,13 @@ get_cached_metrics(struct ass_shaper_metrics_data *metrics,
     if (metrics->vertical && unicode >= VERTICAL_LOWER_BOUND)
         rotate = true;
 
-    metrics->hash_key.glyph_index = glyph;
-    FT_Glyph_Metrics *val = ass_cache_get(metrics->metrics_cache, &metrics->hash_key,
+    GlyphMetricsHashKey key = {
+        .font = metrics->hash_key.font,
+        .face_index = metrics->hash_key.face_index,
+        .size = metrics->hash_key.size,
+        .glyph_index = glyph,
+    };
+    FT_Glyph_Metrics *val = ass_cache_get(metrics->metrics_cache, &key,
                                           rotate ? metrics : NULL);
     if (!val)
         return NULL;

--- a/libass/ass_shaper.c
+++ b/libass/ass_shaper.c
@@ -62,7 +62,8 @@ struct ass_shaper {
     hb_feature_t *features;
     hb_language_t language;
 
-    // Glyph metrics cache, to speed up shaping
+    // Glyph and face-size metrics caches, to speed up shaping
+    Cache *face_size_metrics_cache;
     Cache *metrics_cache;
 
     hb_font_funcs_t *font_funcs;
@@ -191,13 +192,12 @@ static void set_run_features(ASS_Shaper *shaper, GlyphInfo *info)
  * \param hb_font HarfBuzz font
  * \param face associated FreeType font face
  */
-static void update_hb_size(hb_font_t *hb_font, FT_Face face)
+static void update_hb_size(hb_font_t *hb_font, FT_Face face, FT_Size_Metrics *m)
 {
     hb_font_set_scale (hb_font,
-            ((uint64_t) face->size->metrics.x_scale * (uint64_t) face->units_per_EM) >> 16,
-            ((uint64_t) face->size->metrics.y_scale * (uint64_t) face->units_per_EM) >> 16);
-    hb_font_set_ppem (hb_font, face->size->metrics.x_ppem,
-            face->size->metrics.y_ppem);
+            ((uint64_t) m->x_scale * (uint64_t) face->units_per_EM) >> 16,
+            ((uint64_t) m->y_scale * (uint64_t) face->units_per_EM) >> 16);
+    hb_font_set_ppem (hb_font, m->x_ppem, m->y_ppem);
 }
 
 
@@ -235,6 +235,20 @@ get_cached_metrics(struct ass_shaper_metrics_data *metrics,
     return NULL;
 }
 
+size_t ass_face_size_metrics_construct(void *key, void *value, void *priv)
+{
+    FaceSizeMetricsHashKey *k = key;
+    FT_Size_Metrics *v = value;
+
+    FT_Face face = k->font->faces[k->face_index];
+
+    ass_face_set_size(face, k->size);
+
+    memcpy(v, &face->size->metrics, sizeof(FT_Size_Metrics));
+
+    return 1;
+}
+
 size_t ass_glyph_metrics_construct(void *key, void *value, void *priv)
 {
     GlyphMetricsHashKey *k = key;
@@ -244,6 +258,9 @@ size_t ass_glyph_metrics_construct(void *key, void *value, void *priv)
         | FT_LOAD_IGNORE_TRANSFORM;
 
     FT_Face face = k->font->faces[k->face_index];
+
+    ass_face_set_size(face, k->size);
+
     if (FT_Load_Glyph(face, k->glyph_index, load_flags)) {
         v->width = -1;
         return 1;
@@ -453,21 +470,31 @@ static hb_font_t *get_hb_font(ASS_Shaper *shaper, GlyphInfo *info)
 {
     ASS_Font *font = info->font;
     hb_font_t *hb_font = font->hb_fonts[info->face_index];
+
     if (!hb_font)
+        return NULL;
+
+    FaceSizeMetricsHashKey key = {
+        .font = info->font,
+        .face_index = info->face_index,
+        .size = info->font_size,
+    };
+    FT_Size_Metrics *m = ass_cache_get(shaper->face_size_metrics_cache, &key, NULL);
+    if (!m)
         return NULL;
 
     // set up cached metrics access
     struct ass_shaper_metrics_data *metrics = calloc(1, sizeof(struct ass_shaper_metrics_data));
     if (!metrics)
         return NULL;
-    ass_face_set_size(font->faces[info->face_index], info->font_size);
-    update_hb_size(hb_font, font->faces[info->face_index]);
     metrics->metrics_cache = shaper->metrics_cache;
     metrics->hash_key.font = info->font;
     metrics->hash_key.face_index = info->face_index;
     metrics->hash_key.size = info->font_size;
 
     hb_font_set_funcs(hb_font, shaper->font_funcs, metrics, free);
+
+    update_hb_size(hb_font, font->faces[info->face_index], m);
 
     return hb_font;
 }
@@ -992,7 +1019,7 @@ bool ass_shaper_shape(ASS_Shaper *shaper, TextInfo *text_info)
 /**
  * \brief Create a new shaper instance
  */
-ASS_Shaper *ass_shaper_new(Cache *metrics_cache)
+ASS_Shaper *ass_shaper_new(Cache *metrics_cache, Cache *face_size_metrics_cache)
 {
     assert(metrics_cache);
 
@@ -1004,6 +1031,7 @@ ASS_Shaper *ass_shaper_new(Cache *metrics_cache)
 
     if (!init_features(shaper))
         goto error;
+    shaper->face_size_metrics_cache = face_size_metrics_cache;
     shaper->metrics_cache = metrics_cache;
 
     hb_font_funcs_t *funcs = shaper->font_funcs = hb_font_funcs_create();

--- a/libass/ass_shaper.c
+++ b/libass/ass_shaper.c
@@ -79,7 +79,6 @@ struct ass_shaper {
 struct ass_shaper_metrics_data {
     Cache *metrics_cache;
     GlyphMetricsHashKey hash_key;
-    int vertical;
 };
 
 /**
@@ -218,7 +217,7 @@ get_cached_metrics(struct ass_shaper_metrics_data *metrics,
     bool rotate = false;
     // if @font rendering is enabled and the glyph should be rotated,
     // make cached_h_advance pick up the right advance later
-    if (metrics->vertical && unicode >= VERTICAL_LOWER_BOUND)
+    if (metrics->hash_key.font->desc.vertical && unicode >= VERTICAL_LOWER_BOUND)
         rotate = true;
 
     GlyphMetricsHashKey key = {
@@ -467,7 +466,6 @@ static hb_font_t *get_hb_font(ASS_Shaper *shaper, GlyphInfo *info)
     metrics->hash_key.font = info->font;
     metrics->hash_key.face_index = info->face_index;
     metrics->hash_key.size = info->font_size;
-    metrics->vertical = info->font->desc.vertical;
 
     hb_font_set_funcs(hb_font, shaper->font_funcs, metrics, free);
 

--- a/libass/ass_shaper.c
+++ b/libass/ass_shaper.c
@@ -228,7 +228,6 @@ get_cached_metrics(struct ass_shaper_metrics_data *metrics,
         return NULL;
     if (val->width >= 0)
         return val;
-    ass_cache_dec_ref(val);
     return NULL;
 }
 
@@ -293,8 +292,7 @@ get_glyph_nominal(hb_font_t *font, void *font_data, hb_codepoint_t unicode,
         return false;
 
     // rotate glyph advances for @fonts while we still know the Unicode codepoints
-    FT_Glyph_Metrics *metrics = get_cached_metrics(metrics_priv, unicode, *glyph);
-    ass_cache_dec_ref(metrics);
+    get_cached_metrics(metrics_priv, unicode, *glyph);
     return true;
 }
 
@@ -312,8 +310,7 @@ get_glyph_variation(hb_font_t *font, void *font_data, hb_codepoint_t unicode,
         return false;
 
     // rotate glyph advances for @fonts while we still know the Unicode codepoints
-    FT_Glyph_Metrics *metrics = get_cached_metrics(metrics_priv, unicode, *glyph);
-    ass_cache_dec_ref(metrics);
+    get_cached_metrics(metrics_priv, unicode, *glyph);
     return true;
 }
 
@@ -327,7 +324,6 @@ cached_h_advance(hb_font_t *font, void *font_data, hb_codepoint_t glyph,
         return 0;
 
     hb_position_t advance = metrics->horiAdvance;
-    ass_cache_dec_ref(metrics);
     return advance;
 }
 
@@ -341,7 +337,6 @@ cached_v_advance(hb_font_t *font, void *font_data, hb_codepoint_t glyph,
         return 0;
 
     hb_position_t advance = metrics->vertAdvance;
-    ass_cache_dec_ref(metrics);
     return advance;
 }
 
@@ -363,7 +358,6 @@ cached_v_origin(hb_font_t *font, void *font_data, hb_codepoint_t glyph,
 
     *x = metrics->horiBearingX - metrics->vertBearingX;
     *y = metrics->horiBearingY + metrics->vertBearingY;
-    ass_cache_dec_ref(metrics);
     return true;
 }
 
@@ -401,7 +395,6 @@ cached_extents(hb_font_t *font, void *font_data, hb_codepoint_t glyph,
     extents->y_bearing =  metrics->horiBearingY;
     extents->width     =  metrics->width;
     extents->height    = -metrics->height;
-    ass_cache_dec_ref(metrics);
     return true;
 }
 
@@ -614,7 +607,6 @@ shape_harfbuzz_process_run(GlyphInfo *glyphs, hb_buffer_t *buf, int offset)
             info->next = malloc(sizeof(GlyphInfo));
             if (info->next) {
                 memcpy(info->next, info, sizeof(GlyphInfo));
-                ass_cache_inc_ref(info->font);
                 info = info->next;
                 info->next = NULL;
             }

--- a/libass/ass_shaper.c
+++ b/libass/ass_shaper.c
@@ -79,7 +79,7 @@ struct ass_shaper {
 
 struct ass_shaper_metrics_data {
     Cache *metrics_cache;
-    GlyphMetricsHashKey hash_key;
+    FaceSizeMetricsHashKey hash_key;
 };
 
 /**
@@ -490,9 +490,7 @@ static hb_font_t *get_hb_font(ASS_Shaper *shaper, GlyphInfo *info)
         return NULL;
     }
     metrics->metrics_cache = shaper->metrics_cache;
-    metrics->hash_key.font = info->font;
-    metrics->hash_key.face_index = info->face_index;
-    metrics->hash_key.size = info->font_size;
+    memcpy(&metrics->hash_key, &key, sizeof(key));
 
     hb_font_set_funcs(hb_font, shaper->font_funcs, metrics, free);
 

--- a/libass/ass_shaper.c
+++ b/libass/ass_shaper.c
@@ -469,10 +469,6 @@ bool ass_create_hb_font(ASS_Font *font, int index)
 static hb_font_t *get_hb_font(ASS_Shaper *shaper, GlyphInfo *info)
 {
     ASS_Font *font = info->font;
-    hb_font_t *hb_font = font->hb_fonts[info->face_index];
-
-    if (!hb_font)
-        return NULL;
 
     FaceSizeMetricsHashKey key = {
         .font = info->font,
@@ -483,10 +479,16 @@ static hb_font_t *get_hb_font(ASS_Shaper *shaper, GlyphInfo *info)
     if (!m)
         return NULL;
 
+    hb_font_t *hb_font = hb_font_create_sub_font(font->hb_fonts[info->face_index]);
+    if (!hb_font)
+        return NULL;
+
     // set up cached metrics access
     struct ass_shaper_metrics_data *metrics = calloc(1, sizeof(struct ass_shaper_metrics_data));
-    if (!metrics)
+    if (!metrics) {
+        hb_font_destroy(hb_font);
         return NULL;
+    }
     metrics->metrics_cache = shaper->metrics_cache;
     metrics->hash_key.font = info->font;
     metrics->hash_key.face_index = info->face_index;
@@ -721,6 +723,8 @@ static bool shape_harfbuzz(ASS_Shaper *shaper, GlyphInfo *glyphs, size_t len)
         shape_harfbuzz_process_run(glyphs, buf,
                 shaper->whole_text_layout ? 0 : offset - lead_context);
         hb_buffer_reset(buf);
+
+        hb_font_destroy(font);
     }
 
     return true;

--- a/libass/ass_shaper.h
+++ b/libass/ass_shaper.h
@@ -31,7 +31,7 @@ typedef struct ass_shaper ASS_Shaper;
 #endif
 
 void ass_shaper_info(ASS_Library *lib);
-ASS_Shaper *ass_shaper_new(Cache *metrics_cache);
+ASS_Shaper *ass_shaper_new(Cache *metrics_cache, Cache *face_size_metrics_cache);
 void ass_shaper_free(ASS_Shaper *shaper);
 bool ass_create_hb_font(ASS_Font *font, int index);
 void ass_shaper_set_kerning(ASS_Shaper *shaper, bool kern);

--- a/libass/ass_shaper.h
+++ b/libass/ass_shaper.h
@@ -31,7 +31,7 @@ typedef struct ass_shaper ASS_Shaper;
 #endif
 
 void ass_shaper_info(ASS_Library *lib);
-ASS_Shaper *ass_shaper_new(Cache *metrics_cache, Cache *face_size_metrics_cache);
+ASS_Shaper *ass_shaper_new(Cache *metrics_cache, Cache *face_size_metrics_cache, CacheClient *cache_client);
 void ass_shaper_free(ASS_Shaper *shaper);
 bool ass_create_hb_font(ASS_Font *font, int index);
 void ass_shaper_set_kerning(ASS_Shaper *shaper, bool kern);

--- a/libass/ass_threading.h
+++ b/libass/ass_threading.h
@@ -1,0 +1,246 @@
+/*
+ * Copyright (C) 2023 libass contributors
+ *
+ * This file is part of libass.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef LIBASS_THREADING_H
+#define LIBASS_THREADING_H
+
+#include "config.h"
+
+#include "ass_compat.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+
+#ifdef HAVE_SCHED_H
+#include <sched.h>
+#endif
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#endif
+
+#ifdef HAVE_STDATOMIC_H
+
+#include <stdatomic.h>
+
+#ifdef CONFIG_W32THREAD
+
+#define ENABLE_THREADS 1
+
+struct ThreadStruct {
+    void *(*start_routine)(void *);
+    void *arg;
+    void *ret;
+    HANDLE handle;
+};
+
+typedef struct ThreadStruct *pthread_t;
+
+typedef CRITICAL_SECTION   pthread_mutex_t;
+typedef CONDITION_VARIABLE pthread_cond_t;
+
+static inline int pthread_mutex_init(pthread_mutex_t *mtx, const void *attr)
+{
+    assert(!attr);
+    InitializeCriticalSection(mtx);
+    return 0;
+}
+
+#define pthread_mutex_destroy DeleteCriticalSection
+#define pthread_mutex_lock EnterCriticalSection
+#define pthread_mutex_unlock LeaveCriticalSection
+
+static inline bool pthread_cond_init(pthread_cond_t *cond, const void *attr)
+{
+    assert(!attr);
+    InitializeConditionVariable(cond);
+    return 0;
+}
+
+#define pthread_cond_destroy(x) ((void) 0) // No-op
+#define pthread_cond_signal WakeConditionVariable
+#define pthread_cond_broadcast WakeAllConditionVariable
+
+static inline int pthread_cond_wait(pthread_cond_t *cond, pthread_mutex_t *mutex)
+{
+    return (SleepConditionVariableCS(cond, mutex, INFINITE) == 0) ? 0 : EINVAL;
+}
+
+static DWORD WINAPI
+#ifdef __GNUC__
+__attribute__((force_align_arg_pointer))
+#endif
+thread_start_func(void *arg)
+{
+    pthread_t thread = arg;
+    thread->ret = thread->start_routine(thread->arg);
+    return 0;
+}
+
+static inline int pthread_create(pthread_t *threadp, const void *attr, void *(*start_routine)(void *), void *arg)
+{
+    *threadp = NULL;
+
+    if (attr)
+        return EINVAL;
+
+    pthread_t thread = malloc(sizeof(struct ThreadStruct));
+    thread->start_routine = start_routine;
+    thread->arg = arg;
+    if ((thread->handle = CreateThread(NULL, 0, thread_start_func, thread, 0, NULL))) {
+        *threadp = thread;
+        return 0;
+    } else {
+        free(thread);
+        return EPERM;
+    }
+}
+
+static inline int pthread_join(pthread_t thread, void **value_ptr)
+{
+    DWORD ret = WaitForSingleObject(thread->handle, INFINITE);
+    CloseHandle(thread->handle);
+
+    if (ret == WAIT_OBJECT_0 && value_ptr)
+        *value_ptr = thread->ret;
+
+    free(thread);
+
+    return ret == WAIT_OBJECT_0 ? 0 : EINVAL;
+}
+
+static inline void thread_set_namew(PCWSTR name)
+{
+#if ASS_WINAPI_DESKTOP
+    HMODULE dll = GetModuleHandleW(L"kernel32.dll");
+    if (!dll)
+        return;
+
+    HRESULT (WINAPI *func)(HANDLE, PCWSTR) = (void *) GetProcAddress(dll, "SetThreadDescription");
+    if (!func)
+        return;
+
+    func(GetCurrentThread(), name);
+#endif
+}
+#define thread_set_name(x) thread_set_namew(L"" x)
+
+#elif defined(CONFIG_PTHREAD)
+
+#include <pthread.h>
+#define ENABLE_THREADS 1
+
+static inline void thread_set_name(const char *name)
+{
+#if defined(__APPLE__)
+    pthread_setname_np(name);
+#elif defined(__linux__)
+    pthread_setname_np(pthread_self(), name);
+#elif defined(__FreeBSD__)
+    pthread_set_name_np(pthread_self(), name);
+#endif
+}
+
+#endif /* CONFIG_PTHREAD */
+
+#endif /* HAVE_STDATOMIC_H */
+
+#ifdef ENABLE_THREADS
+
+#define inc_ref(x) (void) (atomic_fetch_add_explicit(x, 1, memory_order_relaxed))
+#define dec_ref(x) (atomic_fetch_sub_explicit(x, 1, memory_order_acq_rel) - 1)
+
+static inline unsigned default_threads(void)
+{
+    if (getenv("LIBASS_NO_THREADS"))
+        return 1;
+
+#if HAVE_SCHED_GETAFFINITY && defined(CPU_COUNT)
+    cpu_set_t cpuset;
+    CPU_ZERO(&cpuset);
+    if (!sched_getaffinity(0, sizeof(cpuset), &cpuset))
+        return CPU_COUNT(&cpuset);
+#elif defined(_SC_NPROCESSORS_ONLN)
+    long sc = sysconf(_SC_NPROCESSORS_ONLN);
+    if (sc < 0)
+        return 1;
+    return sc;
+#elif defined(_WIN32)
+    SYSTEM_INFO info;
+    GetNativeSystemInfo(&info);
+    return info.dwNumberOfProcessors;
+#endif
+
+    return 1;
+}
+
+#else
+
+#define ENABLE_THREADS 0
+
+static inline void inc_ref(size_t *count) { ++(*count); }
+static inline size_t dec_ref(size_t *count) { return --(*count); }
+
+#ifndef atomic_compare_exchange_strong
+#define atomic_compare_exchange_strong(obj, expected, desired) ((*(obj) == *(expected)) ? (*(obj) = (desired), true) : (*(expected) = *(obj), false))
+#endif
+
+#ifndef atomic_compare_exchange_weak
+#define atomic_compare_exchange_weak atomic_compare_exchange_strong
+#endif
+
+#ifndef atomic_store_explicit
+#define atomic_store_explicit(obj, desired, order) (*(obj) = (desired))
+#endif
+
+#ifndef atomic_load_explicit
+#define atomic_load_explicit(obj, order) (*(obj))
+#endif
+
+#ifndef atomic_fetch_add_explicit
+#define atomic_fetch_add_explicit(obj, arg, order) (void) (*(obj) += (arg))
+#endif
+
+#ifndef atomic_exchange_explicit
+static inline void *do_exchange(void *obj, void *desired) {
+    void *old = *(void **)obj;
+    *(void **)obj = desired;
+    return old;
+}
+
+#define atomic_exchange_explicit(obj, desired, order) do_exchange(obj, desired)
+#endif
+
+#ifndef _Atomic
+#define _Atomic
+#endif
+
+#define pthread_mutex_lock(x) do {} while(0)
+#define pthread_mutex_unlock(x) do {} while(0)
+#define pthread_cond_signal(x) do {} while(0)
+#define pthread_cond_broadcast(x) do {} while(0)
+
+#endif /* !ENABLE_THREADS */
+
+#endif                          /* LIBASS_THREADING_H */

--- a/libass/libass.sym
+++ b/libass/libass.sym
@@ -8,6 +8,7 @@ ass_renderer_init
 ass_renderer_done
 ass_set_frame_size
 ass_set_storage_size
+ass_set_threads
 ass_set_margins
 ass_set_use_margins
 ass_set_aspect_ratio

--- a/m4/ax_pthread.m4
+++ b/m4/ax_pthread.m4
@@ -1,0 +1,522 @@
+# ===========================================================================
+#        https://www.gnu.org/software/autoconf-archive/ax_pthread.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_PTHREAD([ACTION-IF-FOUND[, ACTION-IF-NOT-FOUND]])
+#
+# DESCRIPTION
+#
+#   This macro figures out how to build C programs using POSIX threads. It
+#   sets the PTHREAD_LIBS output variable to the threads library and linker
+#   flags, and the PTHREAD_CFLAGS output variable to any special C compiler
+#   flags that are needed. (The user can also force certain compiler
+#   flags/libs to be tested by setting these environment variables.)
+#
+#   Also sets PTHREAD_CC and PTHREAD_CXX to any special C compiler that is
+#   needed for multi-threaded programs (defaults to the value of CC
+#   respectively CXX otherwise). (This is necessary on e.g. AIX to use the
+#   special cc_r/CC_r compiler alias.)
+#
+#   NOTE: You are assumed to not only compile your program with these flags,
+#   but also to link with them as well. For example, you might link with
+#   $PTHREAD_CC $CFLAGS $PTHREAD_CFLAGS $LDFLAGS ... $PTHREAD_LIBS $LIBS
+#   $PTHREAD_CXX $CXXFLAGS $PTHREAD_CFLAGS $LDFLAGS ... $PTHREAD_LIBS $LIBS
+#
+#   If you are only building threaded programs, you may wish to use these
+#   variables in your default LIBS, CFLAGS, and CC:
+#
+#     LIBS="$PTHREAD_LIBS $LIBS"
+#     CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+#     CXXFLAGS="$CXXFLAGS $PTHREAD_CFLAGS"
+#     CC="$PTHREAD_CC"
+#     CXX="$PTHREAD_CXX"
+#
+#   In addition, if the PTHREAD_CREATE_JOINABLE thread-attribute constant
+#   has a nonstandard name, this macro defines PTHREAD_CREATE_JOINABLE to
+#   that name (e.g. PTHREAD_CREATE_UNDETACHED on AIX).
+#
+#   Also HAVE_PTHREAD_PRIO_INHERIT is defined if pthread is found and the
+#   PTHREAD_PRIO_INHERIT symbol is defined when compiling with
+#   PTHREAD_CFLAGS.
+#
+#   ACTION-IF-FOUND is a list of shell commands to run if a threads library
+#   is found, and ACTION-IF-NOT-FOUND is a list of commands to run it if it
+#   is not found. If ACTION-IF-FOUND is not specified, the default action
+#   will define HAVE_PTHREAD.
+#
+#   Please let the authors know if this macro fails on any platform, or if
+#   you have any other suggestions or comments. This macro was based on work
+#   by SGJ on autoconf scripts for FFTW (http://www.fftw.org/) (with help
+#   from M. Frigo), as well as ac_pthread and hb_pthread macros posted by
+#   Alejandro Forero Cuervo to the autoconf macro repository. We are also
+#   grateful for the helpful feedback of numerous users.
+#
+#   Updated for Autoconf 2.68 by Daniel Richard G.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Steven G. Johnson <stevenj@alum.mit.edu>
+#   Copyright (c) 2011 Daniel Richard G. <skunk@iSKUNK.ORG>
+#   Copyright (c) 2019 Marc Stevens <marc.stevens@cwi.nl>
+#
+#   This program is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation, either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 31
+
+AU_ALIAS([ACX_PTHREAD], [AX_PTHREAD])
+AC_DEFUN([AX_PTHREAD], [
+AC_REQUIRE([AC_CANONICAL_HOST])
+AC_REQUIRE([AC_PROG_CC])
+AC_REQUIRE([AC_PROG_SED])
+AC_LANG_PUSH([C])
+ax_pthread_ok=no
+
+# We used to check for pthread.h first, but this fails if pthread.h
+# requires special compiler flags (e.g. on Tru64 or Sequent).
+# It gets checked for in the link test anyway.
+
+# First of all, check if the user has set any of the PTHREAD_LIBS,
+# etcetera environment variables, and if threads linking works using
+# them:
+if test "x$PTHREAD_CFLAGS$PTHREAD_LIBS" != "x"; then
+        ax_pthread_save_CC="$CC"
+        ax_pthread_save_CFLAGS="$CFLAGS"
+        ax_pthread_save_LIBS="$LIBS"
+        AS_IF([test "x$PTHREAD_CC" != "x"], [CC="$PTHREAD_CC"])
+        AS_IF([test "x$PTHREAD_CXX" != "x"], [CXX="$PTHREAD_CXX"])
+        CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+        LIBS="$PTHREAD_LIBS $LIBS"
+        AC_MSG_CHECKING([for pthread_join using $CC $PTHREAD_CFLAGS $PTHREAD_LIBS])
+        AC_LINK_IFELSE([AC_LANG_CALL([], [pthread_join])], [ax_pthread_ok=yes])
+        AC_MSG_RESULT([$ax_pthread_ok])
+        if test "x$ax_pthread_ok" = "xno"; then
+                PTHREAD_LIBS=""
+                PTHREAD_CFLAGS=""
+        fi
+        CC="$ax_pthread_save_CC"
+        CFLAGS="$ax_pthread_save_CFLAGS"
+        LIBS="$ax_pthread_save_LIBS"
+fi
+
+# We must check for the threads library under a number of different
+# names; the ordering is very important because some systems
+# (e.g. DEC) have both -lpthread and -lpthreads, where one of the
+# libraries is broken (non-POSIX).
+
+# Create a list of thread flags to try. Items with a "," contain both
+# C compiler flags (before ",") and linker flags (after ","). Other items
+# starting with a "-" are C compiler flags, and remaining items are
+# library names, except for "none" which indicates that we try without
+# any flags at all, and "pthread-config" which is a program returning
+# the flags for the Pth emulation library.
+
+ax_pthread_flags="pthreads none -Kthread -pthread -pthreads -mthreads pthread --thread-safe -mt pthread-config"
+
+# The ordering *is* (sometimes) important.  Some notes on the
+# individual items follow:
+
+# pthreads: AIX (must check this before -lpthread)
+# none: in case threads are in libc; should be tried before -Kthread and
+#       other compiler flags to prevent continual compiler warnings
+# -Kthread: Sequent (threads in libc, but -Kthread needed for pthread.h)
+# -pthread: Linux/gcc (kernel threads), BSD/gcc (userland threads), Tru64
+#           (Note: HP C rejects this with "bad form for `-t' option")
+# -pthreads: Solaris/gcc (Note: HP C also rejects)
+# -mt: Sun Workshop C (may only link SunOS threads [-lthread], but it
+#      doesn't hurt to check since this sometimes defines pthreads and
+#      -D_REENTRANT too), HP C (must be checked before -lpthread, which
+#      is present but should not be used directly; and before -mthreads,
+#      because the compiler interprets this as "-mt" + "-hreads")
+# -mthreads: Mingw32/gcc, Lynx/gcc
+# pthread: Linux, etcetera
+# --thread-safe: KAI C++
+# pthread-config: use pthread-config program (for GNU Pth library)
+
+case $host_os in
+
+        freebsd*)
+
+        # -kthread: FreeBSD kernel threads (preferred to -pthread since SMP-able)
+        # lthread: LinuxThreads port on FreeBSD (also preferred to -pthread)
+
+        ax_pthread_flags="-kthread lthread $ax_pthread_flags"
+        ;;
+
+        hpux*)
+
+        # From the cc(1) man page: "[-mt] Sets various -D flags to enable
+        # multi-threading and also sets -lpthread."
+
+        ax_pthread_flags="-mt -pthread pthread $ax_pthread_flags"
+        ;;
+
+        openedition*)
+
+        # IBM z/OS requires a feature-test macro to be defined in order to
+        # enable POSIX threads at all, so give the user a hint if this is
+        # not set. (We don't define these ourselves, as they can affect
+        # other portions of the system API in unpredictable ways.)
+
+        AC_EGREP_CPP([AX_PTHREAD_ZOS_MISSING],
+            [
+#            if !defined(_OPEN_THREADS) && !defined(_UNIX03_THREADS)
+             AX_PTHREAD_ZOS_MISSING
+#            endif
+            ],
+            [AC_MSG_WARN([IBM z/OS requires -D_OPEN_THREADS or -D_UNIX03_THREADS to enable pthreads support.])])
+        ;;
+
+        solaris*)
+
+        # On Solaris (at least, for some versions), libc contains stubbed
+        # (non-functional) versions of the pthreads routines, so link-based
+        # tests will erroneously succeed. (N.B.: The stubs are missing
+        # pthread_cleanup_push, or rather a function called by this macro,
+        # so we could check for that, but who knows whether they'll stub
+        # that too in a future libc.)  So we'll check first for the
+        # standard Solaris way of linking pthreads (-mt -lpthread).
+
+        ax_pthread_flags="-mt,-lpthread pthread $ax_pthread_flags"
+        ;;
+esac
+
+# Are we compiling with Clang?
+
+AC_CACHE_CHECK([whether $CC is Clang],
+    [ax_cv_PTHREAD_CLANG],
+    [ax_cv_PTHREAD_CLANG=no
+     # Note that Autoconf sets GCC=yes for Clang as well as GCC
+     if test "x$GCC" = "xyes"; then
+        AC_EGREP_CPP([AX_PTHREAD_CC_IS_CLANG],
+            [/* Note: Clang 2.7 lacks __clang_[a-z]+__ */
+#            if defined(__clang__) && defined(__llvm__)
+             AX_PTHREAD_CC_IS_CLANG
+#            endif
+            ],
+            [ax_cv_PTHREAD_CLANG=yes])
+     fi
+    ])
+ax_pthread_clang="$ax_cv_PTHREAD_CLANG"
+
+
+# GCC generally uses -pthread, or -pthreads on some platforms (e.g. SPARC)
+
+# Note that for GCC and Clang -pthread generally implies -lpthread,
+# except when -nostdlib is passed.
+# This is problematic using libtool to build C++ shared libraries with pthread:
+# [1] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=25460
+# [2] https://bugzilla.redhat.com/show_bug.cgi?id=661333
+# [3] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=468555
+# To solve this, first try -pthread together with -lpthread for GCC
+
+AS_IF([test "x$GCC" = "xyes"],
+      [ax_pthread_flags="-pthread,-lpthread -pthread -pthreads $ax_pthread_flags"])
+
+# Clang takes -pthread (never supported any other flag), but we'll try with -lpthread first
+
+AS_IF([test "x$ax_pthread_clang" = "xyes"],
+      [ax_pthread_flags="-pthread,-lpthread -pthread"])
+
+
+# The presence of a feature test macro requesting re-entrant function
+# definitions is, on some systems, a strong hint that pthreads support is
+# correctly enabled
+
+case $host_os in
+        darwin* | hpux* | linux* | osf* | solaris*)
+        ax_pthread_check_macro="_REENTRANT"
+        ;;
+
+        aix*)
+        ax_pthread_check_macro="_THREAD_SAFE"
+        ;;
+
+        *)
+        ax_pthread_check_macro="--"
+        ;;
+esac
+AS_IF([test "x$ax_pthread_check_macro" = "x--"],
+      [ax_pthread_check_cond=0],
+      [ax_pthread_check_cond="!defined($ax_pthread_check_macro)"])
+
+
+if test "x$ax_pthread_ok" = "xno"; then
+for ax_pthread_try_flag in $ax_pthread_flags; do
+
+        case $ax_pthread_try_flag in
+                none)
+                AC_MSG_CHECKING([whether pthreads work without any flags])
+                ;;
+
+                *,*)
+                PTHREAD_CFLAGS=`echo $ax_pthread_try_flag | sed "s/^\(.*\),\(.*\)$/\1/"`
+                PTHREAD_LIBS=`echo $ax_pthread_try_flag | sed "s/^\(.*\),\(.*\)$/\2/"`
+                AC_MSG_CHECKING([whether pthreads work with "$PTHREAD_CFLAGS" and "$PTHREAD_LIBS"])
+                ;;
+
+                -*)
+                AC_MSG_CHECKING([whether pthreads work with $ax_pthread_try_flag])
+                PTHREAD_CFLAGS="$ax_pthread_try_flag"
+                ;;
+
+                pthread-config)
+                AC_CHECK_PROG([ax_pthread_config], [pthread-config], [yes], [no])
+                AS_IF([test "x$ax_pthread_config" = "xno"], [continue])
+                PTHREAD_CFLAGS="`pthread-config --cflags`"
+                PTHREAD_LIBS="`pthread-config --ldflags` `pthread-config --libs`"
+                ;;
+
+                *)
+                AC_MSG_CHECKING([for the pthreads library -l$ax_pthread_try_flag])
+                PTHREAD_LIBS="-l$ax_pthread_try_flag"
+                ;;
+        esac
+
+        ax_pthread_save_CFLAGS="$CFLAGS"
+        ax_pthread_save_LIBS="$LIBS"
+        CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+        LIBS="$PTHREAD_LIBS $LIBS"
+
+        # Check for various functions.  We must include pthread.h,
+        # since some functions may be macros.  (On the Sequent, we
+        # need a special flag -Kthread to make this header compile.)
+        # We check for pthread_join because it is in -lpthread on IRIX
+        # while pthread_create is in libc.  We check for pthread_attr_init
+        # due to DEC craziness with -lpthreads.  We check for
+        # pthread_cleanup_push because it is one of the few pthread
+        # functions on Solaris that doesn't have a non-functional libc stub.
+        # We try pthread_create on general principles.
+
+        AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <pthread.h>
+#                       if $ax_pthread_check_cond
+#                        error "$ax_pthread_check_macro must be defined"
+#                       endif
+                        static void *some_global = NULL;
+                        static void routine(void *a)
+                          {
+                             /* To avoid any unused-parameter or
+                                unused-but-set-parameter warning.  */
+                             some_global = a;
+                          }
+                        static void *start_routine(void *a) { return a; }],
+                       [pthread_t th; pthread_attr_t attr;
+                        pthread_create(&th, 0, start_routine, 0);
+                        pthread_join(th, 0);
+                        pthread_attr_init(&attr);
+                        pthread_cleanup_push(routine, 0);
+                        pthread_cleanup_pop(0) /* ; */])],
+            [ax_pthread_ok=yes],
+            [])
+
+        CFLAGS="$ax_pthread_save_CFLAGS"
+        LIBS="$ax_pthread_save_LIBS"
+
+        AC_MSG_RESULT([$ax_pthread_ok])
+        AS_IF([test "x$ax_pthread_ok" = "xyes"], [break])
+
+        PTHREAD_LIBS=""
+        PTHREAD_CFLAGS=""
+done
+fi
+
+
+# Clang needs special handling, because older versions handle the -pthread
+# option in a rather... idiosyncratic way
+
+if test "x$ax_pthread_clang" = "xyes"; then
+
+        # Clang takes -pthread; it has never supported any other flag
+
+        # (Note 1: This will need to be revisited if a system that Clang
+        # supports has POSIX threads in a separate library.  This tends not
+        # to be the way of modern systems, but it's conceivable.)
+
+        # (Note 2: On some systems, notably Darwin, -pthread is not needed
+        # to get POSIX threads support; the API is always present and
+        # active.  We could reasonably leave PTHREAD_CFLAGS empty.  But
+        # -pthread does define _REENTRANT, and while the Darwin headers
+        # ignore this macro, third-party headers might not.)
+
+        # However, older versions of Clang make a point of warning the user
+        # that, in an invocation where only linking and no compilation is
+        # taking place, the -pthread option has no effect ("argument unused
+        # during compilation").  They expect -pthread to be passed in only
+        # when source code is being compiled.
+        #
+        # Problem is, this is at odds with the way Automake and most other
+        # C build frameworks function, which is that the same flags used in
+        # compilation (CFLAGS) are also used in linking.  Many systems
+        # supported by AX_PTHREAD require exactly this for POSIX threads
+        # support, and in fact it is often not straightforward to specify a
+        # flag that is used only in the compilation phase and not in
+        # linking.  Such a scenario is extremely rare in practice.
+        #
+        # Even though use of the -pthread flag in linking would only print
+        # a warning, this can be a nuisance for well-run software projects
+        # that build with -Werror.  So if the active version of Clang has
+        # this misfeature, we search for an option to squash it.
+
+        AC_CACHE_CHECK([whether Clang needs flag to prevent "argument unused" warning when linking with -pthread],
+            [ax_cv_PTHREAD_CLANG_NO_WARN_FLAG],
+            [ax_cv_PTHREAD_CLANG_NO_WARN_FLAG=unknown
+             # Create an alternate version of $ac_link that compiles and
+             # links in two steps (.c -> .o, .o -> exe) instead of one
+             # (.c -> exe), because the warning occurs only in the second
+             # step
+             ax_pthread_save_ac_link="$ac_link"
+             ax_pthread_sed='s/conftest\.\$ac_ext/conftest.$ac_objext/g'
+             ax_pthread_link_step=`AS_ECHO(["$ac_link"]) | sed "$ax_pthread_sed"`
+             ax_pthread_2step_ac_link="($ac_compile) && (echo ==== >&5) && ($ax_pthread_link_step)"
+             ax_pthread_save_CFLAGS="$CFLAGS"
+             for ax_pthread_try in '' -Qunused-arguments -Wno-unused-command-line-argument unknown; do
+                AS_IF([test "x$ax_pthread_try" = "xunknown"], [break])
+                CFLAGS="-Werror -Wunknown-warning-option $ax_pthread_try -pthread $ax_pthread_save_CFLAGS"
+                ac_link="$ax_pthread_save_ac_link"
+                AC_LINK_IFELSE([AC_LANG_SOURCE([[int main(void){return 0;}]])],
+                    [ac_link="$ax_pthread_2step_ac_link"
+                     AC_LINK_IFELSE([AC_LANG_SOURCE([[int main(void){return 0;}]])],
+                         [break])
+                    ])
+             done
+             ac_link="$ax_pthread_save_ac_link"
+             CFLAGS="$ax_pthread_save_CFLAGS"
+             AS_IF([test "x$ax_pthread_try" = "x"], [ax_pthread_try=no])
+             ax_cv_PTHREAD_CLANG_NO_WARN_FLAG="$ax_pthread_try"
+            ])
+
+        case "$ax_cv_PTHREAD_CLANG_NO_WARN_FLAG" in
+                no | unknown) ;;
+                *) PTHREAD_CFLAGS="$ax_cv_PTHREAD_CLANG_NO_WARN_FLAG $PTHREAD_CFLAGS" ;;
+        esac
+
+fi # $ax_pthread_clang = yes
+
+
+
+# Various other checks:
+if test "x$ax_pthread_ok" = "xyes"; then
+        ax_pthread_save_CFLAGS="$CFLAGS"
+        ax_pthread_save_LIBS="$LIBS"
+        CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+        LIBS="$PTHREAD_LIBS $LIBS"
+
+        # Detect AIX lossage: JOINABLE attribute is called UNDETACHED.
+        AC_CACHE_CHECK([for joinable pthread attribute],
+            [ax_cv_PTHREAD_JOINABLE_ATTR],
+            [ax_cv_PTHREAD_JOINABLE_ATTR=unknown
+             for ax_pthread_attr in PTHREAD_CREATE_JOINABLE PTHREAD_CREATE_UNDETACHED; do
+                 AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <pthread.h>],
+                                                 [int attr = $ax_pthread_attr; return attr /* ; */])],
+                                [ax_cv_PTHREAD_JOINABLE_ATTR=$ax_pthread_attr; break],
+                                [])
+             done
+            ])
+        AS_IF([test "x$ax_cv_PTHREAD_JOINABLE_ATTR" != "xunknown" && \
+               test "x$ax_cv_PTHREAD_JOINABLE_ATTR" != "xPTHREAD_CREATE_JOINABLE" && \
+               test "x$ax_pthread_joinable_attr_defined" != "xyes"],
+              [AC_DEFINE_UNQUOTED([PTHREAD_CREATE_JOINABLE],
+                                  [$ax_cv_PTHREAD_JOINABLE_ATTR],
+                                  [Define to necessary symbol if this constant
+                                   uses a non-standard name on your system.])
+               ax_pthread_joinable_attr_defined=yes
+              ])
+
+        AC_CACHE_CHECK([whether more special flags are required for pthreads],
+            [ax_cv_PTHREAD_SPECIAL_FLAGS],
+            [ax_cv_PTHREAD_SPECIAL_FLAGS=no
+             case $host_os in
+             solaris*)
+             ax_cv_PTHREAD_SPECIAL_FLAGS="-D_POSIX_PTHREAD_SEMANTICS"
+             ;;
+             esac
+            ])
+        AS_IF([test "x$ax_cv_PTHREAD_SPECIAL_FLAGS" != "xno" && \
+               test "x$ax_pthread_special_flags_added" != "xyes"],
+              [PTHREAD_CFLAGS="$ax_cv_PTHREAD_SPECIAL_FLAGS $PTHREAD_CFLAGS"
+               ax_pthread_special_flags_added=yes])
+
+        AC_CACHE_CHECK([for PTHREAD_PRIO_INHERIT],
+            [ax_cv_PTHREAD_PRIO_INHERIT],
+            [AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <pthread.h>]],
+                                             [[int i = PTHREAD_PRIO_INHERIT;
+                                               return i;]])],
+                            [ax_cv_PTHREAD_PRIO_INHERIT=yes],
+                            [ax_cv_PTHREAD_PRIO_INHERIT=no])
+            ])
+        AS_IF([test "x$ax_cv_PTHREAD_PRIO_INHERIT" = "xyes" && \
+               test "x$ax_pthread_prio_inherit_defined" != "xyes"],
+              [AC_DEFINE([HAVE_PTHREAD_PRIO_INHERIT], [1], [Have PTHREAD_PRIO_INHERIT.])
+               ax_pthread_prio_inherit_defined=yes
+              ])
+
+        CFLAGS="$ax_pthread_save_CFLAGS"
+        LIBS="$ax_pthread_save_LIBS"
+
+        # More AIX lossage: compile with *_r variant
+        if test "x$GCC" != "xyes"; then
+            case $host_os in
+                aix*)
+                AS_CASE(["x/$CC"],
+                    [x*/c89|x*/c89_128|x*/c99|x*/c99_128|x*/cc|x*/cc128|x*/xlc|x*/xlc_v6|x*/xlc128|x*/xlc128_v6],
+                    [#handle absolute path differently from PATH based program lookup
+                     AS_CASE(["x$CC"],
+                         [x/*],
+                         [
+			   AS_IF([AS_EXECUTABLE_P([${CC}_r])],[PTHREAD_CC="${CC}_r"])
+			   AS_IF([test "x${CXX}" != "x"], [AS_IF([AS_EXECUTABLE_P([${CXX}_r])],[PTHREAD_CXX="${CXX}_r"])])
+			 ],
+                         [
+			   AC_CHECK_PROGS([PTHREAD_CC],[${CC}_r],[$CC])
+			   AS_IF([test "x${CXX}" != "x"], [AC_CHECK_PROGS([PTHREAD_CXX],[${CXX}_r],[$CXX])])
+			 ]
+                     )
+                    ])
+                ;;
+            esac
+        fi
+fi
+
+test -n "$PTHREAD_CC" || PTHREAD_CC="$CC"
+test -n "$PTHREAD_CXX" || PTHREAD_CXX="$CXX"
+
+AC_SUBST([PTHREAD_LIBS])
+AC_SUBST([PTHREAD_CFLAGS])
+AC_SUBST([PTHREAD_CC])
+AC_SUBST([PTHREAD_CXX])
+
+# Finally, execute ACTION-IF-FOUND/ACTION-IF-NOT-FOUND:
+if test "x$ax_pthread_ok" = "xyes"; then
+        ifelse([$1],,[AC_DEFINE([HAVE_PTHREAD],[1],[Define if you have POSIX threads libraries and header files.])],[$1])
+        :
+else
+        ax_pthread_ok=no
+        $2
+fi
+AC_LANG_POP
+])dnl AX_PTHREAD


### PR DESCRIPTION
Long-awaited successor to #107.

TODO:
- [x] Make sure we require a new enough (thread-safe) fribidi
- [x] Gate `CONFIG_PTHREAD` on `<stdatomic.h>` availability
- [x] Implement the pthread functions used for win32 (anybody wanna take this one? this only really uses some fairly basic functions)
- [x] Detect CPU count on Win32
- [x] Provide an API to set thread count

And of course, this'll need some extensive testing (I've put it through some basics under asan/tsan, but I'm sure other folks have other ideas; stuff with a lot of weird fonts is likely to be tricky).

Note that this PR can be merged piecemeal; any initial series of commits will work fine without the rest. In particular, we could merge the portion prior to `configure: detect pthreads` ahead of the last few commits that actually add pthread-specific code.