### PR TITLE
Support Core Text on Mac OS X 10.5 and prerelease 10.6

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -146,7 +146,7 @@ AS_IF([test "x$enable_coretext" != xno], [
     AC_COMPILE_IFELSE([
         AC_LANG_PROGRAM( dnl# First test for legacy include
             [[#include <ApplicationServices/ApplicationServices.h>]],
-            [[CTFontDescriptorCopyAttribute(NULL, kCTFontURLAttribute);]]
+            [[CTFontDescriptorCopyAttribute(NULL, kCTFontNameAttribute);]]
         )
     ], [
         pkg_libs="$pkg_libs -framework ApplicationServices -framework CoreFoundation"
@@ -158,7 +158,7 @@ AS_IF([test "x$enable_coretext" != xno], [
         AC_COMPILE_IFELSE([
             AC_LANG_PROGRAM( dnl# Otherwise check newer include style
                 [[#include <CoreText/CoreText.h>]],
-                [[CTFontDescriptorCopyAttribute(NULL, kCTFontURLAttribute);]]
+                [[CTFontDescriptorCopyAttribute(NULL, kCTFontNameAttribute);]]
             )
         ], [
             pkg_libs="$pkg_libs -framework CoreText -framework CoreFoundation"

--- a/libass/ass_coretext.c
+++ b/libass/ass_coretext.c
@@ -61,29 +61,6 @@ static void destroy_font(void *priv)
     CFRelease(fontd);
 }
 
-static bool is_postscript_font_format(CFNumberRef cfformat)
-{
-    bool ret = false;
-    int format;
-    if (CFNumberGetValue(cfformat, kCFNumberIntType, &format)) {
-        ret = format == kCTFontFormatOpenTypePostScript ||
-              format == kCTFontFormatPostScript;
-    }
-    return ret;
-}
-
-static bool check_postscript(void *priv)
-{
-    CTFontDescriptorRef fontd = priv;
-    CFNumberRef cfformat =
-        CTFontDescriptorCopyAttribute(fontd, kCTFontFormatAttribute);
-    if (!cfformat)
-        return false;
-    bool ret = is_postscript_font_format(cfformat);
-    CFRelease(cfformat);
-    return ret;
-}
-
 static bool check_glyph(void *priv, uint32_t code)
 {
     if (code == 0)
@@ -295,7 +272,6 @@ static void get_substitutions(void *priv, const char *name,
 }
 
 static ASS_FontProviderFuncs coretext_callbacks = {
-    .check_postscript   = check_postscript,
     .check_glyph        = check_glyph,
     .destroy_font       = destroy_font,
     .match_fonts        = match_fonts,

--- a/libass/ass_coretext.c
+++ b/libass/ass_coretext.c
@@ -57,8 +57,8 @@ static char *cfstr2buf(CFStringRef string)
 
 static void destroy_font(void *priv)
 {
-    CTFontDescriptorRef fontd = priv;
-    CFRelease(fontd);
+    CFCharacterSetRef set = priv;
+    SAFE_CFRelease(set);
 }
 
 static bool check_glyph(void *priv, uint32_t code)
@@ -66,16 +66,12 @@ static bool check_glyph(void *priv, uint32_t code)
     if (code == 0)
         return true;
 
-    CTFontDescriptorRef fontd = priv;
-    CFCharacterSetRef set =
-        CTFontDescriptorCopyAttribute(fontd, kCTFontCharacterSetAttribute);
+    CFCharacterSetRef set = priv;
 
     if (!set)
         return true;
 
-    bool result = CFCharacterSetIsLongCharacterMember(set, code);
-    CFRelease(set);
-    return result;
+    return CFCharacterSetIsLongCharacterMember(set, code);
 }
 
 static char *get_font_file(CTFontDescriptorRef fontd)
@@ -139,8 +135,9 @@ static void process_descriptors(ASS_FontProvider *provider, CFArrayRef fontsd)
 
         char *path = NULL;
         if (get_font_info_ct(fontd, &path, &meta)) {
-            CFRetain(fontd);
-            ass_font_provider_add_font(provider, &meta, path, index, (void*)fontd);
+            CFCharacterSetRef set =
+                CTFontDescriptorCopyAttribute(fontd, kCTFontCharacterSetAttribute);
+            ass_font_provider_add_font(provider, &meta, path, index, (void*)set);
         }
 
         free(meta.postscript_name);

--- a/libass/ass_coretext.c
+++ b/libass/ass_coretext.c
@@ -29,6 +29,18 @@
 
 #include "ass_coretext.h"
 
+#ifndef __has_builtin
+#define __has_builtin 0
+#endif
+
+#if __has_builtin(__builtin_available)
+#define CHECK_AVAILABLE(sym, ...) __builtin_available(__VA_ARGS__)
+#else
+// Cast to suppress "comparison never succeeds" warnings in some compilers
+// when the build target is new enough that sym isn't a weak symbol
+#define CHECK_AVAILABLE(sym, ...) (!!(intptr_t) &sym)
+#endif
+
 #define SAFE_CFRelease(x) do { if (x) CFRelease(x); } while (0)
 
 static const ASS_FontMapping font_substitutions[] = {

--- a/libass/ass_fontselect.h
+++ b/libass/ass_fontselect.h
@@ -158,7 +158,7 @@ typedef char   *(*GetFallbackFunc)(void *priv,
 
 typedef struct font_provider_funcs {
     GetDataFunc         get_data;               /* optional/mandatory */
-    CheckPostscriptFunc check_postscript;       /* mandatory */
+    CheckPostscriptFunc check_postscript;       /* optional */
     CheckGlyphFunc      check_glyph;            /* mandatory */
     DestroyFontFunc     destroy_font;           /* optional */
     DestroyProviderFunc destroy_provider;       /* optional */
@@ -211,6 +211,12 @@ struct ass_font_provider_meta_data {
                         // See FONT_WEIGHT_*
     int width;          // Font weight in percent, normally 100
                         // See FONT_WIDTH_*
+
+    /**
+     * Whether the font contains PostScript outlines.
+     * Unused if the font provider has a check_postscript function.
+     */
+    bool is_postscript;
 };
 
 struct ass_font_stream {


### PR DESCRIPTION
This should fix #595 and further make the Core Text system font provider usable on Mac OS X 10.5 “Leopard”—because why not?

@TheOneric Do we have any tests on PostScript-name vs full-name font selection? Looks like not? I don’t think it’s in any way urgent or a blocker for this, but at some point we probably should add some. And it would be great to have some tests targeting specifically system font providers, although I’m not quite sure how we could do that.