### PR TITLE
readme: replace erroneous pseudo spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The following projects/companies use libass:
 
 Information about the ASS format:
 =================================
-- [ASS format overview (incomplete and partially incorrect)](http://moodub.free.fr/video/ass-specs.doc)
+- [ASS format overview](https://github.com/libass/libass/wiki/ASS-File-Format-Guide)
 - [ASS override tags (Aegisub manual)](http://docs.aegisub.org/latest/ASS_Tags/)
 - [VSFilter source code (Guliverkli2)](http://sourceforge.net/p/guliverkli2/code/HEAD/tree/src/subtitles/)
 


### PR DESCRIPTION
Hopefully having a proper guide with all modern recommendations will help to prevent more broken ASS from being generated *(as e.g. happened before with FFmpeg)*.

This has been discussed on IRC before, though I also extended the Style notes a bit since because Aegisub’s manual doesn't specify the in-file representation of values. See: https://github.com/libass/libass/wiki/ASS-File-Format-Guide/_compare/2b0a8387ebe543dbcd897db6efed2e7fe644341a...678350f140d458f148990f66f6bd17992255ada7

