### PR TITLE
Document tonemapping beyond RGB mangling

### DIFF
--- a/libass/ass_types.h
+++ b/libass/ass_types.h
@@ -229,6 +229,12 @@ typedef struct ass_event {
  * absolutely can't do that, because the video colorspace is required
  * in order to handle this as intended. API users must use the exposed
  * information to perform color mangling as described above.
+ *
+ * Further note all of the above only concerns the RGB values.
+ * Color primaries and transfer charateristics of ASS subtitles
+ * must always match their associated video.
+ * (This indeed has some undesirable effects on HDR videos,
+ * but no mechanism avoiding this is yet standardized.)
  */
 typedef enum ASS_YCbCrMatrix {
     YCBCR_DEFAULT = 0,  // Header missing


### PR DESCRIPTION
Followup to the IRC discussion preceding and https://github.com/mpv-player/mpv/issues/13381 itself.

I’m not sure I got the terminology quite right, please check.

The YCbCr section in the file format guide prob also needs some tweaking. Perhaps something like **(changed section emphasised)*?:
> **YCbCr Matrix**
>
> [...]
> 
> Following these instructions will ensure, the final colours effectively exactly match the sRGB values specified in ASS. Diverging from this, will lead to **unmapped** colours being mangled as described in ass_types.h. **(But colour primaries and tone mapping will always follow the video colourspace regardless)**