### PR TITLE
Checkasm v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ Makefile.in
 /compare/compare
 /profile/profile
 /fuzz/fuzz
+/checkasm/checkasm
 
 # pkgconfig
 /libass.pc
@@ -38,3 +39,4 @@ Makefile.in
 /ltmain.sh
 /missing
 /m4
+/test-driver

--- a/Makefile.am
+++ b/Makefile.am
@@ -10,8 +10,14 @@ EXTRA_DIST = libass.pc.in Changelog MAINTAINERS ltnasm.sh
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = libass.pc
 
+nasm_verbose = $(nasm_verbose_$(V))
+nasm_verbose_ = $(nasm_verbose_$(AM_DEFAULT_VERBOSITY))
+nasm_verbose_0 = @echo "  NASM    " $@;
+
 lib_LTLIBRARIES =
 noinst_PROGRAMS =
+check_PROGRAMS =
+TESTS =
 
 include libass/Makefile_library.am
 include Makefile_util.am

--- a/Makefile_util.am
+++ b/Makefile_util.am
@@ -50,6 +50,7 @@ endif
 	$(nasm_verbose)$(AS) $(ASFLAGS) -I$(top_srcdir)/libass/ -o $@ $<
 
 checkasm_checkasm_SOURCES = \
+    checkasm/rasterizer.c \
     checkasm/blend_bitmaps.c \
     checkasm/be_blur.c \
     checkasm/blur.c \

--- a/Makefile_util.am
+++ b/Makefile_util.am
@@ -52,6 +52,7 @@ endif
 checkasm_checkasm_SOURCES = \
     checkasm/blend_bitmaps.c \
     checkasm/be_blur.c \
+    checkasm/blur.c \
     checkasm/checkasm.h checkasm/checkasm.c
 
 checkasm_checkasm_CPPFLAGS = -I$(top_srcdir)/libass

--- a/Makefile_util.am
+++ b/Makefile_util.am
@@ -38,3 +38,35 @@ fuzz/fuzz_ossfuzz: fuzz/fuzz-fuzz.o libass/libass.la $(srcdir)/libass.pc
 		$$(pkg-config --static --libs $(srcdir)/libass.pc | sed -e 's/-lm //g' -e 's/-lass //g') \
 		-Wl,-Bdynamic
 endif
+
+
+if ENABLE_CHECKASM
+check_PROGRAMS += checkasm/checkasm
+TESTS += checkasm/checkasm$(EXEEXT)
+bench: run-checkasm-bench
+endif
+
+.asm.o:
+	$(nasm_verbose)$(AS) $(ASFLAGS) -I$(top_srcdir)/libass/ -o $@ $<
+
+checkasm_checkasm_SOURCES = \
+    checkasm/blend_bitmaps.c \
+    checkasm/be_blur.c \
+    checkasm/checkasm.h checkasm/checkasm.c
+
+checkasm_checkasm_CPPFLAGS = -I$(top_srcdir)/libass
+checkasm_checkasm_LDADD = libass/libass.la
+checkasm_checkasm_LDFLAGS = $(AM_LDFLAGS) -static
+
+if X86
+checkasm_checkasm_SOURCES += checkasm/x86/checkasm.asm
+endif
+if AARCH64
+checkasm_checkasm_SOURCES += checkasm/arm/checkasm_64.S
+endif
+
+run-checkasm: checkasm/checkasm$(EXEEXT)
+	checkasm/checkasm$(EXEEXT)
+
+run-checkasm-bench: checkasm/checkasm$(EXEEXT)
+	checkasm/checkasm$(EXEEXT) --bench

