### PR TITLE
PlayResX scaling and Effect’s delay precison and (non-)scaling

### DIFF
--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -672,9 +672,9 @@ static void blend_vector_clip(ASS_Renderer *render_priv, ASS_Image *head)
 
     double m[3][3] = {{0}};
     int32_t scale_base = lshiftwrapi(1, render_priv->state.clip_drawing_scale - 1);
-    double w = scale_base > 0 ? (render_priv->font_scale / scale_base) : 0;
-    m[0][0] = render_priv->font_scale_x * w;
-    m[1][1] = w;
+    double w = scale_base > 0 ? (1.0 / scale_base) : 0;
+    m[0][0] = render_priv->screen_scale_x * w;
+    m[1][1] = render_priv->screen_scale_y * w;
     m[2][2] = 1;
 
     m[0][2] = int_to_d6(render_priv->settings.left_margin);
@@ -999,21 +999,31 @@ static void init_font_scale(ASS_Renderer *render_priv)
 {
     ASS_Settings *settings_priv = &render_priv->settings;
 
+    double font_scr_w = render_priv->orig_width;
     double font_scr_h = render_priv->orig_height;
-    if (!render_priv->state.explicit && render_priv->settings.use_margins)
+    if (!render_priv->state.explicit && render_priv->settings.use_margins) {
+        font_scr_w = render_priv->fit_width;
         font_scr_h = render_priv->fit_height;
+    }
 
-    render_priv->font_scale = font_scr_h / render_priv->track->PlayResY;
-    render_priv->blur_scale = font_scr_h / ass_layout_res(render_priv).y;
-    if (render_priv->track->ScaledBorderAndShadow)
-        render_priv->border_scale =
-            font_scr_h / render_priv->track->PlayResY;
-    else
-        render_priv->border_scale = render_priv->blur_scale;
+    render_priv->screen_scale_x = font_scr_w / render_priv->track->PlayResX;
+    render_priv->screen_scale_y = font_scr_h / render_priv->track->PlayResY;
+
+    ASS_Vector layout_res = ass_layout_res(render_priv);
+    render_priv->blur_scale = font_scr_h / layout_res.y;
+    if (render_priv->track->ScaledBorderAndShadow) {
+        render_priv->border_scale_x = render_priv->screen_scale_x;
+        render_priv->border_scale_y = render_priv->screen_scale_y;
+    } else {
+        render_priv->border_scale_x = font_scr_w / layout_res.x;
+        render_priv->border_scale_y = render_priv->blur_scale;
+    }
 
     if (render_priv->state.apply_font_scale) {
-        render_priv->font_scale *= settings_priv->font_size_coeff;
-        render_priv->border_scale *= settings_priv->font_size_coeff;
+        render_priv->screen_scale_x *= settings_priv->font_size_coeff;
+        render_priv->screen_scale_y *= settings_priv->font_size_coeff;
+        render_priv->border_scale_x *= settings_priv->font_size_coeff;
+        render_priv->border_scale_y *= settings_priv->font_size_coeff;
         render_priv->blur_scale *= settings_priv->font_size_coeff;
     }
 }
@@ -1137,9 +1147,9 @@ get_outline_glyph(ASS_Renderer *priv, GlyphInfo *info)
         }
 
         int32_t scale_base = lshiftwrapi(1, info->drawing_scale - 1);
-        double w = scale_base > 0 ? (priv->font_scale / scale_base) : 0;
-        scale.x = info->scale_x * w;
-        scale.y = info->scale_y * w;
+        double w = scale_base > 0 ? (1.0 / scale_base) : 0;
+        scale.x = info->scale_x * w * priv->screen_scale_x / priv->font_scale_x;
+        scale.y = info->scale_y * w * priv->screen_scale_y;
         desc = 64 * info->drawing_pbo;
         asc = val->asc - desc;
 
