### PR TITLE
directwrite: read metadata on our own, use DirectWrite-reported name as fallback

### DIFF
--- a/libass/ass_directwrite.c
+++ b/libass/ass_directwrite.c
@@ -580,23 +580,6 @@ static char *get_fallback(void *priv, ASS_Library *lib,
     return family;
 }
 
-static int map_width(enum DWRITE_FONT_STRETCH stretch)
-{
-    switch (stretch) {
-    case DWRITE_FONT_STRETCH_ULTRA_CONDENSED: return 50;
-    case DWRITE_FONT_STRETCH_EXTRA_CONDENSED: return 63;
-    case DWRITE_FONT_STRETCH_CONDENSED:       return FONT_WIDTH_CONDENSED;
-    case DWRITE_FONT_STRETCH_SEMI_CONDENSED:  return 88;
-    case DWRITE_FONT_STRETCH_MEDIUM:          return FONT_WIDTH_NORMAL;
-    case DWRITE_FONT_STRETCH_SEMI_EXPANDED:   return 113;
-    case DWRITE_FONT_STRETCH_EXPANDED:        return FONT_WIDTH_EXPANDED;
-    case DWRITE_FONT_STRETCH_EXTRA_EXPANDED:  return 150;
-    case DWRITE_FONT_STRETCH_ULTRA_EXPANDED:  return 200;
-    default:
-        return FONT_WIDTH_NORMAL;
-    }
-}
-
 #define FONT_TYPE IDWriteFontFace3
 #include "ass_directwrite_info_template.h"
 #undef FONT_TYPE

