### PR TITLE
ass: explicitly read 32bit ints on timestring parts

### DIFF
--- a/libass/ass.c
+++ b/libass/ass.c
@@ -228,9 +228,9 @@ static void set_default_style(ASS_Style *style)
 
 static long long string2timecode(ASS_Library *library, char *p)
 {
-    int h, m, s, ms;
+    int32_t h, m, s, ms;
     long long tm;
-    int res = sscanf(p, "%d:%d:%d.%d", &h, &m, &s, &ms);
+    int res = sscanf(p, "%" SCNd32 ":%" SCNd32 ":%" SCNd32 ".%" SCNd32, &h, &m, &s, &ms);
     if (res < 4) {
         ass_msg(library, MSGL_WARN, "Bad timestamp");
         return 0;


### PR DESCRIPTION
This matches VSFilter and avoids signed overflows for ABIs with 64bit `int`s, like ILP64.

In practice the latter is probably only a theoretical concern atm and this change more cosmetic.
Still, it amkes the intent clearer and matches how we’re moving more and more `int` to explicit `int32_t`.

My only concern comes from a vague memory, that `inttype.h` print/scan macros may sometimes under certain conditions *hurt* portability with some Windows compilation settings or so. @astiob, iinm this was something you brought up/discovered once, do you recall more and if this is applicable here (or am I just confused and mixing things up)?  
Though we already use `PRId64` further down in `ass.c`.