### PR TITLE
Improve weight and faux-italic compatibility with VSFilter

### DIFF
--- a/libass/ass_font.c
+++ b/libass/ass_font.c
@@ -504,10 +504,31 @@ void ass_face_set_size(FT_Face face, double size)
 int ass_face_get_weight(FT_Face face)
 {
     TT_OS2 *os2 = FT_Get_Sfnt_Table(face, FT_SFNT_OS2);
-    if (os2 && os2->usWeightClass)
-        return os2->usWeightClass;
-    else
+    FT_UShort os2Weight = os2 ? os2->usWeightClass : 0;
+    switch (os2Weight) {
+    case 0:
         return 300 * !!(face->style_flags & FT_STYLE_FLAG_BOLD) + 400;
+    case 1:
+        return 100;
+    case 2:
+        return 200;
+    case 3:
+        return 300;
+    case 4:
+        return 350;
+    case 5:
+        return 400;
+    case 6:
+        return 600;
+    case 7:
+        return 700;
+    case 8:
+        return 800;
+    case 9:
+        return 900;
+    default:
+        return os2Weight;
+    }
 }
 
 /**

--- a/libass/ass_font.c
+++ b/libass/ass_font.c
@@ -560,6 +560,21 @@ static void ass_glyph_embolden(FT_GlyphSlot slot)
 }
 
 /**
+ * Slightly italicize a glyph
+ */
+static void ass_glyph_italicize(FT_GlyphSlot slot)
+{
+    FT_Matrix xfrm = {
+        .xx = 0x10000L,
+        .yx = 0x00000L,
+        .xy = 0x05700L,
+        .yy = 0x10000L,
+    };
+
+    FT_Outline_Transform(&slot->outline, &xfrm);
+}
+
+/**
  * \brief Get glyph and face index
  * Finds a face that has the requested codepoint and returns both face
  * and glyph index.
@@ -662,7 +677,7 @@ bool ass_font_get_glyph(ASS_Font *font, int face_index, int index,
         return false;
     }
     if (!(face->style_flags & FT_STYLE_FLAG_ITALIC) && (font->desc.italic > 55))
-        FT_GlyphSlot_Oblique(face->glyph);
+        ass_glyph_italicize(face->glyph);
     if (font->desc.bold > ass_face_get_weight(face) + 150)
         ass_glyph_embolden(face->glyph);
     return true;


### PR DESCRIPTION
- Match GDI's special-case behavior for font weight values from 1 to 9.
- Match GDI's italicization transform matrix.

Both issues are demonstrated in the attached file:
[With_Jester.mkv.zip](https://github.com/libass/libass/files/10475605/With_Jester.mkv.zip)

This font used has weight 5.
[Jester Original.ttf.zip](https://github.com/libass/libass/files/10475612/Jester.Original.ttf.zip)

VSFilter rendering:
![im6bZ3sR](https://user-images.githubusercontent.com/819638/213942549-79e6fd21-4e22-4083-b7ab-f3e8c5068d02.jpg)

Current libass rendering (faux-bolded unnecessarily; sheared roughly 12 degrees rather than vsfilter's 20):
![8KbSGDdI](https://user-images.githubusercontent.com/819638/213942583-769799a5-5378-496a-8175-3c3526304e69.jpg)

With this PR (perfect match):
![italic-new7](https://user-images.githubusercontent.com/819638/213942588-be2b3765-3372-4521-9b2b-dce251755f66.png)