--- a/libass/ass_directwrite.c
+++ b/libass/ass_directwrite.c
@@ -568,7 +568,15 @@ static char *get_fallback(void *priv, ASS_Library *lib,
     hr = IDWriteFont_GetInformationalStrings(font,
             DWRITE_INFORMATIONAL_STRING_WIN32_FAMILY_NAMES,
             &familyNames, &exists);
-    if (FAILED(hr) || !exists) {
+    if (SUCCEEDED(hr) && !exists) {
+        IDWriteFontFamily *fontFamily = NULL;
+        hr = IDWriteFont_GetFontFamily(font, &fontFamily);
+        if (SUCCEEDED(hr)) {
+            hr = IDWriteFontFamily_GetFamilyNames(fontFamily, &familyNames);
+            IDWriteFontFamily_Release(fontFamily);
+        }
+    }
+    if (FAILED(hr)) {
         IDWriteFont_Release(font);
         return NULL;
     }

--- a/libass/ass_directwrite_info_template.h
+++ b/libass/ass_directwrite_info_template.h
@@ -29,7 +29,7 @@ static bool NAME(FONT_TYPE)(FONT_TYPE *font,
     IDWriteLocalizedStrings *familyNames;
     hr = font->lpVtbl->GetInformationalStrings(font,
             DWRITE_INFORMATIONAL_STRING_WIN32_FAMILY_NAMES, &familyNames, &exists);
-    if (!FAILED(hr) && !exists) {
+    if (SUCCEEDED(hr) && !exists) {
 #ifdef FAMILY_AS_ARG
         hr = IDWriteFontFamily_GetFamilyNames(fontFamily, &familyNames);
 #else

--- a/libass/ass_directwrite_info_template.h
+++ b/libass/ass_directwrite_info_template.h
@@ -31,7 +31,14 @@ static bool NAME(FONT_TYPE)(FONT_TYPE *font,
             DWRITE_INFORMATIONAL_STRING_WIN32_FAMILY_NAMES, &familyNames, &exists);
     if (SUCCEEDED(hr) && !exists) {
 #ifdef FAMILY_AS_ARG
-        hr = IDWriteFontFamily_GetFamilyNames(fontFamily, &familyNames);
+        if (fontFamily)
+            hr = IDWriteFontFamily_GetFamilyNames(fontFamily, &familyNames);
+        else {
+            hr = font->lpVtbl->GetFontFamily(font, &fontFamily);
+            if (SUCCEEDED(hr))
+                hr = IDWriteFontFamily_GetFamilyNames(fontFamily, &familyNames);
+            IDWriteFontFamily_Release(fontFamily);
+        }
 #else
         hr = font->lpVtbl->GetFamilyNames(font, &familyNames);
 #endif

--- a/libass/ass_directwrite_info_template.h
+++ b/libass/ass_directwrite_info_template.h
@@ -11,14 +11,8 @@ static bool NAME(FONT_TYPE)(FONT_TYPE *font,
     HRESULT hr;
     BOOL exists;
 
-    meta->weight = font->lpVtbl->GetWeight(font);
-    meta->width = map_width(font->lpVtbl->GetStretch(font));
-
-    DWRITE_FONT_STYLE style = font->lpVtbl->GetStyle(font);
-    meta->slant = (style == DWRITE_FONT_STYLE_NORMAL) ? FONT_SLANT_NONE :
-                 (style == DWRITE_FONT_STYLE_OBLIQUE)? FONT_SLANT_OBLIQUE :
-                 (style == DWRITE_FONT_STYLE_ITALIC) ? FONT_SLANT_ITALIC : FONT_SLANT_NONE;
-
+    // This PostScript name will merely be logged by
+    // ass_face_stream in case it encounters an error
     IDWriteLocalizedStrings *psNames;
     hr = font->lpVtbl->GetInformationalStrings(font,
             DWRITE_INFORMATIONAL_STRING_POSTSCRIPT_NAME, &psNames, &exists);
@@ -30,29 +24,6 @@ static bool NAME(FONT_TYPE)(FONT_TYPE *font,
         IDWriteLocalizedStrings_Release(psNames);
         if (!meta->postscript_name)
             return false;
-    }
-
-    IDWriteLocalizedStrings *fontNames;
-    hr = font->lpVtbl->GetInformationalStrings(font,
-            DWRITE_INFORMATIONAL_STRING_FULL_NAME, &fontNames, &exists);
-    if (FAILED(hr))
-        return false;
-
-    if (exists) {
-        meta->n_fullname = IDWriteLocalizedStrings_GetCount(fontNames);
-        meta->fullnames = calloc(meta->n_fullname, sizeof(char *));
-        if (!meta->fullnames) {
-            IDWriteLocalizedStrings_Release(fontNames);
-            return false;
-        }
-        for (int k = 0; k < meta->n_fullname; k++) {
-            meta->fullnames[k] = get_utf8_name(fontNames, k);
-            if (!meta->fullnames[k]) {
-                IDWriteLocalizedStrings_Release(fontNames);
-                return false;
-            }
-        }
-        IDWriteLocalizedStrings_Release(fontNames);
     }
 
     IDWriteLocalizedStrings *familyNames;
@@ -68,20 +39,10 @@ static bool NAME(FONT_TYPE)(FONT_TYPE *font,
     if (FAILED(hr))
         return false;
 
-    meta->n_family = IDWriteLocalizedStrings_GetCount(familyNames);
-    meta->families = calloc(meta->n_family, sizeof(char *));
-    if (!meta->families) {
-        IDWriteLocalizedStrings_Release(familyNames);
-        return false;
-    }
-    for (int k = 0; k < meta->n_family; k++) {
-        meta->families[k] = get_utf8_name(familyNames, k);
-        if (!meta->families[k]) {
-            IDWriteLocalizedStrings_Release(familyNames);
-            return false;
-        }
-    }
+    meta->extended_family = get_utf8_name(familyNames, 0);
     IDWriteLocalizedStrings_Release(familyNames);
+    if (!meta->extended_family)
+        return false;
 
     return true;
 }


### PR DESCRIPTION
DirectWrite sometimes returns names that differ from GDI’s. Instead of trusting it, use our own code that’s meant to be GDI-compatible, even if it costs us some extra resources.

This fixes https://github.com/libass/libass/issues/675 and facilitates future improvements to long font name matching (https://github.com/libass/libass/issues/459).

Plus a few minor improvements/precautions for exotic fonts/situations where we fail to find the same family name as DirectWrite does (or any family name at all).

Tested lightly: “Manrope Regular” works, and the added non-IDWriteFontFace3 code path works.