### PR TITLE
Simpler OS/2 table access

### DIFF
--- a/libass/ass_font.c
+++ b/libass/ass_font.c
@@ -504,7 +504,7 @@ void ass_face_set_size(FT_Face face, double size)
 int ass_face_get_weight(FT_Face face)
 {
     TT_OS2 *os2 = FT_Get_Sfnt_Table(face, FT_SFNT_OS2);
-    if (os2 && os2->version != 0xffff && os2->usWeightClass)
+    if (os2 && os2->usWeightClass)
         return os2->usWeightClass;
     else
         return 300 * !!(face->style_flags & FT_STYLE_FLAG_BOLD) + 400;


### PR DESCRIPTION
@rcombs You introduced the code in `ass_get_font_weight` in https://github.com/libass/libass/pull/316/commits/6c4dca2c8ed20d02ac877d55fe25d7db13ace615, but it wasn’t consistent with our pre-existing uses of the OS/2 table, so this makes them consistent. I don’t think the `version != 0xffff` check does anything useful. I’ve tried to guess why you may have originally included it; see the commit message: does that sound plausible?

Cc @moi15moi: you’ve asked me about the version check.