### PR TITLE
ci/gha: detect leaks on MacOS

### DIFF
--- a/.github/workflows/ghci.yml
+++ b/.github/workflows/ghci.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     name: build(${{ matrix.msystem || matrix.docker_image || matrix.os }},
-      ${{ matrix.cc }}${{ matrix.api && ', ' }}${{ matrix.api }})
+      ${{ matrix.cc }}${{ matrix.api && ', ' }}${{ matrix.api }}${{ matrix.jobname_suffix && ', ' }}${{ matrix.jobname_suffix }})
     strategy:
       fail-fast: false
       matrix:
@@ -47,6 +47,12 @@ jobs:
           # MacOS arm64
           - os: macos-14
             cc: clang
+            omit_asan: no
+          - os: macos-latest
+            cc: clang
+            omit_asan: yes
+            art_binwrap: 'leaks --atExit --'
+            jobname_suffix: leaks
           # Add a Windows build (MinGW-gcc via MSYS2) with no extras
           - os: windows-2019
             msystem: MINGW32
@@ -67,6 +73,7 @@ jobs:
 
     env:
       ART_SAMPLES: ext_art-samples
+      ART_BINWRAP: ${{ matrix.art_binwrap }}
 
     steps:
       # Available core count changes on runner type and over time, but GHA
@@ -180,6 +187,11 @@ jobs:
             # This options will instead force an SIGILL, but remove a report being printed
             # see https://reviews.llvm.org/D35085
             uflags="$uflags -fsanitize-undefined-trap-on-error"
+          fi
+
+          # ASAN is incompatible with other tools so some jobs want to opt-out
+          if [ "${{ matrix.omit_asan }}" = "yes" ] ; then
+            aflags=""
           fi
 
           # UBSAN: Alpine and MSys2 doesn't ship the UBSAN library,


### PR DESCRIPTION
Depends on https://github.com/libass/libass-tests/pull/3

It fails the CI run with the `leaks` check as expected. However, the redirecting to silence `fuzz`’s *(originally `profile`’s)* detailed output also removes `leaks` report, so there are no immediately visible details on what went wrong and for some reason the fialing CI job gets stuck in the following cleanup steps. See e.g.: https://github.com/TheOneric/libass/actions/runs/5661487504/job/15339487365 or the preceding runs.  
**EDIT:** so the output of the `test` step isn't even available anymore thanks to getting stuck, but basically it just told you the crash tests did indeed crash (only for the run with `leaks`) but without any details on why, then `make check` exited and our manually defined steps were done with and it went to the automatically inserted cleanup stages where it gets stuck.

@rcombs, any ideas what `leaks` might do to cause the job to getstuck or how to improve reporting without also getting all the details from `fuzz`?
