### PR TITLE
Adjust spelling of libass in pc file

### DIFF
--- a/libass.pc.in
+++ b/libass.pc.in
@@ -4,7 +4,7 @@ libdir=@libdir@
 includedir=@includedir@
 
 Name: libass
-Description: LibASS is an SSA/ASS subtitles rendering library
+Description: libass is an SSA/ASS subtitles rendering library
 Version: @PACKAGE_VERSION@
 Requires: @PKG_REQUIRES_PUBLIC@
 Requires.private: @PKG_REQUIRES_PRIVATE@


### PR DESCRIPTION
Minor cosmetic thing. After asking on IRC it seems like nobody still uses “LibASS”, so let’s be consistent.

Changelog entries for 0.9.5 and 0.9.6 are left as “LibASS”, otherwise this was the only remaining occurrence of “LibASS”.