### PR TITLE
Update documentation re subs on HDR

### DIFF
--- a/libass/ass_types.h
+++ b/libass/ass_types.h
@@ -232,9 +232,14 @@ typedef struct ass_event {
  *
  * Further note all of the above only concerns the RGB values.
  * Color primaries and transfer charateristics of ASS subtitles
- * must always match their associated video.
- * (This indeed has some undesirable effects on HDR videos,
- * but no mechanism avoiding this is yet standardized.)
+ * must always match their associated video when placed on top of SDR video.
+ *
+ * Subs on HDR video need additional consideration to yield satisfactory results,
+ * but unfortunately no mechanisms for this are standardized yet.
+ * Until such mechanisms are introduced and sub files start to enable them,
+ * all subtitles are to be considered SDR. When placed on top of HDR video
+ * exact color matching is not relevant and the choice of SDR colorspace
+ * to render subs in is left to the presenter.
  */
 typedef enum ASS_YCbCrMatrix {
     YCBCR_DEFAULT = 0,  // Header missing


### PR DESCRIPTION
Revises #735 based on practical experience from mpv and further discussion summarised in https://github.com/libass/libass/issues/297#issuecomment-1991497184

Note:
- ~~the wording implies HDR subs will never be subject to `YCbCr Matrix` colour mangling; this isn’t explicitly stated in the linked comment but was suggested before and seems sensible~~
- this behaviour is now fixed for all current subs and will only change once files opt-in future HDR mechanisms
- this leaves the exact choice of SDR space implementation defined; if *(as some seemed to prefer)* we instead want to choose one single blessed colourspace, [mpv’s current choice](https://github.com/mpv-player/mpv/blob/6179995dd7ef576073e184abd01fd34890e1b59f/video/out/vo_gpu_next.c#L359-L362)  may be a good candidate