### PR TITLE
ASS/SSA Format: Introduce LayoutRes{X,Y} script headers to allow easy multi-resolution releases

### DIFF
--- a/libass/ass.c
+++ b/libass/ass.c
@@ -543,6 +543,10 @@ void ass_process_force_style(ASS_Track *track)
             track->PlayResX = parse_int_header(token);
         else if (!ass_strcasecmp(*fs, "PlayResY"))
             track->PlayResY = parse_int_header(token);
+        else if (!ass_strcasecmp(*fs, "LayoutResX"))
+            track->LayoutResX = parse_int_header(token);
+        else if (!ass_strcasecmp(*fs, "LayoutResY"))
+            track->LayoutResY = parse_int_header(token);
         else if (!ass_strcasecmp(*fs, "Timer"))
             track->Timer = ass_atof(token);
         else if (!ass_strcasecmp(*fs, "WrapStyle"))
@@ -848,6 +852,12 @@ static int process_info_line(ASS_Track *track, char *str)
     } else if (!strncmp(str, "PlayResY:", 9)) {
         check_duplicate_info_line(track, SINFO_PLAYRESY, "PlayResY");
         track->PlayResY = parse_int_header(str + 9);
+    } else if (!strncmp(str, "LayoutResX:", 11)) {
+        check_duplicate_info_line(track, SINFO_LAYOUTRESX, "LayoutResX");
+        track->LayoutResX = parse_int_header(str + 11);
+    } else if (!strncmp(str, "LayoutResY:", 11)) {
+        check_duplicate_info_line(track, SINFO_LAYOUTRESY, "LayoutResY");
+        track->LayoutResY = parse_int_header(str + 11);
     } else if (!strncmp(str, "Timer:", 6)) {
         check_duplicate_info_line(track, SINFO_TIMER, "Timer");
         track->Timer = ass_atof(str + 6);

--- a/libass/ass.h
+++ b/libass/ass.h
@@ -24,7 +24,7 @@
 #include <stdarg.h>
 #include "ass_types.h"
 
-#define LIBASS_VERSION 0x01600010
+#define LIBASS_VERSION 0x01600020
 
 #ifdef __cplusplus
 extern "C" {
@@ -392,6 +392,7 @@ void ass_set_frame_size(ASS_Renderer *priv, int w, int h);
  * \brief Set the source image size in pixels.
  * This affects some ASS tags like e.g. 3D transforms and
  * is used to calculate the source aspect ratio and blur scale.
+ * If subtitles specify valid LayoutRes* headers, those will take precedence.
  * The source image size can be reset to default by setting w and h to 0.
  * The value set with this function can influence the pixel aspect ratio used
  * for rendering.
@@ -461,6 +462,11 @@ void ass_set_use_margins(ASS_Renderer *priv, int use);
  * that this default assumes the frame size after compensating for margins
  * corresponds to an isotropically scaled version of the video display size.
  * If the storage size has not been set, a pixel aspect ratio of 1 is assumed.
+ *
+ * If subtitles specify valid LayoutRes* headers, the API-configured
+ * pixel aspect value is discarded in favour of one calculated out of the
+ * headers and values set with ass_set_frame_size().
+ *
  * \param priv renderer handle
  * \param par pixel aspect ratio (1.0 means square pixels, 0 means default)
  */

--- a/libass/ass_priv.h
+++ b/libass/ass_priv.h
@@ -42,6 +42,8 @@ typedef enum {
     SINFO_COLOURMATRIX = 1 << 6,
     SINFO_KERNING      = 1 << 7,
     SINFO_SCRIPTTYPE   = 1 << 8,
+    SINFO_LAYOUTRESX   = 1 << 9,
+    SINFO_LAYOUTRESY   = 1 << 10,
     // for legacy detection
     GENBY_FFMPEG       = 1 << 14
     // max 32 enumerators

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -1002,11 +1002,14 @@ static ASS_Style *handle_selective_style_overrides(RenderContext *state,
 
 ASS_Vector ass_layout_res(ASS_Renderer *render_priv)
 {
+    ASS_Track *track = render_priv->track;
+    if (track->LayoutResX > 0 && track->LayoutResY > 0)
+        return (ASS_Vector) { track->LayoutResX, track->LayoutResY };
+
     ASS_Settings *settings = &render_priv->settings;
     if (settings->storage_width > 0 && settings->storage_height > 0)
         return (ASS_Vector) { settings->storage_width, settings->storage_height };
 
-    ASS_Track *track = render_priv->track;
     if (settings->par <= 0 || settings->par == 1 ||
             !render_priv->frame_content_width || !render_priv->frame_content_height)
         return (ASS_Vector) { track->PlayResX, track->PlayResY };
@@ -3109,9 +3112,10 @@ ass_start_frame(ASS_Renderer *render_priv, ASS_Track *track,
 
     // PAR correction
     double par = render_priv->settings.par;
-    if (par == 0.) {
-        if (render_priv->frame_content_width && render_priv->frame_content_height &&
-                render_priv->settings.storage_width && render_priv->settings.storage_height) {
+    bool lr_track = track->LayoutResX > 0 && track->LayoutResY > 0;
+    if (par == 0. || lr_track) {
+        if (render_priv->frame_content_width && render_priv->frame_content_height && (lr_track ||
+                (render_priv->settings.storage_width && render_priv->settings.storage_height))) {
             double dar = ((double) render_priv->frame_content_width) /
                          render_priv->frame_content_height;
             ASS_Vector layout_res = ass_layout_res(render_priv);

--- a/libass/ass_types.h
+++ b/libass/ass_types.h
@@ -283,6 +283,9 @@ typedef struct ass_track {
     ASS_Library *library;
     ASS_ParserPriv *parser_priv;
 
+    int LayoutResX;  // overrides values from ass_set_storage_size and
+    int LayoutResY;  // also takes precendence over ass_set_pixel_aspect
+
     // New fields can be added here in new ABI-compatible library releases.
 } ASS_Track;
 


### PR DESCRIPTION
@Cyberbeing, @pinterf, @clsid2:
We would like to propose a retroactive addition to the ASS/SSA format, but in order to not fracture ASS even more we will only move forward with this if this extension will also be accepted and implemented in (most) active VSFilters.
This retroactive addition should be able to provide tangible benefits, while avoiding undue issues.

Some background first:
Rendering of the ASS/SSA format depends on the **video’s** *storage* resolution for several effects. This means subtitle releases are bound to a specific video (storage) resolution and in general cannot be reused for e.g. later BD-source releases of a higher resolution or in case of DVD-sources, different encodes which did/didn't undo the anamorphic stretching. *(Simple, sparingly styled subs may happen to avoid this by not using the affected effects, but this isn't possible for more complex subs.)* Affected tags are `\be`, `\blur`, `\frx`, `\frz` and if `ScaledBorderAndShadow` isn't set to `yes` also all border and shadow tags.

Thus we propose adding two new headers `LayoutResX` and `LayoutResY`, which if both present and both set to legal (`> 0`) values will be used in all places instead of the storage dimensions of the video file.
This way, subtitle authors are able to create subs *once* and then reuse the very same file for future release with arbitrary video resolutions as long as the display aspect ratio matches the original *(and timing + colours didn't change, but we can't do much about that and they are easier to semi-automatically adjust than the scaling-affected tags)*.
If the headers are not or only partially present or set to illegal values, rendering continues to work exactly as it always did before.

It seems fairly unlikely any existing subs put non-functional `LayoutRes{X,Y}` headers into their `[Script Info]` section, so this change will not break existing subtitle files. By encouraging authors to set the layout resolution equal to the actual video storage resolution, the initial/main subtitle releases would also continue to work in older renderers, giving users some time to update their renderers instead of suddenly be confronted with bizarre rendering results.
If this extensions is accepted, the plan is to also get common Aegisub forks to implement support for it and automatically initialise the headers as the actual storage resolution (and possibly, for the beginning at least, nudge users to keep it in sync with the actual resolution as currently happens for `PlayRes{X,Y}`)

---

@Cyberbeing, @pinterf:
I wanted to draft up a patch implementing the headers for xy-VSFilter, but unfortunately I don't have access to any Windows dev setup and no familiarity with VS, so I can only offer this completely untested patch:
see [here](https://github.com/TheOneric/xy-VSFilter/commits/rc5_layout-res), or [xy-VSFilter_layout-res_patches.tar.gz](https://github.com/libass/libass/files/9440080/xy-VSFilter_layout-res_patches.tar.gz).
The patch is on top of Cyberbeing’s `xy_sub_filter_rc5` branch, specifically https://github.com/Cyberbeing/xy-VSFilter/commit/fc01a8da5ea6af9091aaab839bc62dc94a90094e though it likely applies to pinterf/xy-VSFilter as well after the incompatible scaling changes are reverted (see: https://github.com/pinterf/xy-VSFilter/pull/34).
I tried getting it to build in GitHub Actions, but this didn't work out either with the build failing to locate yasm no matter where I put `yasm.exe`. I'm willing to test and work on this patch, but would require assistance in getting a working build setup. Certainly welcome and ideal though, would be someone more familiar with both Microsoft VS and xy-VSFilter taking over the patches.

@clsid2:
For MPC-HC’s Internal Subtitle Renderer the situation is actually a bit different from original guliverkli(2)-VSFilter, xy-VSFilter and libass. MPC-HC’s ISR is already incompatible with many existing files and other renderers for a long time *(in our experience, this resulted in barely any complex subs targeting ISR)*. Among others, MPC-HC's ISR completely stopped considering the original video resolution during rendering. While this deviation has been around long enough for ISR to probably better keep it when no `LayoutRes{X,Y}` was set, it would be nice if the headers could be taken into account when they are present to reduce the incompatibilities to other softsub renderers.

---

(Replaces #597 to get a new, backlog-free, discussion now that more people are involved and the previous points re. `LayoutRes{X,Y}` have all been decided.)