### PR TITLE
Reject drawings not starting with m

### DIFF
--- a/libass/ass_drawing.c
+++ b/libass/ass_drawing.c
@@ -108,8 +108,21 @@ static ASS_DrawingToken *drawing_tokenize(const char *str)
                 tail->next = calloc(1, sizeof(ASS_DrawingToken));
                 tail->next->prev = tail;
                 tail = tail->next;
-            } else
+            } else {
+                /* VSFilter compat:
+                 * In guliverkli(2) VSFilter all drawings
+                 * whose first valid command isn't m are rejected.
+                 * xy-VSF and MPC-HC ISR this was (possibly inadvertenly) later relaxed,
+                 * such that all valid commands but n are ignored if there was no m yet.
+                 */
+                if (type == TOKEN_MOVE_NC) {
+                    return NULL;
+                } else if (type != TOKEN_MOVE) {
+                    p++;
+                    continue;
+                }
                 root = tail = calloc(1, sizeof(ASS_DrawingToken));
+            }
             tail->type = type;
             tail->point = point;
             is_set = 0;

--- a/libass/ass_drawing.c
+++ b/libass/ass_drawing.c
@@ -33,7 +33,7 @@
 /*
  * \brief Check whether a number of items on the list is available
  */
-static bool token_check_values(ASS_DrawingToken *token, int i, int type)
+static bool token_check_values(ASS_DrawingToken *token, int i, ASS_TokenType type)
 {
     for (int j = 0; j < i; j++) {
         if (!token || token->type != type) return false;
@@ -50,7 +50,8 @@ static bool token_check_values(ASS_DrawingToken *token, int i, int type)
 static ASS_DrawingToken *drawing_tokenize(const char *str)
 {
     char *p = (char *) str;
-    int type = -1, is_set = 0;
+    ASS_TokenType type = TOKEN_INVALID;
+    int is_set = 0;
     double val;
     ASS_Vector point = {0, 0};
 
@@ -102,7 +103,7 @@ static ASS_DrawingToken *drawing_tokenize(const char *str)
         if (!got_coord)
             is_set = 0;
 
-        if (type != -1 && is_set == 2) {
+        if (type != TOKEN_INVALID && is_set == 2) {
             if (root) {
                 tail->next = calloc(1, sizeof(ASS_DrawingToken));
                 tail->next->prev = tail;

--- a/libass/ass_drawing.h
+++ b/libass/ass_drawing.h
@@ -24,6 +24,7 @@
 #include "ass_bitmap.h"
 
 typedef enum {
+    TOKEN_INVALID,
     TOKEN_MOVE,
     TOKEN_MOVE_NC,
     TOKEN_LINE,


### PR DESCRIPTION
This adjusts us to current VSFilter behaviour and is one approach to fix #719 

We know this will affect (at least, but from an extensive search *only*) two original typesets, but they aren’t degraded tooo badly.

Since we didn't find *any* samples broken by accepting such drawings, patching VSFilters instead to accept them was also suggested as an alternative on IRC. If done this would codify our somewhat odd existing behaviour on m-less drawings, but no files would be broken.

If someone wants to pursue the VSFilter patch approach, I have no objections to that and we can close this PR once that’s ready. Personally, I think it’s probably fine to degrade those two samples and adopt VSFilter’s current and imho more intuitive behaviour. Either way though, I think we shouldn’t put this off too long to avoid more (future) broken files being created.