### PR TITLE
Add LayoutResX and LayoutResY to fuzz ass dict

### DIFF
--- a/fuzz/ass.dict
+++ b/fuzz/ass.dict
@@ -39,6 +39,8 @@
 "ScriptType"
 "PlayResX"
 "PlayResY"
+"LayoutResX"
+"LayoutResY"
 "Timer"
 "WrapStyle"
 "ScaledBorderAndShadow"


### PR DESCRIPTION
The fuzz dictionary was missing the new headers for LayoutResX and LayoutResY. I simply added them.