@@ -1375,8 +1385,11 @@ get_bitmap_glyph(ASS_Renderer *render_priv, GlyphInfo *info,
 
         ol_key.type = OUTLINE_BOX;
 
-        double w = 64 * render_priv->border_scale;
-        ASS_DVector bord = { info->border_x * w, info->border_y * w };
+        ASS_DVector bord = {
+            64 * info->border_x * render_priv->border_scale_x /
+                render_priv->font_scale_x,
+            64 * info->border_y * render_priv->border_scale_y,
+        };
         double width = info->hspacing_scaled + info->advance.x;
         double height = info->asc + info->desc;
 
@@ -1413,9 +1426,11 @@ get_bitmap_glyph(ASS_Renderer *render_priv, GlyphInfo *info,
         BorderHashKey *k = &ol_key.u.border;
         k->outline = info->outline;
 
-        double w = 64 * render_priv->border_scale;
-        double bord_x = w * info->border_x / tr->scale.x;
-        double bord_y = w * info->border_y / tr->scale.y;
+        double bord_x =
+            64 * render_priv->border_scale_x * info->border_x / tr->scale.x /
+                render_priv->font_scale_x;
+        double bord_y =
+            64 * render_priv->border_scale_y * info->border_y / tr->scale.y;
 
         const ASS_Rect *bbox = &info->outline->cbox;
         // Estimate bounding box half size after stroking
@@ -1429,7 +1444,7 @@ get_bitmap_glyph(ASS_Renderer *render_priv, GlyphInfo *info,
         double mzx = fabs(m[2][0]), mzy = fabs(m[2][1]);
 
         double z0 = m[2][2] - mzx * dx - mzy * dy;
-        w = 1 / FFMAX(z0, m[2][2] / MAX_PERSP_SCALE);
+        double w = 1 / FFMAX(z0, m[2][2] / MAX_PERSP_SCALE);
 
         // Notation from quantize_transform().
         // Note that goal here is to estimate acceptable error for stroking, i. e. D(x) and D(y).
@@ -1527,12 +1542,12 @@ static void measure_text_on_eol(ASS_Renderer *render_priv, double scale, int cur
     render_priv->text_info.height += scale * max_asc + scale * max_desc;
     // For *VSFilter compatibility do biased rounding on max_border*
     // https://github.com/Cyberbeing/xy-VSFilter/blob/xy_sub_filter_rc4@%7B2020-05-17%7D/src/subtitles/RTS.cpp#L1465
-    render_priv->text_info.border_bottom = (int) (render_priv->border_scale * max_border_y + 0.5);
+    render_priv->text_info.border_bottom = (int) (render_priv->border_scale_y * max_border_y + 0.5);
     if (cur_line == 0)
         render_priv->text_info.border_top = render_priv->text_info.border_bottom;
     // VSFilter takes max \bordx into account for collision, even if far from edge
     render_priv->text_info.border_x = FFMAX(render_priv->text_info.border_x,
-            (int) (render_priv->border_scale * max_border_x + 0.5));
+            (int) (render_priv->border_scale_x * max_border_x + 0.5));
 }
 
 
@@ -2098,8 +2113,9 @@ static bool parse_events(ASS_Renderer *render_priv, ASS_Event *event)
         info->effect_type = render_priv->state.effect_type;
         info->effect_timing = render_priv->state.effect_timing;
         info->effect_skip_timing = render_priv->state.effect_skip_timing;
+        // VSFilter compatibility: font glyphs use PlayResY scaling in both dimensions
         info->font_size =
-            fabs(render_priv->state.font_size * render_priv->font_scale);
+            fabs(render_priv->state.font_size * render_priv->screen_scale_y);
         info->be = render_priv->state.be;
         info->blur = render_priv->state.blur;
         info->shadow_x = render_priv->state.shadow_x;
@@ -2127,7 +2143,8 @@ static bool parse_events(ASS_Renderer *render_priv, ASS_Event *event)
 
         if (!drawing_text.str) {
             info->hspacing_scaled = double_to_d6(info->hspacing *
-                    render_priv->font_scale * info->scale_x);
+                    render_priv->screen_scale_x / render_priv->font_scale_x *
+                    info->scale_x);
             fix_glyph_scaling(render_priv, info);
         }
 
@@ -2349,10 +2366,10 @@ static void calculate_rotation_params(ASS_Renderer *render_priv, ASS_DRect *bbox
         GlyphInfo *info = text_info->glyphs + i;
         while (info) {
             info->shift.x = info->pos.x + double_to_d6(device_x - center.x +
-                    info->shadow_x * render_priv->border_scale /
+                    info->shadow_x * render_priv->border_scale_x /
                     render_priv->font_scale_x);
             info->shift.y = info->pos.y + double_to_d6(device_y - center.y +
-                    info->shadow_y * render_priv->border_scale);
+                    info->shadow_y * render_priv->border_scale_y);
             info = info->next;
         }
     }
