### PR TITLE
Support parsing ASS2 (v4++) scripts

### DIFF
--- a/libass/Makefile_library.am
+++ b/libass/Makefile_library.am
@@ -1,6 +1,6 @@
-LIBASS_LT_CURRENT = 11
-LIBASS_LT_REVISION = 1
-LIBASS_LT_AGE = 2
+LIBASS_LT_CURRENT = 12
+LIBASS_LT_REVISION = 0
+LIBASS_LT_AGE = 0
 
 .asm.lo:
 	$(nasm_verbose)$(LIBTOOL) $(AM_V_lt) --tag=CC --mode=compile $(top_srcdir)/ltnasm.sh $(AS) $(ASFLAGS) -I$(top_srcdir)/libass/ -Dprivate_prefix=ass -o $@ $<

--- a/libass/ass.c
+++ b/libass/ass.c
@@ -114,6 +114,10 @@ int ass_alloc_style(ASS_Track *track)
 
     sid = track->n_styles++;
     memset(track->styles + sid, 0, sizeof(ASS_Style));
+
+    // Explicitly flag newer values as unset
+    track->styles[sid].MarginB = INT_MIN;
+
     return sid;
 }
 
@@ -224,6 +228,7 @@ static void set_default_style(ASS_Style *style)
     style->Shadow           = 3;
     style->Alignment        = 2;
     style->MarginL = style->MarginR = style->MarginV = 20;
+    style->MarginB = INT_MIN;
 }
 
 static long long string2timecode(ASS_Library *library, char *p)