--- a/checkasm/arm/checkasm_64.S
+++ b/checkasm/arm/checkasm_64.S
@@ -1,0 +1,211 @@
+/******************************************************************************
+ * Copyright © 2018, VideoLAN and dav1d authors
+ * Copyright © 2015 Martin Storsjo
+ * Copyright © 2015 Janne Grunau
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *****************************************************************************/
+
+#define PRIVATE_PREFIX checkasm_
+
+#include "src/arm/asm.S"
+#include "src/arm/64/util.S"
+
+const register_init, align=4
+        .quad 0x21f86d66c8ca00ce
+        .quad 0x75b6ba21077c48ad
+        .quad 0xed56bb2dcb3c7736
+        .quad 0x8bda43d3fd1a7e06
+        .quad 0xb64a9c9e5d318408
+        .quad 0xdf9a54b303f1d3a3
+        .quad 0x4a75479abd64e097
+        .quad 0x249214109d5d1c88
+        .quad 0x1a1b2550a612b48c
+        .quad 0x79445c159ce79064
+        .quad 0x2eed899d5a28ddcd
+        .quad 0x86b2536fcd8cf636
+        .quad 0xb0856806085e7943
+        .quad 0x3f2bf84fc0fcca4e
+        .quad 0xacbd382dcf5b8de2
+        .quad 0xd229e1f5b281303f
+        .quad 0x71aeaff20b095fd9
+        .quad 0xab63e2e11fa38ed9
+endconst
+
+
+const error_message_register
+        .asciz "failed to preserve register"
+error_message_stack:
+        .asciz "stack clobbered"
+endconst
+
+
+// max number of args used by any asm function.
+#define MAX_ARGS 15
+
+#define CLOBBER_STACK ((8*MAX_ARGS + 15) & ~15)
+
+function stack_clobber, export=1
+        mov             x3,  sp
+        mov             x2,  #CLOBBER_STACK
+1:
+        stp             x0,  x1,  [sp, #-16]!
+        subs            x2,  x2,  #16
+        b.gt            1b
+        mov             sp,  x3
+        ret
+endfunc
+
+// + 16 for stack canary reference
+#define ARG_STACK ((8*(MAX_ARGS - 8) + 15) & ~15 + 16)
+
+function checked_call, export=1
+        stp             x29, x30, [sp, #-16]!
+        mov             x29, sp
+        stp             x19, x20, [sp, #-16]!
+        stp             x21, x22, [sp, #-16]!
+        stp             x23, x24, [sp, #-16]!
+        stp             x25, x26, [sp, #-16]!
+        stp             x27, x28, [sp, #-16]!
+        stp             d8,  d9,  [sp, #-16]!
+        stp             d10, d11, [sp, #-16]!
+        stp             d12, d13, [sp, #-16]!
+        stp             d14, d15, [sp, #-16]!
+
+        movrel          x9, register_init
+        ldp             d8,  d9,  [x9], #16
+        ldp             d10, d11, [x9], #16
+        ldp             d12, d13, [x9], #16
+        ldp             d14, d15, [x9], #16
+        ldp             x19, x20, [x9], #16
+        ldp             x21, x22, [x9], #16
+        ldp             x23, x24, [x9], #16
+        ldp             x25, x26, [x9], #16
+        ldp             x27, x28, [x9], #16
+
+        sub             sp,  sp,  #ARG_STACK
+.equ pos, 0
+.rept MAX_ARGS-8
+        // Skip the first 8 args, that are loaded into registers
+        ldr             x9, [x29, #16 + 8*8 + pos]
+        str             x9, [sp, #pos]
+.equ pos, pos + 8
+.endr
+
+        // Fill x8-x17 with garbage. This doesn't have to be preserved,
+        // but avoids relying on them having any particular value.
+        movrel          x9, register_init
+        ldp             x10, x11, [x9], #32
+        ldp             x12, x13, [x9], #32
+        ldp             x14, x15, [x9], #32
+        ldp             x16, x17, [x9], #32
+        ldp             x8,  x9,  [x9]
+
+        // For stack overflows, the callee is free to overwrite the parameters
+        // that were passed on the stack (if any), so we can only check after
+        // that point. First figure out how many parameters the function
+        // really took on the stack:
+        ldr             w2,  [x29, #16 + 8*8 + (MAX_ARGS-8)*8]
+        // Load the first non-parameter value from the stack, that should be
+        // left untouched by the function. Store a copy of it inverted, so that
+        // e.g. overwriting everything with zero would be noticed.
+        ldr             x2,  [sp, x2, lsl #3]
+        mvn             x2,  x2
+        str             x2,  [sp, #ARG_STACK-8]
+
+        // Load the in-register arguments
+        mov             x12, x0
+        ldp             x0,  x1,  [x29, #16]
+        ldp             x2,  x3,  [x29, #32]
+        ldp             x4,  x5,  [x29, #48]
+        ldp             x6,  x7,  [x29, #64]
+        // Call the target function
+        blr             x12
+
+        // Load the number of stack parameters, stack canary and its reference
+        ldr             w2,  [x29, #16 + 8*8 + (MAX_ARGS-8)*8]
+        ldr             x2,  [sp, x2, lsl #3]
+        ldr             x3,  [sp, #ARG_STACK-8]
+
+        add             sp,  sp,  #ARG_STACK
+        stp             x0,  x1,  [sp, #-16]!
+
+        mvn             x3,  x3
+        cmp             x2,  x3
+        b.ne            2f
+
+        movrel          x9, register_init
+        movi            v3.8h,  #0
+
+.macro check_reg_neon reg1, reg2
+        ldr             q1,  [x9], #16
+        uzp1            v2.2d,  v\reg1\().2d, v\reg2\().2d
+        eor             v1.16b, v1.16b, v2.16b
+        orr             v3.16b, v3.16b, v1.16b
+.endm
+        check_reg_neon  8,  9
+        check_reg_neon  10, 11
+        check_reg_neon  12, 13
+        check_reg_neon  14, 15
+        uqxtn           v3.8b,  v3.8h
+        umov            x3,  v3.d[0]
+
+.macro check_reg reg1, reg2
+        ldp             x0,  x1,  [x9], #16
+        eor             x0,  x0,  \reg1
+        eor             x1,  x1,  \reg2
+        orr             x3,  x3,  x0
+        orr             x3,  x3,  x1
+.endm
+        check_reg       x19, x20
+        check_reg       x21, x22
+        check_reg       x23, x24
+        check_reg       x25, x26
+        check_reg       x27, x28
+
+        cbz             x3,  0f
+
+        movrel          x0, error_message_register
+        b               1f
+2:
+        movrel          x0, error_message_stack
+1:
+#ifdef PREFIX
+        bl              _checkasm_fail_func
+#else
+        bl              checkasm_fail_func
+#endif
+0:
+        ldp             x0,  x1,  [sp], #16
+        ldp             d14, d15, [sp], #16
+        ldp             d12, d13, [sp], #16
+        ldp             d10, d11, [sp], #16
+        ldp             d8,  d9,  [sp], #16
+        ldp             x27, x28, [sp], #16
+        ldp             x25, x26, [sp], #16
+        ldp             x23, x24, [sp], #16
+        ldp             x21, x22, [sp], #16
+        ldp             x19, x20, [sp], #16
+        ldp             x29, x30, [sp], #16
+        ret
+endfunc

--- a/checkasm/arm/checkasm_64.S
+++ b/checkasm/arm/checkasm_64.S
@@ -60,6 +60,13 @@ error_message_stack:
 endconst
 
 
+#if defined(__BYTE_ORDER__ ) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#define WORD_OFFS 4
+#else
+#define WORD_OFFS 0
+#endif
+
+
 // max number of args used by any asm function.
 #define MAX_ARGS 15
 
@@ -125,7 +132,7 @@ function checked_call, export=1
         // that were passed on the stack (if any), so we can only check after
         // that point. First figure out how many parameters the function
         // really took on the stack:
-        ldr             w2,  [x29, #16 + 8*8 + (MAX_ARGS-8)*8]
+        ldr             w2,  [x29, #16 + 8*8 + (MAX_ARGS-8)*8 + WORD_OFFS]
         // Load the first non-parameter value from the stack, that should be
         // left untouched by the function. Store a copy of it inverted, so that
         // e.g. overwriting everything with zero would be noticed.
@@ -143,7 +150,7 @@ function checked_call, export=1
         blr             x12
 
         // Load the number of stack parameters, stack canary and its reference
-        ldr             w2,  [x29, #16 + 8*8 + (MAX_ARGS-8)*8]
+        ldr             w2,  [x29, #16 + 8*8 + (MAX_ARGS-8)*8 + WORD_OFFS]
         ldr             x2,  [sp, x2, lsl #3]
         ldr             x3,  [sp, #ARG_STACK-8]
 
@@ -158,7 +165,7 @@ function checked_call, export=1
         movi            v3.8h,  #0
 
 .macro check_reg_neon reg1, reg2
-        ldr             q1,  [x9], #16
+        ld1             {v1.2d},  [x9], #16
         uzp1            v2.2d,  v\reg1\().2d, v\reg2\().2d
         eor             v1.16b, v1.16b, v2.16b
         orr             v3.16b, v3.16b, v1.16b

--- a/checkasm/arm/checkasm_64.S
+++ b/checkasm/arm/checkasm_64.S
@@ -28,8 +28,7 @@
 
 #define PRIVATE_PREFIX checkasm_
 
-#include "src/arm/asm.S"
-#include "src/arm/64/util.S"
+#include "aarch64/asm.S"
 
 const register_init, align=4
         .quad 0x21f86d66c8ca00ce

--- a/checkasm/be_blur.c
+++ b/checkasm/be_blur.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2020-2022 libass contributors
+ *
+ * This file is part of libass.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "checkasm.h"
+
+#define HEIGHT 8
+#define STRIDE 64
+#define MIN_WIDTH 2
+
+static void check_be_blur(BeBlurFunc func)
+{
+    ALIGN(uint8_t buf_ref[STRIDE * HEIGHT], 32);
+    ALIGN(uint8_t buf_new[STRIDE * HEIGHT], 32);
+    ALIGN(uint16_t tmp[STRIDE * 2], 32);
+    declare_func(void,
+                 uint8_t *buf, ptrdiff_t stride,
+                 size_t width, size_t height, uint16_t *tmp);
+
+    if (check_func(func, "be_blur")) {
+        for (int w = MIN_WIDTH; w <= STRIDE; w++) {
+            memset(buf_ref, 0, sizeof(buf_ref));
+            memset(buf_new, 0, sizeof(buf_new));
+            for (int y = 0; y < HEIGHT; y++) {
+                for (int x = 0; x < w - 1; x++)
+                    buf_ref[y * STRIDE + x] = buf_new[y * STRIDE + x] = rnd();
+            }
+
+            for (int i = 0; i < 2 * STRIDE; i++)
+                tmp[i] = rnd();
+            call_ref(buf_ref, STRIDE, w, HEIGHT, tmp);
+
+            for (int i = 0; i < 2 * STRIDE; i++)
+                tmp[i] = rnd();
+            call_new(buf_new, STRIDE, w, HEIGHT, tmp);
+
+            if (memcmp(buf_ref, buf_new, sizeof(buf_ref))) {
+                fail();
+                break;
+            }
+        }
+
+        bench_new(buf_new, STRIDE, STRIDE, HEIGHT, tmp);
+    }
+
+    report("be_blur");
+}
+
+void checkasm_check_be_blur(unsigned cpu_flag)
+{
+    BitmapEngine engine = ass_bitmap_engine_init(cpu_flag);
+    check_be_blur(engine.be_blur);
+}

--- a/checkasm/blend_bitmaps.c
+++ b/checkasm/blend_bitmaps.c
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2020-2022 libass contributors
+ *
+ * This file is part of libass.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "checkasm.h"
+
+#define HEIGHT 8
+#define DST_STRIDE 64
+#define MIN_WIDTH  1
+#define SRC1_STRIDE 96
+#define SRC2_STRIDE 128
+
+static void check_blend_bitmaps(BitmapBlendFunc func, const char *name)
+{
+    ALIGN(uint8_t src[SRC1_STRIDE * HEIGHT], 32);
+    ALIGN(uint8_t dst_ref[DST_STRIDE * HEIGHT], 32);
+    ALIGN(uint8_t dst_new[DST_STRIDE * HEIGHT], 32);
+    declare_func(void,
+                 uint8_t *dst, ptrdiff_t dst_stride,
+                 const uint8_t *src, ptrdiff_t src_stride,
+                 size_t width, size_t height);
+
+    if (check_func(func, name)) {
+        for (int w = MIN_WIDTH; w <= DST_STRIDE; w++) {
+            for (int i = 0; i < sizeof(src); i++)
+                src[i] = rnd();
+
+            for (int i = 0; i < sizeof(dst_ref); i++)
+                dst_ref[i] = dst_new[i] = rnd();
+
+            call_ref(dst_ref, DST_STRIDE, src, SRC1_STRIDE, w, HEIGHT);
+            call_new(dst_new, DST_STRIDE, src, SRC1_STRIDE, w, HEIGHT);
+
+            if (memcmp(dst_ref, dst_new, sizeof(dst_ref))) {
+                fail();
+                break;
+            }
+        }
+
+        bench_new(dst_new, DST_STRIDE, src, SRC1_STRIDE, DST_STRIDE, HEIGHT);
+    }
+
+    report(name);
+}
+
+static void check_mul_bitmaps(BitmapMulFunc func)
+{
+    ALIGN(uint8_t src1[SRC1_STRIDE * HEIGHT], 32);
+    ALIGN(uint8_t src2[SRC2_STRIDE * HEIGHT], 32);
+    ALIGN(uint8_t dst_ref[DST_STRIDE * HEIGHT], 32);
+    ALIGN(uint8_t dst_new[DST_STRIDE * HEIGHT], 32);
+    declare_func(void,
+                 uint8_t *dst, ptrdiff_t dst_stride,
+                 const uint8_t *src1, ptrdiff_t src1_stride,
+                 const uint8_t *src2, ptrdiff_t src2_stride,
+                 size_t width, size_t height);
+
+    if (check_func(func, "mul_bitmaps")) {
+        for (int w = MIN_WIDTH; w < DST_STRIDE; w++) {
+            for (int i = 0; i < sizeof(src1); i++)
+                src1[i] = rnd();
+
+            for (int i = 0; i < sizeof(src2); i++)
+                src2[i] = rnd();
+
+            memset(dst_ref, 0, sizeof(dst_ref));
+            memset(dst_new, 0, sizeof(dst_new));
+
+            call_ref(dst_ref, DST_STRIDE, src1, SRC1_STRIDE, src2, SRC2_STRIDE, w, HEIGHT);
+            call_new(dst_new, DST_STRIDE, src1, SRC1_STRIDE, src2, SRC2_STRIDE, w, HEIGHT);
+
+            if (memcmp(dst_ref, dst_new, sizeof(dst_ref))) {
+                fail();
+                break;
+            }
+        }
+
+        bench_new(dst_new, DST_STRIDE, src1, SRC1_STRIDE, src2, SRC2_STRIDE, DST_STRIDE, HEIGHT);
+    }
+
+    report("mul_bitmaps");
+}
+
+void checkasm_check_blend_bitmaps(unsigned cpu_flag)
+{
+    BitmapEngine engine = ass_bitmap_engine_init(cpu_flag);
+    check_blend_bitmaps(engine.add_bitmaps, "add_bitmaps");
+    check_blend_bitmaps(engine.imul_bitmaps, "imul_bitmaps");
+    check_mul_bitmaps(engine.mul_bitmaps);
+}

--- a/checkasm/blur.c
+++ b/checkasm/blur.c
@@ -1,0 +1,192 @@
+/*
+ * Copyright (C) 2021-2022 libass contributors
+ *
+ * This file is part of libass.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "checkasm.h"
+
+#define HEIGHT 13
+#define STRIDE 64
+#define MIN_WIDTH 1
+
+static void check_stripe_unpack(Convert8to16Func func, const char *name, int align)
+{
+    ALIGN(uint8_t src[STRIDE * HEIGHT], 32);
+    ALIGN(int16_t dst_ref[STRIDE * HEIGHT], 32);
+    ALIGN(int16_t dst_new[STRIDE * HEIGHT], 32);
+    declare_func(void,
+                 int16_t *dst, const uint8_t *src, ptrdiff_t src_stride,
+                 size_t width, size_t height);
+
+    if (check_func(func, name, align)) {
+        for (int w = MIN_WIDTH; w <= STRIDE; w++) {
+            for (int i = 0; i < sizeof(src); i++)
+                src[i] = rnd();
+
+            for (int i = 0; i < sizeof(dst_ref) / 2; i++)
+                dst_ref[i] = dst_new[i] = rnd();
+
+            int h = HEIGHT - (rnd() & 3);
+            call_ref(dst_ref, src, STRIDE, w, h);
+            call_new(dst_new, src, STRIDE, w, h);
+
+            if (memcmp(dst_ref, dst_new, sizeof(dst_ref))) {
+                fail();
+                break;
+            }
+        }
+
+        bench_new(dst_new, src, STRIDE, STRIDE, HEIGHT);
+    }
+
+    report(name, align);
+}
+
+static void check_stripe_pack(Convert16to8Func func, const char *name, int align)
+{
+    ALIGN(int16_t src[STRIDE * HEIGHT], 32);
+    ALIGN(uint8_t dst_ref[STRIDE * HEIGHT], 32);
+    ALIGN(uint8_t dst_new[STRIDE * HEIGHT], 32);
+    declare_func(void,
+                 uint8_t *dst, ptrdiff_t dst_stride, const int16_t *src,
+                 size_t width, size_t height);
+
+    if (check_func(func, name, align)) {
+        for (int w = MIN_WIDTH; w <= STRIDE; w++) {
+            for (int i = 0; i < sizeof(src) / 2; i++)
+                src[i] = rnd() % 0x4001;
+
+            memset(dst_ref, 0, sizeof(dst_ref));
+            memset(dst_new, 0, sizeof(dst_new));
+            for (int y = 0; y < HEIGHT; y++) {
+                for (int x = 0; x < w; x++)
+                    dst_ref[y * STRIDE + x] = dst_new[y * STRIDE + x] = rnd();
+            }
+
+            int h = HEIGHT - (rnd() & 3);
+            call_ref(dst_ref, STRIDE, src, w, h);
+            call_new(dst_new, STRIDE, src, w, h);
+
+            if (memcmp(dst_ref, dst_new, sizeof(dst_ref))) {
+                fail();
+                break;
+            }
+        }
+
+        bench_new(dst_new, STRIDE, src, STRIDE, HEIGHT);
+    }
+
+    report(name, align);
+}
+
+static void check_fixed_filter(FilterFunc func, const char *name, int align)
+{
+    enum { PADDING = FFMAX(32 * HEIGHT, 4 * STRIDE) };
+
+    ALIGN(int16_t src[STRIDE * HEIGHT], 32);
+    ALIGN(int16_t dst_ref[2 * STRIDE * HEIGHT + PADDING], 32);
+    ALIGN(int16_t dst_new[2 * STRIDE * HEIGHT + PADDING], 32);
+    declare_func(void,
+                 int16_t *dst, const int16_t *src,
+                 size_t src_width, size_t src_height);
+
+    if (check_func(func, name, align)) {
+        for (int w = MIN_WIDTH; w <= STRIDE; w++) {
+            for (int i = 0; i < sizeof(src) / 2; i++)
+                src[i] = rnd() % 0x4001;
+
+            for (int i = 0; i < sizeof(dst_ref) / 2; i++)
+                dst_ref[i] = dst_new[i] = rnd();
+
+            int h = HEIGHT - (rnd() & 3);
+            call_ref(dst_ref, src, w, h);
+            call_new(dst_new, src, w, h);
+
+            if (memcmp(dst_ref, dst_new, sizeof(dst_ref))) {
+                fail();
+                break;
+            }
+        }
+
+        bench_new(dst_new, src, STRIDE, HEIGHT);
+    }
+
+    report(name, align);
+}
+
+static void check_param_filter(ParamFilterFunc func, const char *name, int n, int align)
+{
+    enum { PADDING = FFMAX(32 * HEIGHT, 16 * STRIDE) };
+
+    ALIGN(int16_t src[STRIDE * HEIGHT], 32);
+    ALIGN(int16_t dst_ref[STRIDE * HEIGHT + PADDING], 32);
+    ALIGN(int16_t dst_new[STRIDE * HEIGHT + PADDING], 32);
+    int16_t param[8];
+    declare_func(void,
+                 int16_t *dst, const int16_t *src,
+                 size_t src_width, size_t src_height,
+                 const int16_t *param);
+
+    if (check_func(func, name, n, align)) {
+        for (int w = MIN_WIDTH; w <= STRIDE; w++) {
+            for (int i = 0; i < sizeof(src) / 2; i++)
+                src[i] = rnd() % 0x4001;
+
+            for (int i = 0; i < sizeof(dst_ref) / 2; i++)
+                dst_ref[i] = dst_new[i] = rnd();
+
+            int left = 0x8000;
+            for (int i = 0; i < n; i++) {
+                param[i] = rnd() % (left + 1);
+                left -= param[i];
+            }
+
+            int h = HEIGHT - (rnd() & 3);
+            call_ref(dst_ref, src, w, h, param);
+            call_new(dst_new, src, w, h, param);
+
+            if (memcmp(dst_ref, dst_new, sizeof(dst_ref))) {
+                fail();
+                break;
+            }
+        }
+
+        bench_new(dst_new, src, STRIDE, HEIGHT, param);
+    }
+
+    report(name, n, align);
+}
+
+void checkasm_check_blur(unsigned cpu_flag)
+{
+    BitmapEngine engine[2] = {
+        ass_bitmap_engine_init(cpu_flag),
+        ass_bitmap_engine_init(cpu_flag | ASS_FLAG_WIDE_STRIPE)
+    };
+    for (int i = 0; i < 2; i++) {
+        int align = 1 << engine[i].align_order;
+        check_stripe_unpack(engine[i].stripe_unpack, "stripe_unpack%d", align);
+        check_stripe_pack(engine[i].stripe_pack, "stripe_pack%d", align);
+        check_fixed_filter(engine[i].shrink_horz, "shrink_horz%d", align);
+        check_fixed_filter(engine[i].shrink_vert, "shrink_vert%d", align);
+        check_fixed_filter(engine[i].expand_horz, "expand_horz%d", align);
+        check_fixed_filter(engine[i].expand_vert, "expand_vert%d", align);
+        for (int n = 4; n <= 8; n++) {
+            check_param_filter(engine[i].blur_horz[n - 4], "blur%d_horz%d", n, align);
+            check_param_filter(engine[i].blur_vert[n - 4], "blur%d_vert%d", n, align);
+        }
+    }
+}

--- a/checkasm/checkasm.c
+++ b/checkasm/checkasm.c
@@ -1,0 +1,924 @@
+/*
+ * Copyright © 2018, VideoLAN and dav1d authors
+ * Copyright © 2018, Two Orioles, LLC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "tests/checkasm/checkasm.h"
+
+#include <math.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "src/cpu.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#define COLOR_RED    FOREGROUND_RED
+#define COLOR_GREEN  FOREGROUND_GREEN
+#define COLOR_YELLOW (FOREGROUND_RED|FOREGROUND_GREEN)
+#else
+#include <unistd.h>
+#include <signal.h>
+#include <time.h>
+#ifdef __APPLE__
+#include <mach/mach_time.h>
+#endif
+#define COLOR_RED    1
+#define COLOR_GREEN  2
+#define COLOR_YELLOW 3
+#endif
+
+/* List of tests to invoke */
+static const struct {
+    const char *name;
+    void (*func)(void);
+} tests[] = {
+    { "msac", checkasm_check_msac },
+    { "refmvs", checkasm_check_refmvs },
+#if CONFIG_8BPC
+    { "cdef_8bpc", checkasm_check_cdef_8bpc },
+    { "filmgrain_8bpc", checkasm_check_filmgrain_8bpc },
+    { "ipred_8bpc", checkasm_check_ipred_8bpc },
+    { "itx_8bpc", checkasm_check_itx_8bpc },
+    { "loopfilter_8bpc", checkasm_check_loopfilter_8bpc },
+    { "looprestoration_8bpc", checkasm_check_looprestoration_8bpc },
+    { "mc_8bpc", checkasm_check_mc_8bpc },
+#endif
+#if CONFIG_16BPC
+    { "cdef_16bpc", checkasm_check_cdef_16bpc },
+    { "filmgrain_16bpc", checkasm_check_filmgrain_16bpc },
+    { "ipred_16bpc", checkasm_check_ipred_16bpc },
+    { "itx_16bpc", checkasm_check_itx_16bpc },
+    { "loopfilter_16bpc", checkasm_check_loopfilter_16bpc },
+    { "looprestoration_16bpc", checkasm_check_looprestoration_16bpc },
+    { "mc_16bpc", checkasm_check_mc_16bpc },
+#endif
+    { 0 }
+};
+
+/* List of cpu flags to check */
+static const struct {
+    const char *name;
+    const char *suffix;
+    unsigned flag;
+} cpus[] = {
+#if ARCH_X86
+    { "SSE2",               "sse2",      DAV1D_X86_CPU_FLAG_SSE2 },
+    { "SSSE3",              "ssse3",     DAV1D_X86_CPU_FLAG_SSSE3 },
+    { "SSE4.1",             "sse4",      DAV1D_X86_CPU_FLAG_SSE41 },
+    { "AVX2",               "avx2",      DAV1D_X86_CPU_FLAG_AVX2 },
+    { "AVX-512 (Ice Lake)", "avx512icl", DAV1D_X86_CPU_FLAG_AVX512ICL },
+#elif ARCH_AARCH64 || ARCH_ARM
+    { "NEON",               "neon",      DAV1D_ARM_CPU_FLAG_NEON },
+#elif ARCH_PPC64LE
+    { "VSX",                "vsx",       DAV1D_PPC_CPU_FLAG_VSX },
+#endif
+    { 0 }
+};
+
+typedef struct CheckasmFuncVersion {
+    struct CheckasmFuncVersion *next;
+    void *func;
+    int ok;
+    unsigned cpu;
+    int iterations;
+    uint64_t cycles;
+} CheckasmFuncVersion;
+
+/* Binary search tree node */
+typedef struct CheckasmFunc {
+    struct CheckasmFunc *child[2];
+    CheckasmFuncVersion versions;
+    uint8_t color; /* 0 = red, 1 = black */
+    char name[];
+} CheckasmFunc;
+
+/* Internal state */
+static struct {
+    CheckasmFunc *funcs;
+    CheckasmFunc *current_func;
+    CheckasmFuncVersion *current_func_ver;
+    const char *current_test_name;
+    int num_checked;
+    int num_failed;
+    int nop_time;
+    unsigned cpu_flag;
+    const char *cpu_flag_name;
+    const char *test_pattern;
+    const char *function_pattern;
+    unsigned seed;
+    int bench;
+    int bench_c;
+    int verbose;
+    int function_listing;
+    int catch_signals;
+#if ARCH_X86_64
+    void (*simd_warmup)(void);
+#endif
+} state;
+
+/* float compare support code */
+typedef union {
+    float f;
+    uint32_t i;
+} intfloat;
+
+static uint32_t xs_state[4];
+
+static void xor128_srand(unsigned seed) {
+    xs_state[0] = seed;
+    xs_state[1] = ( seed & 0xffff0000) | (~seed & 0x0000ffff);
+    xs_state[2] = (~seed & 0xffff0000) | ( seed & 0x0000ffff);
+    xs_state[3] = ~seed;
+}
+
+// xor128 from Marsaglia, George (July 2003). "Xorshift RNGs".
+//             Journal of Statistical Software. 8 (14).
+//             doi:10.18637/jss.v008.i14.
+int xor128_rand(void) {
+    const uint32_t x = xs_state[0];
+    const uint32_t t = x ^ (x << 11);
+
+    xs_state[0] = xs_state[1];
+    xs_state[1] = xs_state[2];
+    xs_state[2] = xs_state[3];
+    uint32_t w = xs_state[3];
+
+    w = (w ^ (w >> 19)) ^ (t ^ (t >> 8));
+    xs_state[3] = w;
+
+    return w >> 1;
+}
+
+static int is_negative(const intfloat u) {
+    return u.i >> 31;
+}
+
+int float_near_ulp(const float a, const float b, const unsigned max_ulp) {
+    intfloat x, y;
+
+    x.f = a;
+    y.f = b;
+
+    if (is_negative(x) != is_negative(y)) {
+        // handle -0.0 == +0.0
+        return a == b;
+    }
+
+    if (llabs((int64_t)x.i - y.i) <= max_ulp)
+        return 1;
+
+    return 0;
+}
+
+int float_near_ulp_array(const float *const a, const float *const b,
+                         const unsigned max_ulp, const int len)
+{
+    for (int i = 0; i < len; i++)
+        if (!float_near_ulp(a[i], b[i], max_ulp))
+            return 0;
+
+    return 1;
+}
+
+int float_near_abs_eps(const float a, const float b, const float eps) {
+    return fabsf(a - b) < eps;
+}
+
+int float_near_abs_eps_array(const float *const a, const float *const b,
+                             const float eps, const int len)
+{
+    for (int i = 0; i < len; i++)
+        if (!float_near_abs_eps(a[i], b[i], eps))
+            return 0;
+
+    return 1;
+}
+
+int float_near_abs_eps_ulp(const float a, const float b, const float eps,
+                           const unsigned max_ulp)
+{
+    return float_near_ulp(a, b, max_ulp) || float_near_abs_eps(a, b, eps);
+}
+
+int float_near_abs_eps_array_ulp(const float *const a, const float *const b,
+                                 const float eps, const unsigned max_ulp,
+                                 const int len)
+{
+    for (int i = 0; i < len; i++)
+        if (!float_near_abs_eps_ulp(a[i], b[i], eps, max_ulp))
+            return 0;
+
+    return 1;
+}
+
+/* Print colored text to stderr if the terminal supports it */
+static void color_printf(const int color, const char *const fmt, ...) {
+    static int8_t use_color = -1;
+    va_list arg;
+
+#ifdef _WIN32
+    static HANDLE con;
+    static WORD org_attributes;
+
+    if (use_color < 0) {
+        CONSOLE_SCREEN_BUFFER_INFO con_info;
+        con = GetStdHandle(STD_ERROR_HANDLE);
+        if (con && con != INVALID_HANDLE_VALUE &&
+            GetConsoleScreenBufferInfo(con, &con_info))
+        {
+            org_attributes = con_info.wAttributes;
+            use_color = 1;
+        } else
+            use_color = 0;
+    }
+    if (use_color)
+        SetConsoleTextAttribute(con, (org_attributes & 0xfff0) |
+                                (color & 0x0f));
+#else
+    if (use_color < 0) {
+        const char *const term = getenv("TERM");
+        use_color = term && strcmp(term, "dumb") && isatty(2);
+    }
+    if (use_color)
+        fprintf(stderr, "\x1b[%d;3%dm", (color & 0x08) >> 3, color & 0x07);
+#endif
+
+    va_start(arg, fmt);
+    vfprintf(stderr, fmt, arg);
+    va_end(arg);
+
+    if (use_color) {
+#ifdef _WIN32
+        SetConsoleTextAttribute(con, org_attributes);
+#else
+        fprintf(stderr, "\x1b[0m");
+#endif
+    }
+}
+
+/* Deallocate a tree */
+static void destroy_func_tree(CheckasmFunc *const f) {
+    if (f) {
+        CheckasmFuncVersion *v = f->versions.next;
+        while (v) {
+            CheckasmFuncVersion *next = v->next;
+            free(v);
+            v = next;
+        }
+
+        destroy_func_tree(f->child[0]);
+        destroy_func_tree(f->child[1]);
+        free(f);
+    }
+}
+
+/* Allocate a zero-initialized block, clean up and exit on failure */
+static void *checkasm_malloc(const size_t size) {
+    void *const ptr = calloc(1, size);
+    if (!ptr) {
+        fprintf(stderr, "checkasm: malloc failed\n");
+        destroy_func_tree(state.funcs);
+        exit(1);
+    }
+    return ptr;
+}
+
+/* Get the suffix of the specified cpu flag */
+static const char *cpu_suffix(const unsigned cpu) {
+    for (int i = (int)(sizeof(cpus) / sizeof(*cpus)) - 2; i >= 0; i--)
+        if (cpu & cpus[i].flag)
+            return cpus[i].suffix;
+
+    return "c";
+}
+
+#ifdef readtime
+static int cmp_nop(const void *a, const void *b) {
+    return *(const uint16_t*)a - *(const uint16_t*)b;
+}
+
+/* Measure the overhead of the timing code (in decicycles) */
+static int measure_nop_time(void) {
+    uint16_t nops[10000];
+    int nop_sum = 0;
+
+    for (int i = 0; i < 10000; i++) {
+        uint64_t t = readtime();
+        nops[i] = (uint16_t) (readtime() - t);
+    }
+
+    qsort(nops, 10000, sizeof(uint16_t), cmp_nop);
+    for (int i = 2500; i < 7500; i++)
+        nop_sum += nops[i];
+
+    return nop_sum / 500;
+}
+
+/* Print benchmark results */
+static void print_benchs(const CheckasmFunc *const f) {
+    if (f) {
+        print_benchs(f->child[0]);
+
+        /* Only print functions with at least one assembly version */
+        if (state.bench_c || f->versions.cpu || f->versions.next) {
+            const CheckasmFuncVersion *v = &f->versions;
+            do {
+                if (v->iterations) {
+                    const int decicycles = (int) (10*v->cycles/v->iterations -
+                                                  state.nop_time) / 4;
+                    printf("%s_%s: %d.%d\n", f->name, cpu_suffix(v->cpu),
+                           decicycles/10, decicycles%10);
+                }
+            } while ((v = v->next));
+        }
+
+        print_benchs(f->child[1]);
+    }
+}
+#endif
+
+static void print_functions(const CheckasmFunc *const f) {
+    if (f) {
+        print_functions(f->child[0]);
+        printf("%s\n", f->name);
+        print_functions(f->child[1]);
+    }
+}
+
+#define is_digit(x) ((x) >= '0' && (x) <= '9')
+
+/* ASCIIbetical sort except preserving natural order for numbers */
+static int cmp_func_names(const char *a, const char *b) {
+    const char *const start = a;
+    int ascii_diff, digit_diff;
+
+    for (; !(ascii_diff = *(const unsigned char*)a -
+                          *(const unsigned char*)b) && *a; a++, b++);
+    for (; is_digit(*a) && is_digit(*b); a++, b++);
+
+    if (a > start && is_digit(a[-1]) &&
+        (digit_diff = is_digit(*a) - is_digit(*b)))
+    {
+        return digit_diff;
+    }
+
+    return ascii_diff;
+}
+
+/* Perform a tree rotation in the specified direction and return the new root */
+static CheckasmFunc *rotate_tree(CheckasmFunc *const f, const int dir) {
+    CheckasmFunc *const r = f->child[dir^1];
+    f->child[dir^1] = r->child[dir];
+    r->child[dir] = f;
+    r->color = f->color;
+    f->color = 0;
+    return r;
+}
+
+#define is_red(f) ((f) && !(f)->color)
+
+/* Balance a left-leaning red-black tree at the specified node */
+static void balance_tree(CheckasmFunc **const root) {
+    CheckasmFunc *const f = *root;
+
+    if (is_red(f->child[0]) && is_red(f->child[1])) {
+        f->color ^= 1;
+        f->child[0]->color = f->child[1]->color = 1;
+    }
+    else if (!is_red(f->child[0]) && is_red(f->child[1]))
+        *root = rotate_tree(f, 0); /* Rotate left */
+    else if (is_red(f->child[0]) && is_red(f->child[0]->child[0]))
+        *root = rotate_tree(f, 1); /* Rotate right */
+}
+
+/* Get a node with the specified name, creating it if it doesn't exist */
+static CheckasmFunc *get_func(CheckasmFunc **const root, const char *const name) {
+    CheckasmFunc *f = *root;
+
+    if (f) {
+        /* Search the tree for a matching node */
+        const int cmp = cmp_func_names(name, f->name);
+        if (cmp) {
+            f = get_func(&f->child[cmp > 0], name);
+
+            /* Rebalance the tree on the way up if a new node was inserted */
+            if (!f->versions.func)
+                balance_tree(root);
+        }
+    } else {
+        /* Allocate and insert a new node into the tree */
+        const size_t name_length = strlen(name) + 1;
+        f = *root = checkasm_malloc(offsetof(CheckasmFunc, name) + name_length);
+        memcpy(f->name, name, name_length);
+    }
+
+    return f;
+}
+
+checkasm_context checkasm_context_buf;
+
+/* Crash handling: attempt to catch crashes and handle them
+ * gracefully instead of just aborting abruptly. */
+#ifdef _WIN32
+static LONG NTAPI signal_handler(EXCEPTION_POINTERS *const e) {
+    if (!state.catch_signals)
+        return EXCEPTION_CONTINUE_SEARCH;
+
+    const char *err;
+    switch (e->ExceptionRecord->ExceptionCode) {
+    case EXCEPTION_FLT_DIVIDE_BY_ZERO:
+    case EXCEPTION_INT_DIVIDE_BY_ZERO:
+        err = "fatal arithmetic error";
+        break;
+    case EXCEPTION_ILLEGAL_INSTRUCTION:
+    case EXCEPTION_PRIV_INSTRUCTION:
+        err = "illegal instruction";
+        break;
+    case EXCEPTION_ACCESS_VIOLATION:
+    case EXCEPTION_ARRAY_BOUNDS_EXCEEDED:
+    case EXCEPTION_DATATYPE_MISALIGNMENT:
+    case EXCEPTION_IN_PAGE_ERROR:
+    case EXCEPTION_STACK_OVERFLOW:
+        err = "segmentation fault";
+        break;
+    default:
+        return EXCEPTION_CONTINUE_SEARCH;
+    }
+    state.catch_signals = 0;
+    checkasm_fail_func(err);
+    checkasm_load_context();
+    return EXCEPTION_CONTINUE_EXECUTION; /* never reached, but shuts up gcc */
+}
+#else
+static void signal_handler(const int s) {
+    if (state.catch_signals) {
+        state.catch_signals = 0;
+        checkasm_fail_func(s == SIGFPE ? "fatal arithmetic error" :
+                           s == SIGILL ? "illegal instruction" :
+                                         "segmentation fault");
+        checkasm_load_context();
+    } else {
+        /* fall back to the default signal handler */
+        static const struct sigaction default_sa = { .sa_handler = SIG_DFL };
+        sigaction(s, &default_sa, NULL);
+        raise(s);
+    }
+}
+#endif
+
+/* Compares a string with a wildcard pattern. */
+static int wildstrcmp(const char *str, const char *pattern) {
+    const char *wild = strchr(pattern, '*');
+    if (wild) {
+        const size_t len = wild - pattern;
+        if (strncmp(str, pattern, len)) return 1;
+        while (*++wild == '*');
+        if (!*wild) return 0;
+        str += len;
+        while (*str && wildstrcmp(str, wild)) str++;
+        return !*str;
+    }
+    return strcmp(str, pattern);
+}
+
+/* Perform tests and benchmarks for the specified
+ * cpu flag if supported by the host */
+static void check_cpu_flag(const char *const name, unsigned flag) {
+    const unsigned old_cpu_flag = state.cpu_flag;
+
+    flag |= old_cpu_flag;
+    dav1d_set_cpu_flags_mask(flag);
+    state.cpu_flag = dav1d_get_cpu_flags();
+
+    if (!flag || state.cpu_flag != old_cpu_flag) {
+        state.cpu_flag_name = name;
+        for (int i = 0; tests[i].func; i++) {
+            if (state.test_pattern && wildstrcmp(tests[i].name, state.test_pattern))
+                continue;
+            xor128_srand(state.seed);
+            state.current_test_name = tests[i].name;
+            tests[i].func();
+        }
+    }
+}
+
+/* Print the name of the current CPU flag, but only do it once */
+static void print_cpu_name(void) {
+    if (state.cpu_flag_name) {
+        color_printf(COLOR_YELLOW, "%s:\n", state.cpu_flag_name);
+        state.cpu_flag_name = NULL;
+    }
+}
+
+static unsigned get_seed(void) {
+#ifdef _WIN32
+    LARGE_INTEGER i;
+    QueryPerformanceCounter(&i);
+    return i.LowPart;
+#elif defined(__APPLE__)
+    return (unsigned) mach_absolute_time();
+#else
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (unsigned) (1000000000ULL * ts.tv_sec + ts.tv_nsec);
+#endif
+}
+
+int main(int argc, char *argv[]) {
+    state.seed = get_seed();
+
+    while (argc > 1) {
+        if (!strncmp(argv[1], "--help", 6) || !strcmp(argv[1], "-h")) {
+            fprintf(stderr,
+                    "checkasm [options] <random seed>\n"
+                    "    <random seed>              Numeric value to seed the rng\n"
+                    "Options:\n"
+                    "    --test=<pattern>           Test only <pattern>\n"
+                    "    --function=<pattern> -f    Test only the functions matching <pattern>\n"
+                    "    --bench -b                 Benchmark the tested functions\n"
+                    "    --list-functions           List available functions\n"
+                    "    --list-tests               List available tests\n"
+                    "    --bench-c -c               Benchmark the C-only functions\n"
+                    "    --verbose -v               Print failures verbosely\n");
+            return 0;
+        } else if (!strcmp(argv[1], "--bench-c") || !strcmp(argv[1], "-c")) {
+            state.bench_c = 1;
+        } else if (!strcmp(argv[1], "--bench") || !strcmp(argv[1], "-b")) {
+#ifndef readtime
+            fprintf(stderr,
+                    "checkasm: --bench is not supported on your system\n");
+            return 1;
+#endif
+            state.bench = 1;
+        } else if (!strncmp(argv[1], "--test=", 7)) {
+            state.test_pattern = argv[1] + 7;
+        } else if (!strcmp(argv[1], "-t")) {
+            state.test_pattern = argc > 1 ? argv[2] : "";
+            argc--;
+            argv++;
+        } else if (!strncmp(argv[1], "--function=", 11)) {
+            state.function_pattern = argv[1] + 11;
+        } else if (!strcmp(argv[1], "-f")) {
+            state.function_pattern = argc > 1 ? argv[2] : "";
+            argc--;
+            argv++;
+        } else if (!strcmp(argv[1], "--list-functions")) {
+            state.function_listing = 1;
+        } else if (!strcmp(argv[1], "--list-tests")) {
+            for (int i = 0; tests[i].name; i++)
+                printf("%s\n", tests[i].name);
+            return 0;
+        } else if (!strcmp(argv[1], "--verbose") || !strcmp(argv[1], "-v")) {
+            state.verbose = 1;
+        } else {
+            state.seed = (unsigned) strtoul(argv[1], NULL, 10);
+        }
+
+        argc--;
+        argv++;
+    }
+
+#if TRIM_DSP_FUNCTIONS
+    fprintf(stderr, "checkasm: reference functions unavailable\n");
+    return 0;
+#endif
+
+    dav1d_init_cpu();
+
+#ifdef _WIN32
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+    AddVectoredExceptionHandler(0, signal_handler);
+#endif
+#else
+    const struct sigaction sa = {
+        .sa_handler = signal_handler,
+        .sa_flags = SA_NODEFER,
+    };
+    sigaction(SIGBUS,  &sa, NULL);
+    sigaction(SIGFPE,  &sa, NULL);
+    sigaction(SIGILL,  &sa, NULL);
+    sigaction(SIGSEGV, &sa, NULL);
+#endif
+
+#ifdef readtime
+    if (state.bench) {
+        static int testing = 0;
+        checkasm_save_context();
+        if (!testing) {
+            checkasm_set_signal_handler_state(1);
+            testing = 1;
+            readtime();
+            checkasm_set_signal_handler_state(0);
+        } else {
+            fprintf(stderr, "checkasm: unable to access cycle counter\n");
+            return 1;
+        }
+    }
+#endif
+
+    int ret = 0;
+
+    if (!state.function_listing) {
+#if ARCH_X86_64
+        void checkasm_warmup_avx2(void);
+        void checkasm_warmup_avx512(void);
+        const unsigned cpu_flags = dav1d_get_cpu_flags();
+        if (cpu_flags & DAV1D_X86_CPU_FLAG_AVX512ICL)
+            state.simd_warmup = checkasm_warmup_avx512;
+        else if (cpu_flags & DAV1D_X86_CPU_FLAG_AVX2)
+            state.simd_warmup = checkasm_warmup_avx2;
+        checkasm_simd_warmup();
+#endif
+#if ARCH_X86
+        unsigned checkasm_init_x86(char *name);
+        char name[48];
+        const unsigned cpuid = checkasm_init_x86(name);
+        for (size_t len = strlen(name); len && name[len-1] == ' '; len--)
+            name[len-1] = '\0'; /* trim trailing whitespace */
+        fprintf(stderr, "checkasm: %s (%08X) using random seed %u\n", name, cpuid, state.seed);
+#else
+        fprintf(stderr, "checkasm: using random seed %u\n", state.seed);
+#endif
+    }
+
+    check_cpu_flag(NULL, 0);
+
+    if (state.function_listing) {
+        print_functions(state.funcs);
+    } else {
+        for (int i = 0; cpus[i].flag; i++)
+            check_cpu_flag(cpus[i].name, cpus[i].flag);
+        if (!state.num_checked) {
+            fprintf(stderr, "checkasm: no tests to perform\n");
+        } else if (state.num_failed) {
+            fprintf(stderr, "checkasm: %d of %d tests have failed\n",
+                    state.num_failed, state.num_checked);
+            ret = 1;
+        } else {
+            fprintf(stderr, "checkasm: all %d tests passed\n", state.num_checked);
+#ifdef readtime
+            if (state.bench) {
+                state.nop_time = measure_nop_time();
+                printf("nop: %d.%d\n", state.nop_time/10, state.nop_time%10);
+                print_benchs(state.funcs);
+            }
+#endif
+        }
+    }
+
+    destroy_func_tree(state.funcs);
+    return ret;
+}
+
+/* Decide whether or not the specified function needs to be tested and
+ * allocate/initialize data structures if needed. Returns a pointer to a
+ * reference function if the function should be tested, otherwise NULL */
+void *checkasm_check_func(void *const func, const char *const name, ...) {
+    char name_buf[256];
+    va_list arg;
+
+    va_start(arg, name);
+    const int name_length = vsnprintf(name_buf, sizeof(name_buf), name, arg);
+    va_end(arg);
+
+    if (!func || name_length <= 0 || (size_t)name_length >= sizeof(name_buf) ||
+        (state.function_pattern && wildstrcmp(name_buf, state.function_pattern)))
+    {
+        return NULL;
+    }
+
+    state.current_func = get_func(&state.funcs, name_buf);
+
+    if (state.function_listing) /* Save function names without running tests */
+        return NULL;
+
+    state.funcs->color = 1;
+    CheckasmFuncVersion *v = &state.current_func->versions;
+    void *ref = func;
+
+    if (v->func) {
+        CheckasmFuncVersion *prev;
+        do {
+            /* Only test functions that haven't already been tested */
+            if (v->func == func)
+                return NULL;
+
+            if (v->ok)
+                ref = v->func;
+
+            prev = v;
+        } while ((v = v->next));
+
+        v = prev->next = checkasm_malloc(sizeof(CheckasmFuncVersion));
+    }
+
+    v->func = func;
+    v->ok = 1;
+    v->cpu = state.cpu_flag;
+    state.current_func_ver = v;
+    xor128_srand(state.seed);
+
+    if (state.cpu_flag || state.bench_c)
+        state.num_checked++;
+
+    return ref;
+}
+
+/* Decide whether or not the current function needs to be benchmarked */
+int checkasm_bench_func(void) {
+    return !state.num_failed && state.bench;
+}
+
+/* Indicate that the current test has failed, return whether verbose printing
+ * is requested. */
+int checkasm_fail_func(const char *const msg, ...) {
+    if (state.current_func_ver && state.current_func_ver->cpu &&
+        state.current_func_ver->ok)
+    {
+        va_list arg;
+
+        print_cpu_name();
+        fprintf(stderr, "   %s_%s (", state.current_func->name,
+                cpu_suffix(state.current_func_ver->cpu));
+        va_start(arg, msg);
+        vfprintf(stderr, msg, arg);
+        va_end(arg);
+        fprintf(stderr, ")\n");
+
+        state.current_func_ver->ok = 0;
+        state.num_failed++;
+    }
+    return state.verbose;
+}
+
+/* Update benchmark results of the current function */
+void checkasm_update_bench(const int iterations, const uint64_t cycles) {
+    state.current_func_ver->iterations += iterations;
+    state.current_func_ver->cycles += cycles;
+}
+
+/* Print the outcome of all tests performed since
+ * the last time this function was called */
+void checkasm_report(const char *const name, ...) {
+    static int prev_checked, prev_failed;
+    static size_t max_length;
+
+    if (state.num_checked > prev_checked) {
+        int pad_length = (int) max_length + 4;
+        va_list arg;
+
+        print_cpu_name();
+        pad_length -= fprintf(stderr, " - %s.", state.current_test_name);
+        va_start(arg, name);
+        pad_length -= vfprintf(stderr, name, arg);
+        va_end(arg);
+        fprintf(stderr, "%*c", imax(pad_length, 0) + 2, '[');
+
+        if (state.num_failed == prev_failed)
+            color_printf(COLOR_GREEN, "OK");
+        else
+            color_printf(COLOR_RED, "FAILED");
+        fprintf(stderr, "]\n");
+
+        prev_checked = state.num_checked;
+        prev_failed  = state.num_failed;
+    } else if (!state.cpu_flag) {
+        /* Calculate the amount of padding required
+         * to make the output vertically aligned */
+        size_t length = strlen(state.current_test_name);
+        va_list arg;
+
+        va_start(arg, name);
+        length += vsnprintf(NULL, 0, name, arg);
+        va_end(arg);
+
+        if (length > max_length)
+            max_length = length;
+    }
+}
+
+void checkasm_set_signal_handler_state(const int enabled) {
+    state.catch_signals = enabled;
+}
+
+static int check_err(const char *const file, const int line,
+                     const char *const name, const int w, const int h,
+                     int *const err)
+{
+    if (*err)
+        return 0;
+    if (!checkasm_fail_func("%s:%d", file, line))
+        return 1;
+    *err = 1;
+    fprintf(stderr, "%s (%dx%d):\n", name, w, h);
+    return 0;
+}
+
+#define DEF_CHECKASM_CHECK_FUNC(type, fmt) \
+int checkasm_check_##type(const char *const file, const int line, \
+                          const type *buf1, ptrdiff_t stride1, \
+                          const type *buf2, ptrdiff_t stride2, \
+                          const int w, int h, const char *const name, \
+                          const int align_w, const int align_h, \
+                          const int padding) \
+{ \
+    int aligned_w = (w + align_w - 1) & ~(align_w - 1); \
+    int aligned_h = (h + align_h - 1) & ~(align_h - 1); \
+    int err = 0; \
+    stride1 /= sizeof(*buf1); \
+    stride2 /= sizeof(*buf2); \
+    int y = 0; \
+    for (y = 0; y < h; y++) \
+        if (memcmp(&buf1[y*stride1], &buf2[y*stride2], w*sizeof(*buf1))) \
+            break; \
+    if (y != h) { \
+        if (check_err(file, line, name, w, h, &err)) \
+            return 1; \
+        for (y = 0; y < h; y++) { \
+            for (int x = 0; x < w; x++) \
+                fprintf(stderr, " " fmt, buf1[x]); \
+            fprintf(stderr, "    "); \
+            for (int x = 0; x < w; x++) \
+                fprintf(stderr, " " fmt, buf2[x]); \
+            fprintf(stderr, "    "); \
+            for (int x = 0; x < w; x++) \
+                fprintf(stderr, "%c", buf1[x] != buf2[x] ? 'x' : '.'); \
+            buf1 += stride1; \
+            buf2 += stride2; \
+            fprintf(stderr, "\n"); \
+        } \
+        buf1 -= h*stride1; \
+        buf2 -= h*stride2; \
+    } \
+    for (y = -padding; y < 0; y++) \
+        if (memcmp(&buf1[y*stride1 - padding], &buf2[y*stride2 - padding], \
+                   (w + 2*padding)*sizeof(*buf1))) { \
+            if (check_err(file, line, name, w, h, &err)) \
+                return 1; \
+            fprintf(stderr, " overwrite above\n"); \
+            break; \
+        } \
+    for (y = aligned_h; y < aligned_h + padding; y++) \
+        if (memcmp(&buf1[y*stride1 - padding], &buf2[y*stride2 - padding], \
+                   (w + 2*padding)*sizeof(*buf1))) { \
+            if (check_err(file, line, name, w, h, &err)) \
+                return 1; \
+            fprintf(stderr, " overwrite below\n"); \
+            break; \
+        } \
+    for (y = 0; y < h; y++) \
+        if (memcmp(&buf1[y*stride1 - padding], &buf2[y*stride2 - padding], \
+                   padding*sizeof(*buf1))) { \
+            if (check_err(file, line, name, w, h, &err)) \
+                return 1; \
+            fprintf(stderr, " overwrite left\n"); \
+            break; \
+        } \
+    for (y = 0; y < h; y++) \
+        if (memcmp(&buf1[y*stride1 + aligned_w], &buf2[y*stride2 + aligned_w], \
+                   padding*sizeof(*buf1))) { \
+            if (check_err(file, line, name, w, h, &err)) \
+                return 1; \
+            fprintf(stderr, " overwrite right\n"); \
+            break; \
+        } \
+    return err; \
+}
+
+DEF_CHECKASM_CHECK_FUNC(int8_t,   "%4d")
+DEF_CHECKASM_CHECK_FUNC(int16_t,  "%6d")
+DEF_CHECKASM_CHECK_FUNC(int32_t,  "%9d")
+DEF_CHECKASM_CHECK_FUNC(uint8_t,  "%02x")
+DEF_CHECKASM_CHECK_FUNC(uint16_t, "%04x")
+DEF_CHECKASM_CHECK_FUNC(uint32_t, "%08x")
+
+#if ARCH_X86_64
+void checkasm_simd_warmup(void)
+{
+    if (state.simd_warmup)
+        state.simd_warmup();
+}
+#endif

--- a/checkasm/checkasm.c
+++ b/checkasm/checkasm.c
@@ -54,6 +54,7 @@ static const struct {
     const char *name;
     void (*func)(unsigned cpu_flag);
 } tests[] = {
+    { "rasterizer", checkasm_check_rasterizer },
     { "blend_bitmaps", checkasm_check_blend_bitmaps },
     { "be_blur", checkasm_check_be_blur },
     { "blur", checkasm_check_blur },

--- a/checkasm/checkasm.c
+++ b/checkasm/checkasm.c
@@ -56,6 +56,7 @@ static const struct {
 } tests[] = {
     { "blend_bitmaps", checkasm_check_blend_bitmaps },
     { "be_blur", checkasm_check_be_blur },
+    { "blur", checkasm_check_blur },
     { 0 }
 };
 

--- a/checkasm/checkasm.c
+++ b/checkasm/checkasm.c
@@ -240,6 +240,7 @@ static void color_printf(const int color, const char *const fmt, ...) {
     va_list arg;
 
 #ifdef _WIN32
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
     static HANDLE con;
     static WORD org_attributes;
 
@@ -257,6 +258,7 @@ static void color_printf(const int color, const char *const fmt, ...) {
     if (use_color)
         SetConsoleTextAttribute(con, (org_attributes & 0xfff0) |
                                 (color & 0x0f));
+#endif
 #else
     if (use_color < 0) {
         const char *const term = getenv("TERM");
@@ -272,7 +274,9 @@ static void color_printf(const int color, const char *const fmt, ...) {
 
     if (use_color) {
 #ifdef _WIN32
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
         SetConsoleTextAttribute(con, org_attributes);
+#endif
 #else
         fprintf(stderr, "\x1b[0m");
 #endif
@@ -443,6 +447,7 @@ checkasm_context checkasm_context_buf;
 /* Crash handling: attempt to catch crashes and handle them
  * gracefully instead of just aborting abruptly. */
 #ifdef _WIN32
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
 static LONG NTAPI signal_handler(EXCEPTION_POINTERS *const e) {
     if (!state.catch_signals)
         return EXCEPTION_CONTINUE_SEARCH;
@@ -472,6 +477,7 @@ static LONG NTAPI signal_handler(EXCEPTION_POINTERS *const e) {
     checkasm_load_context();
     return EXCEPTION_CONTINUE_EXECUTION; /* never reached, but shuts up gcc */
 }
+#endif
 #else
 static void signal_handler(const int s) {
     if (state.catch_signals) {

--- a/checkasm/checkasm.h
+++ b/checkasm/checkasm.h
@@ -1,0 +1,379 @@
+/*
+ * Copyright © 2018, VideoLAN and dav1d authors
+ * Copyright © 2018, Two Orioles, LLC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DAV1D_TESTS_CHECKASM_CHECKASM_H
+#define DAV1D_TESTS_CHECKASM_CHECKASM_H
+
+#include "config.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#if ARCH_X86_64 && defined(_WIN32)
+/* setjmp/longjmp on 64-bit Windows will try to use SEH to unwind the stack,
+ * which doesn't work for assembly functions without unwind information. */
+#include <windows.h>
+#define checkasm_context CONTEXT
+#define checkasm_save_context() RtlCaptureContext(&checkasm_context_buf)
+#define checkasm_load_context() RtlRestoreContext(&checkasm_context_buf, NULL)
+#else
+#include <setjmp.h>
+#define checkasm_context jmp_buf
+#define checkasm_save_context() setjmp(checkasm_context_buf)
+#define checkasm_load_context() longjmp(checkasm_context_buf, 1)
+#endif
+
+#include "include/common/attributes.h"
+#include "include/common/bitdepth.h"
+#include "include/common/intops.h"
+
+int xor128_rand(void);
+#define rnd xor128_rand
+
+#define decl_check_bitfns(name) \
+name##_8bpc(void); \
+name##_16bpc(void)
+
+void checkasm_check_msac(void);
+void checkasm_check_refmvs(void);
+decl_check_bitfns(void checkasm_check_cdef);
+decl_check_bitfns(void checkasm_check_filmgrain);
+decl_check_bitfns(void checkasm_check_ipred);
+decl_check_bitfns(void checkasm_check_itx);
+decl_check_bitfns(void checkasm_check_loopfilter);
+decl_check_bitfns(void checkasm_check_looprestoration);
+decl_check_bitfns(void checkasm_check_mc);
+
+void *checkasm_check_func(void *func, const char *name, ...);
+int checkasm_bench_func(void);
+int checkasm_fail_func(const char *msg, ...);
+void checkasm_update_bench(int iterations, uint64_t cycles);
+void checkasm_report(const char *name, ...);
+void checkasm_set_signal_handler_state(int enabled);
+extern checkasm_context checkasm_context_buf;
+
+/* float compare utilities */
+int float_near_ulp(float a, float b, unsigned max_ulp);
+int float_near_abs_eps(float a, float b, float eps);
+int float_near_abs_eps_ulp(float a, float b, float eps, unsigned max_ulp);
+int float_near_ulp_array(const float *a, const float *b, unsigned max_ulp,
+                         int len);
+int float_near_abs_eps_array(const float *a, const float *b, float eps,
+                             int len);
+int float_near_abs_eps_array_ulp(const float *a, const float *b, float eps,
+                                 unsigned max_ulp, int len);
+
+#define BENCH_RUNS (1 << 12) /* Trade-off between accuracy and speed */
+
+/* Decide whether or not the specified function needs to be tested */
+#define check_func(func, ...)\
+    (func_ref = checkasm_check_func((func_new = func), __VA_ARGS__))
+
+/* Declare the function prototype. The first argument is the return value,
+ * the remaining arguments are the function parameters. Naming parameters
+ * is optional. */
+#define declare_func(ret, ...)\
+    declare_new(ret, __VA_ARGS__)\
+    void *func_ref, *func_new;\
+    typedef ret func_type(__VA_ARGS__);\
+    checkasm_save_context()
+
+/* Indicate that the current test has failed */
+#define fail() checkasm_fail_func("%s:%d", __FILE__, __LINE__)
+
+/* Print the test outcome */
+#define report checkasm_report
+
+/* Call the reference function */
+#define call_ref(...)\
+    (checkasm_set_signal_handler_state(1),\
+     ((func_type *)func_ref)(__VA_ARGS__));\
+    checkasm_set_signal_handler_state(0)
+
+#if HAVE_ASM
+#if ARCH_X86
+#if defined(_MSC_VER) && !defined(__clang__)
+#include <intrin.h>
+#define readtime() (_mm_lfence(), __rdtsc())
+#else
+static inline uint64_t readtime(void) {
+    uint32_t eax, edx;
+    __asm__ __volatile__("lfence\nrdtsc" : "=a"(eax), "=d"(edx));
+    return (((uint64_t)edx) << 32) | eax;
+}
+#define readtime readtime
+#endif
+#elif (ARCH_AARCH64 || ARCH_ARM) && defined(__APPLE__)
+#include <mach/mach_time.h>
+#define readtime() mach_absolute_time()
+#elif ARCH_AARCH64
+#ifdef _MSC_VER
+#include <windows.h>
+#define readtime() (_InstructionSynchronizationBarrier(), ReadTimeStampCounter())
+#else
+static inline uint64_t readtime(void) {
+    uint64_t cycle_counter;
+    /* This requires enabling user mode access to the cycle counter (which
+     * can only be done from kernel space).
+     * This could also read cntvct_el0 instead of pmccntr_el0; that register
+     * might also be readable (depending on kernel version), but it has much
+     * worse precision (it's a fixed 50 MHz timer). */
+    __asm__ __volatile__("isb\nmrs %0, pmccntr_el0"
+                         : "=r"(cycle_counter)
+                         :: "memory");
+    return cycle_counter;
+}
+#define readtime readtime
+#endif
+#elif ARCH_ARM && !defined(_MSC_VER) && __ARM_ARCH >= 7
+static inline uint64_t readtime(void) {
+    uint32_t cycle_counter;
+    /* This requires enabling user mode access to the cycle counter (which
+     * can only be done from kernel space). */
+    __asm__ __volatile__("isb\nmrc p15, 0, %0, c9, c13, 0"
+                         : "=r"(cycle_counter)
+                         :: "memory");
+    return cycle_counter;
+}
+#define readtime readtime
+#elif ARCH_PPC64LE
+static inline uint64_t readtime(void) {
+    uint32_t tbu, tbl, temp;
+
+    __asm__ __volatile__(
+        "1:\n"
+        "mfspr %2,269\n"
+        "mfspr %0,268\n"
+        "mfspr %1,269\n"
+        "cmpw   %2,%1\n"
+        "bne    1b\n"
+    : "=r"(tbl), "=r"(tbu), "=r"(temp)
+    :
+    : "cc");
+
+    return (((uint64_t)tbu) << 32) | (uint64_t)tbl;
+}
+#define readtime readtime
+#endif
+
+/* Verifies that clobbered callee-saved registers
+ * are properly saved and restored */
+void checkasm_checked_call(void *func, ...);
+
+#if ARCH_X86_64
+/* YMM and ZMM registers on x86 are turned off to save power when they haven't
+ * been used for some period of time. When they are used there will be a
+ * "warmup" period during which performance will be reduced and inconsistent
+ * which is problematic when trying to benchmark individual functions. We can
+ * work around this by periodically issuing "dummy" instructions that uses
+ * those registers to keep them powered on. */
+void checkasm_simd_warmup(void);
+
+/* The upper 32 bits of 32-bit data types are undefined when passed as function
+ * parameters. In practice those bits usually end up being zero which may hide
+ * certain bugs, such as using a register containing undefined bits as a pointer
+ * offset, so we want to intentionally clobber those bits with junk to expose
+ * any issues. The following set of macros automatically calculates a bitmask
+ * specifying which parameters should have their upper halves clobbered. */
+#ifdef _WIN32
+/* Integer and floating-point parameters share "register slots". */
+#define IGNORED_FP_ARGS 0
+#else
+/* Up to 8 floating-point parameters are passed in XMM registers, which are
+ * handled orthogonally from integer parameters passed in GPR registers. */
+#define IGNORED_FP_ARGS 8
+#endif
+#ifdef HAVE_C11_GENERIC
+#define clobber_type(arg) _Generic((void (*)(void*, arg))NULL,\
+     void (*)(void*, int32_t ): clobber_mask |= 1 << mpos++,\
+     void (*)(void*, uint32_t): clobber_mask |= 1 << mpos++,\
+     void (*)(void*, float   ): mpos += (fp_args++ >= IGNORED_FP_ARGS),\
+     void (*)(void*, double  ): mpos += (fp_args++ >= IGNORED_FP_ARGS),\
+     default:                   mpos++)
+#define init_clobber_mask(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, ...)\
+    unsigned clobber_mask = 0;\
+    {\
+        int mpos = 0, fp_args = 0;\
+        clobber_type(a); clobber_type(b); clobber_type(c); clobber_type(d);\
+        clobber_type(e); clobber_type(f); clobber_type(g); clobber_type(h);\
+        clobber_type(i); clobber_type(j); clobber_type(k); clobber_type(l);\
+        clobber_type(m); clobber_type(n); clobber_type(o); clobber_type(p);\
+    }
+#else
+/* Skip parameter clobbering on compilers without support for _Generic() */
+#define init_clobber_mask(...) unsigned clobber_mask = 0
+#endif
+#define declare_new(ret, ...)\
+    ret (*checked_call)(__VA_ARGS__, int, int, int, int, int, int, int,\
+                        int, int, int, int, int, int, int, int, int,\
+                        void*, unsigned) =\
+        (void*)checkasm_checked_call;\
+    init_clobber_mask(__VA_ARGS__, void*, void*, void*, void*,\
+                      void*, void*, void*, void*, void*, void*,\
+                      void*, void*, void*, void*, void*);
+#define call_new(...)\
+    (checkasm_set_signal_handler_state(1),\
+     checkasm_simd_warmup(),\
+     checked_call(__VA_ARGS__, 16, 15, 14, 13, 12, 11, 10, 9, 8,\
+                  7, 6, 5, 4, 3, 2, 1, func_new, clobber_mask));\
+    checkasm_set_signal_handler_state(0)
+#elif ARCH_X86_32
+#define declare_new(ret, ...)\
+    ret (*checked_call)(void *, __VA_ARGS__, int, int, int, int, int, int,\
+                        int, int, int, int, int, int, int, int, int) =\
+        (void *)checkasm_checked_call;
+#define call_new(...)\
+    (checkasm_set_signal_handler_state(1),\
+     checked_call(func_new, __VA_ARGS__, 15, 14, 13, 12,\
+                  11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1));\
+    checkasm_set_signal_handler_state(0)
+#elif ARCH_ARM
+/* Use a dummy argument, to offset the real parameters by 2, not only 1.
+ * This makes sure that potential 8-byte-alignment of parameters is kept
+ * the same even when the extra parameters have been removed. */
+void checkasm_checked_call_vfp(void *func, int dummy, ...);
+#define declare_new(ret, ...)\
+    ret (*checked_call)(void *, int dummy, __VA_ARGS__,\
+                        int, int, int, int, int, int, int, int,\
+                        int, int, int, int, int, int, int) =\
+    (void *)checkasm_checked_call_vfp;
+#define call_new(...)\
+    (checkasm_set_signal_handler_state(1),\
+     checked_call(func_new, 0, __VA_ARGS__, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0));\
+    checkasm_set_signal_handler_state(0)
+#elif ARCH_AARCH64 && !defined(__APPLE__)
+void checkasm_stack_clobber(uint64_t clobber, ...);
+#define declare_new(ret, ...)\
+    ret (*checked_call)(void *, int, int, int, int, int, int, int,\
+                        __VA_ARGS__, int, int, int, int, int, int, int, int,\
+                        int, int, int, int, int, int, int) =\
+    (void *)checkasm_checked_call;
+#define CLOB (UINT64_C(0xdeadbeefdeadbeef))
+#define call_new(...)\
+    (checkasm_set_signal_handler_state(1),\
+     checkasm_stack_clobber(CLOB, CLOB, CLOB, CLOB, CLOB, CLOB,\
+                            CLOB, CLOB, CLOB, CLOB, CLOB, CLOB,\
+                            CLOB, CLOB, CLOB, CLOB, CLOB, CLOB,\
+                            CLOB, CLOB, CLOB, CLOB, CLOB),\
+     checked_call(func_new, 0, 0, 0, 0, 0, 0, 0, __VA_ARGS__,\
+                  7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0));\
+    checkasm_set_signal_handler_state(0)
+#else
+#define declare_new(ret, ...)
+#define call_new(...)\
+    (checkasm_set_signal_handler_state(1),\
+     ((func_type *)func_new)(__VA_ARGS__));\
+    checkasm_set_signal_handler_state(0)
+#endif
+#else /* HAVE_ASM */
+#define declare_new(ret, ...)
+/* Call the function */
+#define call_new(...)\
+    (checkasm_set_signal_handler_state(1),\
+     ((func_type *)func_new)(__VA_ARGS__));\
+    checkasm_set_signal_handler_state(0)
+#endif /* HAVE_ASM */
+
+/* Benchmark the function */
+#ifdef readtime
+#define bench_new(...)\
+    do {\
+        if (checkasm_bench_func()) {\
+            func_type *const tfunc = func_new;\
+            checkasm_set_signal_handler_state(1);\
+            uint64_t tsum = 0;\
+            int tcount = 0;\
+            for (int ti = 0; ti < BENCH_RUNS; ti++) {\
+                uint64_t t = readtime();\
+                int talt = 0; (void)talt;\
+                tfunc(__VA_ARGS__);\
+                talt = 1;\
+                tfunc(__VA_ARGS__);\
+                talt = 0;\
+                tfunc(__VA_ARGS__);\
+                talt = 1;\
+                tfunc(__VA_ARGS__);\
+                t = readtime() - t;\
+                if (t*tcount <= tsum*4 && ti > 0) {\
+                    tsum += t;\
+                    tcount++;\
+                }\
+            }\
+            checkasm_set_signal_handler_state(0);\
+            checkasm_update_bench(tcount, tsum);\
+        } else {\
+            const int talt = 0; (void)talt;\
+            call_new(__VA_ARGS__);\
+        }\
+    } while (0)
+#else
+#define bench_new(...) do {} while (0)
+#endif
+
+/* Alternates between two pointers. Intended to be used within bench_new()
+ * calls for functions which modifies their input buffer(s) to ensure that
+ * throughput, and not latency, is measured. */
+#define alternate(a, b) (talt ? (b) : (a))
+
+#define ROUND_UP(x,a) (((x)+((a)-1)) & ~((a)-1))
+#define PIXEL_RECT(name, w, h) \
+    ALIGN_STK_64(pixel, name##_buf, ((h)+32)*(ROUND_UP(w,64)+64) + 64,); \
+    ptrdiff_t name##_stride = sizeof(pixel)*(ROUND_UP(w,64)+64); \
+    (void)name##_stride; \
+    pixel *name = name##_buf + (ROUND_UP(w,64)+64)*16 + 64
+
+#define CLEAR_PIXEL_RECT(name) \
+    memset(name##_buf, 0x99, sizeof(name##_buf)) \
+
+#define DECL_CHECKASM_CHECK_FUNC(type) \
+int checkasm_check_##type(const char *const file, const int line, \
+                          const type *const buf1, const ptrdiff_t stride1, \
+                          const type *const buf2, const ptrdiff_t stride2, \
+                          const int w, const int h, const char *const name, \
+                          const int align_w, const int align_h, \
+                          const int padding)
+
+DECL_CHECKASM_CHECK_FUNC(int8_t);
+DECL_CHECKASM_CHECK_FUNC(int16_t);
+DECL_CHECKASM_CHECK_FUNC(int32_t);
+DECL_CHECKASM_CHECK_FUNC(uint8_t);
+DECL_CHECKASM_CHECK_FUNC(uint16_t);
+DECL_CHECKASM_CHECK_FUNC(uint32_t);
+
+#define CONCAT(a,b) a ## b
+
+#define checkasm_check2(prefix, ...) CONCAT(checkasm_check_, prefix)(__FILE__, __LINE__, __VA_ARGS__)
+#define checkasm_check(prefix, ...) checkasm_check2(prefix, __VA_ARGS__, 0, 0, 0)
+
+#ifdef BITDEPTH
+#define checkasm_check_pixel(...) checkasm_check(PIXEL_TYPE, __VA_ARGS__)
+#define checkasm_check_pixel_padded(...) checkasm_check2(PIXEL_TYPE, __VA_ARGS__, 1, 1, 8)
+#define checkasm_check_pixel_padded_align(...) checkasm_check2(PIXEL_TYPE, __VA_ARGS__, 8)
+#define checkasm_check_coef(...)  checkasm_check(COEF_TYPE,  __VA_ARGS__)
+#endif
+
+#endif /* DAV1D_TESTS_CHECKASM_CHECKASM_H */

--- a/checkasm/checkasm.h
+++ b/checkasm/checkasm.h
@@ -56,6 +56,7 @@
 int xor128_rand(void);
 #define rnd xor128_rand
 
+void checkasm_check_rasterizer(unsigned cpu_flag);
 void checkasm_check_blend_bitmaps(unsigned cpu_flag);
 void checkasm_check_be_blur(unsigned cpu_flag);
 void checkasm_check_blur(unsigned cpu_flag);

--- a/checkasm/checkasm.h
+++ b/checkasm/checkasm.h
@@ -58,6 +58,7 @@ int xor128_rand(void);
 
 void checkasm_check_blend_bitmaps(unsigned cpu_flag);
 void checkasm_check_be_blur(unsigned cpu_flag);
+void checkasm_check_blur(unsigned cpu_flag);
 
 void *checkasm_check_func(void *func, const char *name, ...);
 int checkasm_bench_func(void);

--- a/checkasm/checkasm.h
+++ b/checkasm/checkasm.h
@@ -80,7 +80,7 @@ int float_near_abs_eps_array(const float *a, const float *b, float eps,
 int float_near_abs_eps_array_ulp(const float *a, const float *b, float eps,
                                  unsigned max_ulp, int len);
 
-#define BENCH_RUNS (1 << 12) /* Trade-off between accuracy and speed */
+#define BENCH_RUNS (1 << 16) /* Trade-off between accuracy and speed */
 
 /* Decide whether or not the specified function needs to be tested */
 #define check_func(func, ...)\

--- a/checkasm/rasterizer.c
+++ b/checkasm/rasterizer.c
@@ -1,0 +1,210 @@
+/*
+ * Copyright (C) 2021-2022 libass contributors
+ *
+ * This file is part of libass.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "checkasm.h"
+#include "ass_rasterizer.h"
+
+#define HEIGHT 34
+#define STRIDE 96
+#define BORD_X 32
+#define BORD_Y 1
+#define REP_COUNT 8
+#define MAX_SEG 8
+
+
+static void generate_segment(struct segment *line, int tile_size, int y1, int y2)
+{
+    unsigned flags = rnd();
+    line->a = rnd() & 0x3FFFFFFF;
+    line->b = rnd() & 0x3FFFFFFF;
+    if (flags % 3u != 1)
+        line->a |= 0x40000000;
+    if (flags % 3u != 2)
+        line->b |= 0x40000000;
+    int32_t max_ab = FFMAX(line->a, line->b);  // 2^30 <= max_ab < 2^31
+    if (flags & 1)
+        line->a = -line->a;
+    if (flags & 2)
+        line->b = -line->b;
+
+    int mask = (64 * tile_size << 16) - 1;
+    int x = rnd() & mask, y = rnd() & mask;
+    line->c = (line->a * (int64_t) x + line->b * (int64_t) y + (1 << 15)) >> 16;
+    // |line->c| <= 2^(tile_order + 7) * max_ab < 2^(tile_order + 38)
+
+#if 0
+    line->scale = ((uint64_t) 1 << 60) / max_ab;
+#else
+    line->scale = (rnd() & 0x1FFFFFFF) | 0x20000000;
+    if (line->scale * (uint64_t) max_ab > (uint64_t) 1 << 60)
+        line->scale ^= 0x20000000;
+#endif
+
+    line->flags = flags & 4 ? SEGFLAG_EXACT_LEFT : 0;  // only left is used
+    if (line->a >= 0)
+        line->flags ^= SEGFLAG_DN | SEGFLAG_UL_DR;
+    if (line->b > 0)
+        line->flags ^= SEGFLAG_UL_DR;
+
+    line->x_min = flags & 8 ? 0x1234ABCD : 0;
+    line->x_max = 0xDEADC0DE;  // not used
+
+    y1 &= 64 * tile_size - 1;
+    y2 &= 64 * tile_size - 1;
+    line->y_min = FFMIN(y1, y2 + 1);
+    line->y_max = FFMAX(y1, y2 + 1);
+}
+
+
+static void check_fill_solid(FillSolidTileFunc func, const char *name, int tile_size)
+{
+    ALIGN(uint8_t buf_ref[STRIDE * HEIGHT], 32);
+    ALIGN(uint8_t buf_new[STRIDE * HEIGHT], 32);
+    declare_func(void,
+                 uint8_t *buf, ptrdiff_t stride, int set);
+
+    if (check_func(func, name, tile_size)) {
+        for(int set = 0; set <= 1; set++) {
+            for (int i = 0; i < sizeof(buf_ref); i++)
+                buf_ref[i] = buf_new[i] = rnd();
+
+            call_ref(buf_ref + BORD_Y * STRIDE + BORD_X, STRIDE, set);
+            call_new(buf_new + BORD_Y * STRIDE + BORD_X, STRIDE, set);
+
+            if (memcmp(buf_ref, buf_new, sizeof(buf_ref))) {
+                fail();
+                break;
+            }
+        }
+
+        bench_new(buf_new + BORD_Y * STRIDE + BORD_X, STRIDE, 1);
+    }
+
+    report(name, tile_size);
+}
+
+static void check_fill_halfplane(FillHalfplaneTileFunc func, const char *name, int tile_size)
+{
+    struct segment line;
+    ALIGN(uint8_t buf_ref[STRIDE * HEIGHT], 32);
+    ALIGN(uint8_t buf_new[STRIDE * HEIGHT], 32);
+    declare_func(void,
+                 uint8_t *buf, ptrdiff_t stride,
+                 int32_t a, int32_t b, int64_t c, int32_t scale);
+
+    if (check_func(func, name, tile_size)) {
+        for(int rep = 0; rep < REP_COUNT; rep++) {
+            for (int i = 0; i < sizeof(buf_ref); i++)
+                buf_ref[i] = buf_new[i] = rnd();
+
+            generate_segment(&line, tile_size, 0, 0);
+            call_ref(buf_ref + BORD_Y * STRIDE + BORD_X, STRIDE, line.a, line.b, line.c, line.scale);
+            call_new(buf_new + BORD_Y * STRIDE + BORD_X, STRIDE, line.a, line.b, line.c, line.scale);
+
+            if (memcmp(buf_ref, buf_new, sizeof(buf_ref))) {
+                fail();
+                break;
+            }
+        }
+
+        bench_new(buf_new + BORD_Y * STRIDE + BORD_X, STRIDE, line.a, line.b, line.c, line.scale);
+    }
+
+    report(name, tile_size);
+}
+
+static void check_fill_generic(FillGenericTileFunc func, const char *name, int tile_size)
+{
+    struct segment line[MAX_SEG];
+    ALIGN(uint8_t buf_ref[STRIDE * HEIGHT], 32);
+    ALIGN(uint8_t buf_new[STRIDE * HEIGHT], 32);
+    declare_func(void,
+                 uint8_t *buf, ptrdiff_t stride,
+                 const struct segment *line, size_t n_lines,
+                 int winding);
+
+    if (check_func(func, name, tile_size)) {
+        for(int rep = 0; rep < REP_COUNT; rep++) {
+            for (int i = 0; i < sizeof(buf_ref); i++)
+                buf_ref[i] = buf_new[i] = rnd();
+
+            int n = rnd() % MAX_SEG + 1;
+            for (int i = 0; i < n; i++)
+                generate_segment(line + i, tile_size, rnd(), rnd());
+
+            int winding = rnd() % 5 - 2;
+            call_ref(buf_ref + BORD_Y * STRIDE + BORD_X, STRIDE, line, n, winding);
+            call_new(buf_new + BORD_Y * STRIDE + BORD_X, STRIDE, line, n, winding);
+
+            if (memcmp(buf_ref, buf_new, sizeof(buf_ref))) {
+                fail();
+                break;
+            }
+        }
+
+        generate_segment(line + 0, tile_size, 3 * 64 + 0, 7 * 64 - 1);
+        generate_segment(line + 1, tile_size, 3 * 64 + 5, 7 * 64 - 5);
+        generate_segment(line + 2, tile_size, 5 * 64 + 3, 5 * 64 + 9);
+        generate_segment(line + 3, tile_size, 5 * 64 + 9, 5 * 64 + 8);
+        bench_new(buf_new + BORD_Y * STRIDE + BORD_X, STRIDE, line, 4, 0);
+    }
+
+    report(name, tile_size);
+}
+
+static void check_merge_tile(MergeTileFunc func, const char *name, int tile_size)
+{
+    ALIGN(uint8_t src[32 * 32], 32);
+    ALIGN(uint8_t buf_ref[STRIDE * HEIGHT], 32);
+    ALIGN(uint8_t buf_new[STRIDE * HEIGHT], 32);
+    declare_func(void,
+                 uint8_t *buf, ptrdiff_t stride, const uint8_t *tile);
+
+    if (check_func(func, name, tile_size)) {
+        for (int i = 0; i < sizeof(src); i++)
+            src[i] = rnd();
+        for (int i = 0; i < sizeof(buf_ref); i++)
+            buf_ref[i] = buf_new[i] = rnd();
+
+        call_ref(buf_ref + BORD_Y * STRIDE + BORD_X, STRIDE, src);
+        call_new(buf_new + BORD_Y * STRIDE + BORD_X, STRIDE, src);
+
+        if (memcmp(buf_ref, buf_new, sizeof(buf_ref)))
+            fail();
+
+        bench_new(buf_new + BORD_Y * STRIDE + BORD_X, STRIDE, src);
+    }
+
+    report(name, tile_size);
+}
+
+
+void checkasm_check_rasterizer(unsigned cpu_flag)
+{
+    BitmapEngine engine[2] = {
+        ass_bitmap_engine_init(cpu_flag),
+        ass_bitmap_engine_init(cpu_flag | ASS_FLAG_LARGE_TILES)
+    };
+    for (int i = 0; i < 2; i++) {
+        int tile_size = 1 << engine[i].tile_order;
+        check_fill_solid(engine[i].fill_solid, "fill_solid_tile%d", tile_size);
+        check_fill_halfplane(engine[i].fill_halfplane, "fill_halfplane_tile%d", tile_size);
+        check_fill_generic(engine[i].fill_generic, "fill_generic_tile%d", tile_size);
+        check_merge_tile(engine[i].merge, "merge_tile%d", tile_size);
+    }
+}

--- a/checkasm/x86/checkasm.asm
+++ b/checkasm/x86/checkasm.asm
@@ -1,0 +1,475 @@
+; Copyright © 2018, VideoLAN and dav1d authors
+; Copyright © 2018, Two Orioles, LLC
+; All rights reserved.
+;
+; Redistribution and use in source and binary forms, with or without
+; modification, are permitted provided that the following conditions are met:
+;
+; 1. Redistributions of source code must retain the above copyright notice, this
+;    list of conditions and the following disclaimer.
+;
+; 2. Redistributions in binary form must reproduce the above copyright notice,
+;    this list of conditions and the following disclaimer in the documentation
+;    and/or other materials provided with the distribution.
+;
+; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+; ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+; WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+; DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+; ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+; (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+; ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+; (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+; SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+%include "config.asm"
+%undef private_prefix
+%define private_prefix checkasm
+%include "ext/x86/x86inc.asm"
+
+SECTION_RODATA 16
+
+%if ARCH_X86_64
+; just random numbers to reduce the chance of incidental match
+%if WIN64
+x6:  dq 0x1a1b2550a612b48c,0x79445c159ce79064
+x7:  dq 0x2eed899d5a28ddcd,0x86b2536fcd8cf636
+x8:  dq 0xb0856806085e7943,0x3f2bf84fc0fcca4e
+x9:  dq 0xacbd382dcf5b8de2,0xd229e1f5b281303f
+x10: dq 0x71aeaff20b095fd9,0xab63e2e11fa38ed9
+x11: dq 0x89b0c0765892729a,0x77d410d5c42c882d
+x12: dq 0xc45ea11a955d8dd5,0x24b3c1d2a024048b
+x13: dq 0x2e8ec680de14b47c,0xdd7b8919edd42786
+x14: dq 0x135ce6888fa02cbf,0x11e53e2b2ac655ef
+x15: dq 0x011ff554472a7a10,0x6de8f4c914c334d5
+n7:  dq 0x21f86d66c8ca00ce
+n8:  dq 0x75b6ba21077c48ad
+%endif
+n9:  dq 0xed56bb2dcb3c7736
+n10: dq 0x8bda43d3fd1a7e06
+n11: dq 0xb64a9c9e5d318408
+n12: dq 0xdf9a54b303f1d3a3
+n13: dq 0x4a75479abd64e097
+n14: dq 0x249214109d5d1c88
+%endif
+
+errmsg_stack: db "stack corruption", 0
+errmsg_register: db "failed to preserve register:%s", 0
+errmsg_vzeroupper: db "missing vzeroupper", 0
+
+SECTION .bss
+
+check_vzeroupper: resd 1
+
+SECTION .text
+
+cextern fail_func
+
+; max number of args used by any asm function.
+; (max_args % 4) must equal 3 for stack alignment
+%define max_args 15
+
+%if UNIX64
+    DECLARE_REG_TMP 0
+%else
+    DECLARE_REG_TMP 4
+%endif
+
+;-----------------------------------------------------------------------------
+; unsigned checkasm_init_x86(char *name)
+;-----------------------------------------------------------------------------
+cglobal init_x86, 0, 5
+%if ARCH_X86_64
+    push          rbx
+%endif
+    movifnidn      t0, r0mp
+    mov           eax, 0x80000000
+    cpuid
+    cmp           eax, 0x80000004
+    jb .no_brand ; processor brand string not supported
+    mov           eax, 0x80000002
+    cpuid
+    mov     [t0+4* 0], eax
+    mov     [t0+4* 1], ebx
+    mov     [t0+4* 2], ecx
+    mov     [t0+4* 3], edx
+    mov           eax, 0x80000003
+    cpuid
+    mov     [t0+4* 4], eax
+    mov     [t0+4* 5], ebx
+    mov     [t0+4* 6], ecx
+    mov     [t0+4* 7], edx
+    mov           eax, 0x80000004
+    cpuid
+    mov     [t0+4* 8], eax
+    mov     [t0+4* 9], ebx
+    mov     [t0+4*10], ecx
+    mov     [t0+4*11], edx
+    xor           eax, eax
+    cpuid
+    jmp .check_xcr1
+.no_brand: ; use manufacturer id as a fallback
+    xor           eax, eax
+    mov      [t0+4*3], eax
+    cpuid
+    mov      [t0+4*0], ebx
+    mov      [t0+4*1], edx
+    mov      [t0+4*2], ecx
+.check_xcr1:
+    test          eax, eax
+    jz .end2 ; cpuid leaf 1 not supported
+    mov           t0d, eax ; max leaf
+    mov           eax, 1
+    cpuid
+    and           ecx, 0x18000000
+    cmp           ecx, 0x18000000
+    jne .end2 ; osxsave/avx not supported
+    cmp           t0d, 13 ; cpuid leaf 13 not supported
+    jb .end2
+    mov           t0d, eax ; cpuid signature
+    mov           eax, 13
+    mov           ecx, 1
+    cpuid
+    test           al, 0x04
+    jz .end ; xcr1 not supported
+    mov           ecx, 1
+    xgetbv
+    test           al, 0x04
+    jnz .end ; always-dirty ymm state
+%if ARCH_X86_64 == 0 && PIC
+    LEA           eax, check_vzeroupper
+    mov         [eax], ecx
+%else
+    mov [check_vzeroupper], ecx
+%endif
+.end:
+    mov           eax, t0d
+.end2:
+%if ARCH_X86_64
+    pop           rbx
+%endif
+    RET
+
+%if ARCH_X86_64
+%if WIN64
+    %define stack_param rsp+32 ; shadow space
+    %define num_fn_args rsp+stack_offset+17*8
+    %assign num_reg_args 4
+    %assign free_regs 7
+    %assign clobber_mask_stack_bit 16
+    DECLARE_REG_TMP 4
+%else
+    %define stack_param rsp
+    %define num_fn_args rsp+stack_offset+11*8
+    %assign num_reg_args 6
+    %assign free_regs 9
+    %assign clobber_mask_stack_bit 64
+    DECLARE_REG_TMP 7
+%endif
+
+%macro CLOBBER_UPPER 2 ; reg, mask_bit
+    mov          r13d, %1d
+    or            r13, r8
+    test          r9b, %2
+    cmovnz         %1, r13
+%endmacro
+
+cglobal checked_call, 2, 15, 16, max_args*8+64+8
+    mov          r10d, [num_fn_args]
+    mov            r8, 0xdeadbeef00000000
+    mov           r9d, [num_fn_args+r10*8+8] ; clobber_mask
+    mov            t0, [num_fn_args+r10*8]   ; func
+
+    ; Clobber the upper halves of 32-bit parameters
+    CLOBBER_UPPER  r0, 1
+    CLOBBER_UPPER  r1, 2
+    CLOBBER_UPPER  r2, 4
+    CLOBBER_UPPER  r3, 8
+%if UNIX64
+    CLOBBER_UPPER  r4, 16
+    CLOBBER_UPPER  r5, 32
+%else ; WIN64
+%assign i 6
+%rep 16-6
+    mova       m %+ i, [x %+ i]
+    %assign i i+1
+%endrep
+%endif
+
+    xor          r11d, r11d
+    sub          r10d, num_reg_args
+    cmovs        r10d, r11d ; num stack args
+
+    ; write stack canaries to the area above parameters passed on the stack
+    mov           r12, [rsp+stack_offset] ; return address
+    not           r12
+%assign i 0
+%rep 8 ; 64 bytes
+    mov [stack_param+(r10+i)*8], r12
+    %assign i i+1
+%endrep
+
+    test         r10d, r10d
+    jz .stack_setup_done ; no stack parameters
+.copy_stack_parameter:
+    mov           r12, [stack_param+stack_offset+8+r11*8]
+    CLOBBER_UPPER r12, clobber_mask_stack_bit
+    shr           r9d, 1
+    mov [stack_param+r11*8], r12
+    inc          r11d
+    cmp          r11d, r10d
+    jl .copy_stack_parameter
+.stack_setup_done:
+
+%assign i 14
+%rep 15-free_regs
+    mov        r %+ i, [n %+ i]
+    %assign i i-1
+%endrep
+    call           t0
+
+    ; check for stack corruption
+    mov           r0d, [num_fn_args]
+    xor           r3d, r3d
+    sub           r0d, num_reg_args
+    cmovs         r0d, r3d ; num stack args
+
+    mov            r3, [rsp+stack_offset]
+    mov            r4, [stack_param+r0*8]
+    not            r3
+    xor            r4, r3
+%assign i 1
+%rep 6
+    mov            r5, [stack_param+(r0+i)*8]
+    xor            r5, r3
+    or             r4, r5
+    %assign i i+1
+%endrep
+    xor            r3, [stack_param+(r0+7)*8]
+    or             r4, r3
+    jz .stack_ok
+    ; Save the return value located in rdx:rax first to prevent clobbering.
+    mov           r10, rax
+    mov           r11, rdx
+    lea            r0, [errmsg_stack]
+    jmp .fail
+.stack_ok:
+
+    ; check for failure to preserve registers
+%assign i 14
+%rep 15-free_regs
+    cmp        r %+ i, [n %+ i]
+    setne         r4b
+    lea           r3d, [r4+r3*2]
+    %assign i i-1
+%endrep
+%if WIN64
+    lea            r0, [rsp+32] ; account for shadow space
+    mov            r5, r0
+    test          r3d, r3d
+    jz .gpr_ok
+%else
+    test          r3d, r3d
+    jz .gpr_xmm_ok
+    mov            r0, rsp
+%endif
+%assign i free_regs
+%rep 15-free_regs
+%if i < 10
+    mov    dword [r0], " r0" + (i << 16)
+    lea            r4, [r0+3]
+%else
+    mov    dword [r0], " r10" + ((i - 10) << 24)
+    lea            r4, [r0+4]
+%endif
+    test          r3b, 1 << (i - free_regs)
+    cmovnz         r0, r4
+    %assign i i+1
+%endrep
+%if WIN64 ; xmm registers
+.gpr_ok:
+%assign i 6
+%rep 16-6
+    pxor       m %+ i, [x %+ i]
+    %assign i i+1
+%endrep
+    packsswb       m6, m7
+    packsswb       m8, m9
+    packsswb      m10, m11
+    packsswb      m12, m13
+    packsswb      m14, m15
+    packsswb       m6, m6
+    packsswb       m8, m10
+    packsswb      m12, m14
+    packsswb       m6, m6
+    packsswb       m8, m12
+    packsswb       m6, m8
+    pxor           m7, m7
+    pcmpeqb        m6, m7
+    pmovmskb      r3d, m6
+    cmp           r3d, 0xffff
+    je .xmm_ok
+    mov           r7d, " xmm"
+%assign i 6
+%rep 16-6
+    mov        [r0+0], r7d
+%if i < 10
+    mov   byte [r0+4], "0" + i
+    lea            r4, [r0+5]
+%else
+    mov   word [r0+4], "10" + ((i - 10) << 8)
+    lea            r4, [r0+6]
+%endif
+    test          r3d, 1 << i
+    cmovz          r0, r4
+    %assign i i+1
+%endrep
+.xmm_ok:
+    cmp            r0, r5
+    je .gpr_xmm_ok
+    mov     byte [r0], 0
+    mov           r11, rdx
+    mov            r1, r5
+%else
+    mov     byte [r0], 0
+    mov           r11, rdx
+    mov            r1, rsp
+%endif
+    mov           r10, rax
+    lea            r0, [errmsg_register]
+    jmp .fail
+.gpr_xmm_ok:
+    ; Check for dirty YMM state, i.e. missing vzeroupper
+    mov           ecx, [check_vzeroupper]
+    test          ecx, ecx
+    jz .ok ; not supported, skip
+    mov           r10, rax
+    mov           r11, rdx
+    xgetbv
+    test           al, 0x04
+    jz .restore_retval ; clean ymm state
+    lea            r0, [errmsg_vzeroupper]
+    vzeroupper
+.fail:
+    ; Call fail_func() with a descriptive message to mark it as a failure.
+    xor           eax, eax
+    call fail_func
+.restore_retval:
+    mov           rax, r10
+    mov           rdx, r11
+.ok:
+    RET
+
+; trigger a warmup of vector units
+%macro WARMUP 0
+cglobal warmup, 0, 0
+    xorps          m0, m0
+    mulps          m0, m0
+    RET
+%endmacro
+
+INIT_YMM avx2
+WARMUP
+INIT_ZMM avx512
+WARMUP
+
+%else
+
+; just random numbers to reduce the chance of incidental match
+%assign n3 0x6549315c
+%assign n4 0xe02f3e23
+%assign n5 0xb78d0d1d
+%assign n6 0x33627ba7
+
+;-----------------------------------------------------------------------------
+; void checkasm_checked_call(void *func, ...)
+;-----------------------------------------------------------------------------
+cglobal checked_call, 1, 7
+    mov            r3, [esp+stack_offset]      ; return address
+    mov            r1, [esp+stack_offset+17*4] ; num_stack_params
+    mov            r2, 27
+    not            r3
+    sub            r2, r1
+.push_canary:
+    push           r3
+    dec            r2
+    jg .push_canary
+.push_parameter:
+    push dword [esp+32*4]
+    dec            r1
+    jg .push_parameter
+    mov            r3, n3
+    mov            r4, n4
+    mov            r5, n5
+    mov            r6, n6
+    call           r0
+
+    ; check for failure to preserve registers
+    cmp            r3, n3
+    setne         r3h
+    cmp            r4, n4
+    setne         r3b
+    shl           r3d, 16
+    cmp            r5, n5
+    setne         r3h
+    cmp            r6, n6
+    setne         r3b
+    test           r3, r3
+    jz .gpr_ok
+    lea            r1, [esp+16]
+    mov       [esp+4], r1
+%assign i 3
+%rep 4
+    mov    dword [r1], " r0" + (i << 16)
+    lea            r4, [r1+3]
+    test           r3, 1 << ((6 - i) * 8)
+    cmovnz         r1, r4
+    %assign i i+1
+%endrep
+    mov     byte [r1], 0
+    mov            r5, eax
+    mov            r6, edx
+    LEA            r1, errmsg_register
+    jmp .fail
+.gpr_ok:
+    ; check for stack corruption
+    mov            r3, [esp+48*4] ; num_stack_params
+    mov            r6, [esp+31*4] ; return address
+    mov            r4, [esp+r3*4]
+    sub            r3, 26
+    not            r6
+    xor            r4, r6
+.check_canary:
+    mov            r5, [esp+(r3+27)*4]
+    xor            r5, r6
+    or             r4, r5
+    inc            r3
+    jl .check_canary
+    mov            r5, eax
+    mov            r6, edx
+    test           r4, r4
+    jz .stack_ok
+    LEA            r1, errmsg_stack
+    jmp .fail
+.stack_ok:
+    ; check for dirty YMM state, i.e. missing vzeroupper
+    LEA           ecx, check_vzeroupper
+    mov           ecx, [ecx]
+    test          ecx, ecx
+    jz .ok ; not supported, skip
+    xgetbv
+    test           al, 0x04
+    jz .ok ; clean ymm state
+    LEA            r1, errmsg_vzeroupper
+    vzeroupper
+.fail:
+    mov         [esp], r1
+    call fail_func
+.ok:
+    add           esp, 27*4
+    mov           eax, r5
+    mov           edx, r6
+    RET
+
+%endif ; ARCH_X86_64

--- a/checkasm/x86/checkasm.asm
+++ b/checkasm/x86/checkasm.asm
@@ -23,10 +23,8 @@
 ; (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 ; SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-%include "config.asm"
-%undef private_prefix
 %define private_prefix checkasm
-%include "ext/x86/x86inc.asm"
+%include "x86/x86inc.asm"
 
 SECTION_RODATA 16
 

--- a/configure.ac
+++ b/configure.ac
@@ -364,6 +364,8 @@ AM_CONDITIONAL([ENABLE_COMPARE], [test "x$enable_compare" = xyes && test "x$libp
 AM_CONDITIONAL([ENABLE_TEST], [test "x$enable_test" = xyes && test "x$libpng" = xtrue])
 AM_CONDITIONAL([ENABLE_PROFILE], [test "x$enable_profile" = xyes])
 AM_CONDITIONAL([ENABLE_FUZZ], [test "x$enable_fuzz" = xyes])
+# tcc doesn't have the full support of __attribute__((aligned(32)))
+AM_CONDITIONAL([ENABLE_CHECKASM], [test "x$can_asm" = xtrue && test "x$GCC" = xyes])
 
 AM_CONDITIONAL([FONTCONFIG], [test "x$fontconfig" = xtrue])
 AM_CONDITIONAL([CORETEXT], [test "x$coretext" = xtrue])
@@ -374,6 +376,9 @@ AM_COND_IF([ASM], [
     AC_DEFINE(CONFIG_ASM, 1, [ASM enabled])
     AM_COND_IF([X86], [
         AC_DEFINE(ARCH_X86, 1, [targeting a 32- or 64-bit x86 host architecture])
+    ])
+    AM_COND_IF([X86_64], [
+        AC_DEFINE(ARCH_X86_64, 1, [targeting a 64-bit x86 host architecture])
     ])
     AM_COND_IF([AARCH64], [
         AC_DEFINE(ARCH_AARCH64, 1, [targeting a 64-bit arm host architecture])

--- a/libass/Makefile_library.am
+++ b/libass/Makefile_library.am
@@ -2,10 +2,6 @@ LIBASS_LT_CURRENT = 11
 LIBASS_LT_REVISION = 1
 LIBASS_LT_AGE = 2
 
-nasm_verbose = $(nasm_verbose_$(V))
-nasm_verbose_ = $(nasm_verbose_$(AM_DEFAULT_VERBOSITY))
-nasm_verbose_0 = @echo "  NASM    " $@;
-
 .asm.lo:
 	$(nasm_verbose)$(LIBTOOL) $(AM_V_lt) --tag=CC --mode=compile $(top_srcdir)/ltnasm.sh $(AS) $(ASFLAGS) -I$(top_srcdir)/libass/ -Dprivate_prefix=ass -o $@ $<
 


### PR DESCRIPTION
Leftover from my checkasm branch. Changes from my previous version:
- updated to current dav1d source (`readtime` for macos is already there, so one less thing to worry);
- simplified rasterizer check (no copy-paste from actual rasterizer code).

As for `BENCH_RUNS` count, I feel that it's not enough: even with `(1 << 16)` and `rdtsc` from x86 there's quite large variation in results. I think the whole timing logic should be modified. Currently it's
```c
uint64_t tsum = 0;
int tcount = 0;
for (int ti = 0; ti < BENCH_RUNS; ti++) {
    uint64_t t = readtime();
    test_func(...);
    test_func(...);
    test_func(...);
    test_func(...);
    t = readtime() - t;
    if (some_black_magic) {
        tsum += t;
        tcount++;
    }
}
```
Basically, it's 4 inner timed iterations plus `BENCH_RUNS` outer iterations with "clever" averaging of the results (skipping of some partial timings). I think the following would be more stable, but I've not checked it yet:
```c
uint64_t tmin = -1;
for (int to = 0; to < OUTER_RUNS; to++) {
    uint64_t t = readtime();
    for (int ti = 0; ti < INNER_RUNS; ti++) {
        test_func(...);
        test_func(...);
        test_func(...);
        test_func(...);
    }
    t = readtime() - t;
    if (t < tmin)
        tmin = t;
}
```

Another point of concern is ABI check for `aarch64[_be]` (`checkasm_stack_clobber()`, `checked_call()`, etc.). It's explicitly disabled for macos and it's crashing under `aarch64_be` NetBSD from earlier. It's quite useful to disable completely, so I think I should look into it and try to understand what's going on there.