### PR TITLE
configure: use $host_os to detect NASM config

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -275,21 +275,21 @@ AS_IF([test "x$enable_asm" != xno], [
                 AC_MSG_WARN(nasm was not found; ASM functions are disabled.)
                 AC_MSG_WARN(Install nasm for a significantly faster libass build.)
             ], [
-                AS_CASE([$host],
-                    [*darwin*], [
+                AS_CASE([$host_os],
+                    [darwin*], [
                         ASFLAGS="$ASFLAGS -f macho$BITTYPE -DPREFIX -DSTACK_ALIGNMENT=16"
                     ],
-                    [*dragonfly*|*bsd*], [
-                        ASFLAGS="$ASFLAGS -f elf$BITTYPE"
-                    ],
-                    [*cygwin*|*mingw*], [
+                    [cygwin*|mingw*], [
                         ASFLAGS="$ASFLAGS -f win$BITTYPE"
                         AS_IF([test "x$BITS" = x32], [
                             ASFLAGS="$ASFLAGS -DPREFIX"
                         ])
                     ],
-                    [*linux*|*solaris*|*haiku*|*-gnu*], [
+                    [linux*|solaris*|haiku*|gnu*], [
                         ASFLAGS="$ASFLAGS -f elf$BITTYPE -DSTACK_ALIGNMENT=16"
+                    ],
+                    [dragonfly*|*bsd*], [
+                        ASFLAGS="$ASFLAGS -f elf$BITTYPE"
                     ],
                     [ # default
                         AC_MSG_ERROR(m4_text_wrap(m4_normalize([
@@ -297,7 +297,7 @@ AS_IF([test "x$enable_asm" != xno], [
                                 support for your platform can be added.
                                 In the meantime you will need to use --disable-asm.]),
                             [                  ],
-                            [could not identify NASM format for $host !],
+                            [could not identify NASM format for $host_os !],
                             [78]
                         ))
                     ]


### PR DESCRIPTION
After testing myself and searching through build logs, it looks like nothing needs `$host_vendor`. So let’s just use `$host_os`.

System          |    $host_os    |   vendor (example) | full $host | Comment
--------------- | -------------- | ------------ | --------- | -------
glibc-Linux     | `linux-gnu`    | `pc` | `x86_64-pc-linux-gnu` | Debian 11
x32 glibc-Linux | `linux-gnux32` | `pc` | `x86_64-pc-linux-gnux32` | Debian Sid
musl-Linux      | `linux-musl`   | `pc` | `i686-pc-linux-musl` | Alpine Linux 3.16
illumos         | `solaris2.11`  | `pc` | `x86_64-pc-solaris2.11` | OpenIndiana Hipster
Haiku           | `haiku`        | `unknown` | `x86_64-unknown-haiku` | Haiku R1/beta4
kFreeBSD        | `kfreebsd-gnu` | `pc` | `x86_64-pc-kfreebsd-gnu` | from Debian [build log](https://buildd.debian.org/status/fetch.php?pkg=libass&arch=kfreebsd-amd64&ver=1%3A0.16.0-1&stamp=1653097961&raw=0)
NetBSD          | `netbsd9.3` | `unknown` | `x86_64-unknown-netbsd9.3` | NetBSD 9.3
Dragonfly       | `dragonfly5.1` | `portbld` | `x86_64-portbld-dragonfly5.1` | taken from GH [comment at DragonFlyBSD/DPorts](https://github.com/DragonFlyBSD/DPorts/issues/196#issuecomment-335518758)
FreeBSD         | `freebsd13.0`  | `unknown` | `x86_64-unknown-freebsd13.0` | FreeBSD 13.0
GNU Hurd        | `gnu` *(may have version suffix)* |  `pc`,`unknown`, ...  | `i686-unknown-gnu0.9` or `i686-pc-gnu` | info by youpi from IRC and Debian [build logs](https://buildd.debian.org/status/fetch.php?pkg=libass&arch=hurd-i386&ver=1%3A0.17.0-2&stamp=1669944066&raw=0)
MacOS          | `darwin21.6.0` | `apple` | `x86_64-apple-darwin21.6.0` | MacOS 12.6.3 from GHA
Windows MinGW  | `mingw32` | `w64` | `i686-w64-mingw32`, `x86_64-w64-mingw32` | MS Windows Server 2019 from GHA (MINGW32 and UCRT64)
Windows Cygwin | `cygwin` | `pc` | `x86_64-pc-cygwin` | Taken from [build log](https://github.com/cygwin/scallywag/actions/runs/4157992880/jobs/7192912697#step:6:177) of Cygwin package build of libbsd