@@ -502,6 +507,7 @@ static int process_event_tail(ASS_Track *track, ASS_Event *event,
             INTVAL(MarginL)
             INTVAL(MarginR)
             INTVAL(MarginV)
+            INTVAL(MarginB)
             TIMEVAL(Start)
             TIMEVAL(Duration)
         PARSE_END
@@ -698,6 +704,7 @@ static int process_style(ASS_Track *track, char *str)
             INTVAL(MarginL)
             INTVAL(MarginR)
             INTVAL(MarginV)
+            INTVAL(MarginB)
             INTVAL(Encoding)
             FPVAL(ScaleX)
             FPVAL(ScaleY)

--- a/libass/ass.c
+++ b/libass/ass.c
@@ -56,6 +56,14 @@ static const char *const ssa_style_format =
 static const char *const ssa_event_format =
         "Marked, Start, End, Style, Name, "
         "MarginL, MarginR, MarginV, Effect, Text";
+static const char *const ass2_style_format =
+        "Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, "
+        "OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, "
+        "ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, "
+        "Alignment, MarginL, MarginR, MarginV, MarginB, Encoding, RelativeTo";
+static const char *const ass2_event_format =
+        "Layer, Start, End, Style, Name, "
+        "MarginL, MarginR, MarginV, MarginB, Effect, Text";
 
 #define ASS_STYLES_ALLOC 20
 
@@ -641,6 +649,8 @@ static int process_style(ASS_Track *track, char *str)
         // probably an ancient script version
         if (track->track_type == TRACK_TYPE_SSA)
             track->style_format = strdup(ssa_style_format);
+        else if (track->track_type == TRACK_TYPE_ASS2)
+            track->style_format = strdup(ass2_style_format);
         else
             track->style_format = strdup(ass_style_format);
         if (!track->style_format)
@@ -696,7 +706,8 @@ static int process_style(ASS_Track *track, char *str)
             FPVAL(Angle)
             INTVAL(BorderStyle)
             INTVAL(Alignment)
-                if (track->track_type == TRACK_TYPE_ASS)
+                if (track->track_type == TRACK_TYPE_ASS ||
+                    track->track_type == TRACK_TYPE_ASS2)
                     target->Alignment = numpad2align(target->Alignment);
                 // VSFilter compatibility
                 else if (target->Alignment == 8)
@@ -814,7 +825,7 @@ static void custom_format_line_compatibility(ASS_Track *const track,
 static int process_styles_line(ASS_Track *track, char *str)
 {
     int ret = 0;
-    if (!strncmp(str, "Format:", 7)) {
+    if (!strncmp(str, "Format:", 7) && track->track_type != TRACK_TYPE_ASS2) {
         char *p = str + 7;
         skip_spaces(&p);
         free(track->style_format);
@@ -848,6 +859,10 @@ static inline void parse_script_type(ASS_Track *track, const char *str)
     int ver = TRACK_TYPE_SSA;
     if (*(p-1) == '+') {
         ver = TRACK_TYPE_ASS;
+        --len; --p;
+    }
+    if (*(p-1) == '+') {
+        ver = TRACK_TYPE_ASS2;
         --len; --p;
     }
 
@@ -918,6 +933,8 @@ static void event_format_fallback(ASS_Track *track)
     track->parser_priv->state = PST_EVENTS;
     if (track->track_type == TRACK_TYPE_SSA)
         track->event_format = strdup(ssa_event_format);
+    else if (track->track_type == TRACK_TYPE_ASS2)
+        track->event_format = strdup(ass2_event_format);
     else
         track->event_format = strdup(ass_event_format);
     ass_msg(track->library, MSGL_V,
@@ -982,7 +999,7 @@ static bool detect_legacy_conv_subs(ASS_Track *track)
 
 static int process_events_line(ASS_Track *track, char *str)
 {
-    if (!strncmp(str, "Format:", 7)) {
+    if (!strncmp(str, "Format:", 7) && track->track_type != TRACK_TYPE_ASS2) {
         char *p = str + 7;
         skip_spaces(&p);
         free(track->event_format);
@@ -1171,6 +1188,9 @@ static int process_line(ASS_Track *track, char *str)
     } else if (!ass_strncasecmp(str, "[V4+ Styles]", 12)) {
         track->parser_priv->state = PST_STYLES;
         track->track_type = TRACK_TYPE_ASS;
+    } else if (!ass_strncasecmp(str, "[V4++ Styles]", 12)) {
+        track->parser_priv->state = PST_STYLES;
+        track->track_type = TRACK_TYPE_ASS2;
     } else if (!ass_strncasecmp(str, "[Events]", 8)) {
         track->parser_priv->state = PST_EVENTS;
     } else if (!ass_strncasecmp(str, "[Fonts]", 7)) {

--- a/libass/ass.c
+++ b/libass/ass.c
@@ -117,6 +117,7 @@ int ass_alloc_style(ASS_Track *track)
 
     // Explicitly flag newer values as unset
     track->styles[sid].MarginB = INT_MIN;
+    track->styles[sid].RelativeTo = 2;
 
     return sid;
 }
@@ -229,6 +230,7 @@ static void set_default_style(ASS_Style *style)
     style->Alignment        = 2;
     style->MarginL = style->MarginR = style->MarginV = 20;
     style->MarginB = INT_MIN;
+    style->RelativeTo = 2;
 }
 
 static long long string2timecode(ASS_Library *library, char *p)
@@ -706,6 +708,7 @@ static int process_style(ASS_Track *track, char *str)
             INTVAL(MarginV)
             INTVAL(MarginB)
             INTVAL(Encoding)
+            INTVAL(RelativeTo)
             FPVAL(ScaleX)
             FPVAL(ScaleY)
             FPVAL(Outline)

--- a/libass/ass.h
+++ b/libass/ass.h
@@ -158,7 +158,7 @@ typedef enum {
      */
     ASS_OVERRIDE_BIT_FONT_SIZE_FIELDS = 1 << 2,
     /**
-     * On dialogue events override: FontName, treat_fontname_as_pattern
+     * On dialogue events override: FontName
      */
     ASS_OVERRIDE_BIT_FONT_NAME = 1 << 3,
     /**

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -980,8 +980,12 @@ static ASS_Style *handle_selective_style_overrides(RenderContext *state,
     if (requested & ASS_OVERRIDE_BIT_MARGINS) {
         new->MarginL = user->MarginL;
         new->MarginR = user->MarginR;
-        new->MarginV = user->MarginV;
+        new->MarginT = user->MarginT;
+        new->MarginB = user->MarginB;
     }
+
+    // Never override RelativeTo; there are separate mechanisms for that
+    new->RelativeTo = rstyle->RelativeTo;
 
     if (!new->FontName)
         new->FontName = rstyle->FontName;
@@ -2880,8 +2884,13 @@ ass_render_event(RenderContext *state, ASS_Event *event,
         (event->MarginL) ? event->MarginL : state->style->MarginL;
     int MarginR =
         (event->MarginR) ? event->MarginR : state->style->MarginR;
-    int MarginV =
-        (event->MarginV) ? event->MarginV : state->style->MarginV;
+    int MarginT =
+        (event->MarginT) ? event->MarginT : state->style->MarginT;
+    int MarginB =
+        (event->MarginB) ? event->MarginB : state->style->MarginB;
+
+    if (MarginB == INT_MIN)
+        MarginB = MarginT;
 
     // calculate max length of a line
     double max_text_width =
@@ -2953,7 +2962,7 @@ ass_render_event(RenderContext *state, ASS_Event *event,
         if (valign == VALIGN_TOP) {     // toptitle
             device_y =
                 y2scr_top(state,
-                          MarginV) + text_info->lines[0].asc;
+                          MarginT) + text_info->lines[0].asc;
         } else if (valign == VALIGN_CENTER) {   // midtitle
             double scr_y =
                 y2scr(state, render_priv->track->PlayResY / 2.0);
@@ -2967,7 +2976,7 @@ ass_render_event(RenderContext *state, ASS_Event *event,
                        "Invalid valign, assuming 0 (subtitle)");
             scr_bottom =
                 y2scr_sub(state,
-                          render_priv->track->PlayResY - MarginV);
+                          render_priv->track->PlayResY - MarginB);
             scr_top = y2scr_top(state, 0); //xxx not always 0?
             device_y = scr_bottom + (scr_top - scr_bottom) * line_pos / 100.0;
             device_y -= text_info->height;

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -949,7 +949,6 @@ static ASS_Style *handle_selective_style_overrides(RenderContext *state,
 
     if (requested & ASS_OVERRIDE_BIT_FONT_NAME) {
         new->FontName = user->FontName;
-        new->treat_fontname_as_pattern = user->treat_fontname_as_pattern;
     }
 
     if (requested & ASS_OVERRIDE_BIT_COLORS) {
@@ -1077,7 +1076,6 @@ void ass_reset_render_context(RenderContext *state, ASS_Style *style)
 
     state->family.str = style->FontName;
     state->family.len = strlen(style->FontName);
-    state->treat_family_as_pattern = style->treat_fontname_as_pattern;
     state->bold = style->Bold;
     state->italic = style->Italic;
     ass_update_font(state);

--- a/libass/ass_render.h
+++ b/libass/ass_render.h
@@ -277,7 +277,6 @@ struct render_context {
     ASS_StringView family;
     unsigned bold;
     unsigned italic;
-    int treat_family_as_pattern;
     int wrap_style;
     int font_encoding;
 

--- a/libass/ass_types.h
+++ b/libass/ass_types.h
@@ -120,7 +120,11 @@ typedef struct ass_style {
     int Alignment; // use `VALIGN_* | HALIGN_*` as value
     int MarginL;
     int MarginR;
-    int MarginV;
+    union {
+        int MarginV;
+        int MarginT;
+    };
+    int MarginB; // Applies only if set to a non-INT_MIN value
     int Encoding;
     double Blur; // sets a default \blur for the event; same values as \blur
     int Justify; // sets text justification independent of event alignment; use ASS_JUSTIFY_*
@@ -141,7 +145,11 @@ typedef struct ass_event {
     char *Name;
     int MarginL;
     int MarginR;
-    int MarginV;
+    union {
+        int MarginV;
+        int MarginT;
+    };
+    int MarginB;
     char *Effect;
     char *Text;
 

--- a/libass/ass_types.h
+++ b/libass/ass_types.h
@@ -122,7 +122,6 @@ typedef struct ass_style {
     int MarginR;
     int MarginV;
     int Encoding;
-    int treat_fontname_as_pattern; // does nothing (left in place for ABI-compatibility)
     double Blur; // sets a default \blur for the event; same values as \blur
     int Justify; // sets text justification independent of event alignment; use ASS_JUSTIFY_*
 } ASS_Style;

--- a/libass/ass_types.h
+++ b/libass/ass_types.h
@@ -272,7 +272,8 @@ typedef struct ass_track {
     enum {
         TRACK_TYPE_UNKNOWN = 0,
         TRACK_TYPE_ASS,
-        TRACK_TYPE_SSA
+        TRACK_TYPE_SSA,
+        TRACK_TYPE_ASS2,
     } track_type;
 
     // Script header fields

--- a/libass/ass_types.h
+++ b/libass/ass_types.h
@@ -128,6 +128,7 @@ typedef struct ass_style {
     int Encoding;
     double Blur; // sets a default \blur for the event; same values as \blur
     int Justify; // sets text justification independent of event alignment; use ASS_JUSTIFY_*
+    int RelativeTo; // 0 for dialogue, 1 for typesetting, 2 for auto
 } ASS_Style;
 
 


### PR DESCRIPTION
This implements MarginB, and parses RelativeTo (but doesn't yet use it for anything). Untested apart from verifying that it doesn't break v4+, since I don't have any v4++ test files right now. Hopefully some of the folks who are interested in this functionality can try it out.

A few relevant notes:
- This explicitly does not support custom format lines for v4++ scripts
- v4++ scripts also don't get the custom-format-line-detection behavior (for SBAS)
- Anonymous unions are used to maintain API compatibility with existing code that uses MarginV
- This includes an ABI break, since it adds members to ASS_Style and ASS_Event, whose sizes are part of the public ABI
- I also took the opportunity to remove `treat_fontname_as_pattern`, since it was no longer used and had been marked as deprecated in code comments for a while. This technically makes this an API break as well; we can remove that if we want (or perhaps make it a member of an anonymous union with the newly-added `MarginB`, but ehhhhhhh).