@@ -2476,8 +2493,8 @@ static void render_and_combine_glyphs(ASS_Renderer *render_priv,
                 double blur_scale = render_priv->blur_scale * (2 / sqrt(log(256)));
                 filter->blur = quantize_blur(info->blur * blur_scale, &shadow_mask);
                 if (flags & FILTER_NONZERO_SHADOW) {
-                    int32_t x = double_to_d6(info->shadow_x * render_priv->border_scale);
-                    int32_t y = double_to_d6(info->shadow_y * render_priv->border_scale);
+                    int32_t x = double_to_d6(info->shadow_x * render_priv->border_scale_x);
+                    int32_t y = double_to_d6(info->shadow_y * render_priv->border_scale_y);
                     filter->shadow.x = (x + (shadow_mask >> 1)) & ~shadow_mask;
                     filter->shadow.y = (y + (shadow_mask >> 1)) & ~shadow_mask;
                 } else
@@ -2695,9 +2712,9 @@ size_t ass_composite_construct(void *key, void *value, void *priv)
 static void add_background(ASS_Renderer *render_priv, EventImages *event_images)
 {
     int size_x = render_priv->state.shadow_x > 0 ?
-        lround(render_priv->state.shadow_x * render_priv->border_scale) : 0;
+        lround(render_priv->state.shadow_x * render_priv->border_scale_x) : 0;
     int size_y = render_priv->state.shadow_y > 0 ?
-        lround(render_priv->state.shadow_y * render_priv->border_scale) : 0;
+        lround(render_priv->state.shadow_y * render_priv->border_scale_y) : 0;
     int left    = event_images->left - size_x;
     int top     = event_images->top  - size_y;
     int right   = event_images->left + event_images->width  + size_x;

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -978,7 +978,21 @@ ASS_Vector ass_layout_res(ASS_Renderer *render_priv)
         return (ASS_Vector) { settings->storage_width, settings->storage_height };
 
     ASS_Track *track = render_priv->track;
-    return (ASS_Vector) { track->PlayResX, track->PlayResY };
+    if (settings->par <= 0 || settings->par == 1 ||
+            !render_priv->orig_width || !render_priv->orig_height)
+        return (ASS_Vector) { track->PlayResX, track->PlayResY };
+    if (settings->par > 1)
+        return (ASS_Vector) {
+            lround(track->PlayResY * render_priv->orig_width / render_priv->orig_height
+                    / settings->par),
+            track->PlayResY
+        };
+    else
+        return (ASS_Vector) {
+            track->PlayResX,
+            lround(track->PlayResX * render_priv->orig_height / render_priv->orig_width
+                    * settings->par)
+        };
 }
 
 static void init_font_scale(ASS_Renderer *render_priv)

--- a/libass/ass_render.h
+++ b/libass/ass_render.h
@@ -308,16 +308,16 @@ struct ass_renderer {
     int eimg_size;              // allocated buffer size
 
     // frame-global data
-    int width, height;          // screen dimensions
-    int orig_height;            // frame height ( = screen height - margins )
-    int orig_width;             // frame width ( = screen width - margins )
-    double fit_height;          // frame height without zoom & pan (fit to screen & letterboxed)
-    double fit_width;           // frame width without zoom & pan (fit to screen & letterboxed)
+    int width, height;          // screen dimensions (the whole frame from ass_set_frame_size)
+    int frame_content_height;   // content frame height ( = screen height - API margins )
+    int frame_content_width;    // content frame width ( = screen width - API margins )
+    double fit_height;          // content frame height without zoom & pan (fit to screen & letterboxed)
+    double fit_width;           // content frame width without zoom & pan (fit to screen & letterboxed)
     ASS_Track *track;
     long long time;             // frame's timestamp, ms
     double screen_scale_x;
     double screen_scale_y;
-    double font_scale_x;        // x scale applied to all glyphs to preserve text aspect ratio
+    double par_scale_x;         // x scale applied to e.g. glyphs to preserve text aspect ratio
     double border_scale_x;
     double border_scale_y;
     double blur_scale;

--- a/libass/ass_render.h
+++ b/libass/ass_render.h
@@ -315,9 +315,11 @@ struct ass_renderer {
     double fit_width;           // frame width without zoom & pan (fit to screen & letterboxed)
     ASS_Track *track;
     long long time;             // frame's timestamp, ms
-    double font_scale;
+    double screen_scale_x;
+    double screen_scale_y;
     double font_scale_x;        // x scale applied to all glyphs to preserve text aspect ratio
-    double border_scale;
+    double border_scale_x;
+    double border_scale_y;
     double blur_scale;
 
     RenderContext state;

--- a/libass/ass_render_api.c
+++ b/libass/ass_render_api.c
@@ -33,20 +33,20 @@ static void ass_reconfigure(ASS_Renderer *priv)
 
     priv->width = settings->frame_width;
     priv->height = settings->frame_height;
-    priv->orig_width = settings->frame_width - settings->left_margin -
+    priv->frame_content_width = settings->frame_width - settings->left_margin -
         settings->right_margin;
-    priv->orig_height = settings->frame_height - settings->top_margin -
+    priv->frame_content_height = settings->frame_height - settings->top_margin -
         settings->bottom_margin;
     priv->fit_width =
-        (long long) priv->orig_width * priv->height >=
-        (long long) priv->orig_height * priv->width ?
+        (long long) priv->frame_content_width * priv->height >=
+        (long long) priv->frame_content_height * priv->width ?
             priv->width :
-            (double) priv->orig_width * priv->height / priv->orig_height;
+            (double) priv->frame_content_width * priv->height / priv->frame_content_height;
     priv->fit_height =
-        (long long) priv->orig_width * priv->height <=
-        (long long) priv->orig_height * priv->width ?
+        (long long) priv->frame_content_width * priv->height <=
+        (long long) priv->frame_content_height * priv->width ?
             priv->height :
-            (double) priv->orig_height * priv->width / priv->orig_width;
+            (double) priv->frame_content_height * priv->width / priv->frame_content_width;
 }
 
 void ass_set_frame_size(ASS_Renderer *priv, int w, int h)

--- a/libass/ass_render_api.c
+++ b/libass/ass_render_api.c
@@ -51,6 +51,8 @@ static void ass_reconfigure(ASS_Renderer *priv)
 
 void ass_set_frame_size(ASS_Renderer *priv, int w, int h)
 {
+    if (w < 0 || h < 0)
+        w = h = 0;
     if (priv->settings.frame_width != w || priv->settings.frame_height != h) {
         priv->settings.frame_width = w;
         priv->settings.frame_height = h;
@@ -60,6 +62,8 @@ void ass_set_frame_size(ASS_Renderer *priv, int w, int h)
 
 void ass_set_storage_size(ASS_Renderer *priv, int w, int h)
 {
+    if (w < 0 || h < 0)
+        w = h = 0;
     if (priv->settings.storage_width != w ||
         priv->settings.storage_height != h) {
         priv->settings.storage_width = w;
@@ -101,6 +105,7 @@ void ass_set_aspect_ratio(ASS_Renderer *priv, double dar, double sar)
 
 void ass_set_pixel_aspect(ASS_Renderer *priv, double par)
 {
+    if (par < 0) par = 0;
     if (priv->settings.par != par) {
         priv->settings.par = par;
         ass_reconfigure(priv);


### PR DESCRIPTION
First commit is just a rebased from astiob’s [draft PlayResX fix](https://github.com/astiob/libass/commit/a550fc5115bd36cb9d0510976d7357b609410645). Afaict this is functionality-wise correct and was only missing the Effect `delay` unscaling. @astiob: Was this the missing thing you mentioned or is there something I overlooked?

Rebasing was mostly just moving things around, but also dealing with the newly emulated „shadow origin“ quirks, and dropping one change as the affected code was removed when the SBAS=no defaults were adjusted before 0.15.0.

One possible issue: anonymous unions used in this patch to alias `font_scale` and `screen_scale_y` are not part of ISO C99 our current baseline *(with some not documented machine assumptions)*. However, those are part of ISO C11 and prior to that were an extension in GNU and some other compilers. So far all compilers I checked accepted it without complaints with default build options:
 - GCC supports it since [at least version 3.1.1](https://gcc.gnu.org/onlinedocs/gcc-3.1.1/gcc/Unnamed-Fields.html#Unnamed-Fields) *(2002-07)*
 - since GCC supported them before clang even existed, it’s likely every release of clang supports them though I haven't tested that
 - tcc *(tested: 0.9.27)*
 - chibicc *(tested: git main)*
 - cproc *(tested: master)*
 - and apparently MSVC [supports them as well](https://docs.microsoft.com/en-US/cpp/cpp/anonymous-class-types?view=msvc-170)

So perhaps we can just rely on them being supported and use it anyway.

---

Some artifical sample files and xy-VSF renderings: [645_samples.tar.gz](https://github.com/libass/libass/files/9499516/645_samples.tar.gz)
