### PR TITLE
GDI-compatible rotation handling

### DIFF
--- a/libass/ass_cache_template.h
+++ b/libass/ass_cache_template.h
@@ -72,6 +72,7 @@ START(glyph_metrics, glyph_metrics_hash_key)
     GENERIC(double, size)
     GENERIC(int, face_index)
     GENERIC(int, glyph_index)
+    GENERIC(int, vertical)  // @font vertical layout
 END(GlyphMetricsHashKey)
 
 // describes an outline glyph

--- a/libass/ass_font.h
+++ b/libass/ass_font.h
@@ -31,8 +31,6 @@ typedef struct ass_font ASS_Font;
 #include "ass_cache.h"
 #include "ass_outline.h"
 
-#define VERTICAL_LOWER_BOUND 0x02f1
-
 #define ASS_FONT_MAX_FACES 10
 #define DECO_UNDERLINE     1
 #define DECO_STRIKETHROUGH 2

--- a/libass/ass_font.h
+++ b/libass/ass_font.h
@@ -43,6 +43,7 @@ struct ass_font {
     ASS_Library *library;
     FT_Library ftlibrary;
     int faces_uid[ASS_FONT_MAX_FACES];
+    FT_Encoding faces_cp[ASS_FONT_MAX_FACES];
     FT_Face faces[ASS_FONT_MAX_FACES];
     ASS_ShaperFontData *shaper_priv;
     int n_faces;

--- a/libass/ass_font.h
+++ b/libass/ass_font.h
@@ -62,6 +62,7 @@ uint32_t ass_font_index_magic(FT_Face face, uint32_t symbol);
 bool ass_font_get_glyph(ASS_Font *font, int face_index, int index,
                         ASS_Hinting hinting);
 void ass_font_clear(ASS_Font *font);
+bool ass_codepoint_is_fullwidth(FT_Encoding encoding, uint32_t symbol);
 
 bool ass_get_glyph_outline(ASS_Outline *outline, int32_t *advance,
                            FT_Face face, unsigned flags);

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -2177,8 +2177,6 @@ static bool parse_events(RenderContext *state, ASS_Event *event)
         info->bold = state->bold;
         info->italic = state->italic;
         info->flags = state->flags;
-        if (info->font->desc.vertical && code >= VERTICAL_LOWER_BOUND)
-            info->flags |= DECO_ROTATE;
         info->frx = state->frx;
         info->fry = state->fry;
         info->frz = state->frz;


### PR DESCRIPTION
I believe this should fix #701, as well as https://github.com/waddou/libass/issues/95 more broadly (or at least improve the situation there).

Caveats:
- As far as I can tell, GDI only applies VERT, not VKNA. I'm leaving this be for now until we can test to see what the impact of changing would be.
- GDI only applies VERT on characters that it deems to be fullwidth; we're applying it to all runs in @fonts. This is _probably_ fine, since it should be quite rare to have a VERT substitution for a halfwidth character as detected by this code.
- GDI prefers to use the `mort` table for vertical substitutions over `gsub`; it looks like harfbuzz has some support for that, but I'm not entirely clear on whether it would apply to our current usage. This seems to only matter for a few very old fonts.
- GDI makes use of the system code page in a couple places, which we don't want to do here; I attempt to guess the font's encoding instead.
- This definitely is going to need a decent amount of testing and comparison with vsfilter behavior.