### PR TITLE
ass_parse: fix premature truncation on \t(\Xa)

### DIFF
--- a/libass/ass_parse.c
+++ b/libass/ass_parse.c
@@ -165,7 +165,7 @@ static void change_color(uint32_t *var, uint32_t new, double pwr)
 // like change_color, but for alpha component only
 inline void change_alpha(uint32_t *var, int32_t new, double pwr)
 {
-    *var = (*var & 0xFFFFFF00) | (uint8_t)calc_anim_int32(_a(new), _a(*var), pwr);
+    *var = (*var & 0xFFFFFF00) | (uint8_t)calc_anim_int32(new, _a(*var), pwr);
 }
 
 /**


### PR DESCRIPTION
This caused animations to out-of-range alpha values to be clipped to the uint8_t range _before_ performing the lerp, rather than only after. VSFilter only truncates after. Using e.g. `\1a0\t(\1a1FF)` should run through the entire 0-FF range _twice_.