### PR TITLE
bitmap: improve shift_bitmap; add vectorized implementation

### DIFF
--- a/Makefile_util.am
+++ b/Makefile_util.am
@@ -54,6 +54,7 @@ checkasm_checkasm_SOURCES = \
     checkasm/blend_bitmaps.c \
     checkasm/be_blur.c \
     checkasm/blur.c \
+    checkasm/shift_bitmap.c \
     checkasm/checkasm.h checkasm/checkasm.c \
     libass/ass_rasterizer.h libass/ass_utils.h
 

--- a/checkasm/checkasm.c
+++ b/checkasm/checkasm.c
@@ -59,6 +59,7 @@ static const struct {
     { "blend_bitmaps", checkasm_check_blend_bitmaps },
     { "be_blur", checkasm_check_be_blur },
     { "blur", checkasm_check_blur },
+    { "shift_bitmap", checkasm_check_shift_bitmap },
     { 0 }
 };
 

--- a/checkasm/checkasm.h
+++ b/checkasm/checkasm.h
@@ -60,6 +60,7 @@ void checkasm_check_rasterizer(unsigned cpu_flag);
 void checkasm_check_blend_bitmaps(unsigned cpu_flag);
 void checkasm_check_be_blur(unsigned cpu_flag);
 void checkasm_check_blur(unsigned cpu_flag);
+void checkasm_check_shift_bitmap(unsigned cpu_flag);
 
 void *checkasm_check_func(void *func, const char *name, ...);
 int checkasm_bench_func(void);

--- a/checkasm/shift_bitmap.c
+++ b/checkasm/shift_bitmap.c
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2020-2024 libass contributors
+ *
+ * This file is part of libass.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "checkasm.h"
+
+#include <stdbool.h>
+#include <string.h>
+#include <stdio.h>
+
+#define HEIGHT 8
+#define STRIDE 64
+#define MIN_WIDTH 2
+
+static void check_shift_bitmap(BitmapShiftFunc func)
+{
+    ALIGN(uint8_t buf_ref[STRIDE * HEIGHT], 32);
+    ALIGN(uint8_t buf_new[STRIDE * HEIGHT], 32);
+    ALIGN(uint16_t tmp[STRIDE], 32);
+    declare_func(void,
+                 uint8_t *restrict buf, ptrdiff_t stride,
+                 size_t width, size_t height,
+                 uint32_t shift_x, uint32_t shift_y, uint16_t *restrict tmp);
+
+    if (check_func(func, "shift_bitmap")) {
+        bool failed = false;
+        for (int shift = 0; shift < 64 && !failed; shift++) {
+            for (int w = MIN_WIDTH; w <= STRIDE && !failed; w++) {
+                memset(buf_ref, 0, sizeof(buf_ref));
+                memset(buf_new, 0, sizeof(buf_new));
+                for (int y = 0; y < HEIGHT; y++) {
+                    for (int x = 0; x < w - 1; x++)
+                        buf_ref[y * STRIDE + x] = buf_new[y * STRIDE + x] = rnd();
+                }
+
+                memset(tmp, 0, sizeof(tmp));
+                call_ref(buf_ref, STRIDE, w, HEIGHT, shift ? shift : 1, shift, tmp);
+
+                memset(tmp, 0, sizeof(tmp));
+                call_new(buf_new, STRIDE, w, HEIGHT, shift ? shift : 1, shift, tmp);
+
+                for (int y = 0; y < HEIGHT; y++) {
+                    if (memcmp(buf_ref + STRIDE * y, buf_new + STRIDE * y, w)) {
+                        printf("FAILED: %i %i\n", shift, w);
+                        failed = true;
+                        fail();
+                        break;
+                    }
+                }
+            }
+        }
+
+        bench_new(buf_new, STRIDE, STRIDE, HEIGHT, 32, 32, tmp);
+    }
+
+    report("shift_bitmap");
+}
+
+void checkasm_check_shift_bitmap(unsigned cpu_flag)
+{
+    BitmapEngine engine = ass_bitmap_engine_init(cpu_flag);
+    check_shift_bitmap(engine.shift_bitmap);
+}

--- a/libass/Makefile_library.am
+++ b/libass/Makefile_library.am
@@ -44,6 +44,7 @@ if AARCH64
 libass_libass_internal_la_SOURCES += \
     libass/aarch64/rasterizer.S \
     libass/aarch64/blend_bitmaps.S \
+    libass/aarch64/shift_bitmap.S \
     libass/aarch64/be_blur.S \
     libass/aarch64/blur.S \
     libass/aarch64/asm.S

--- a/libass/Makefile_library.am
+++ b/libass/Makefile_library.am
@@ -28,6 +28,7 @@ libass_libass_internal_la_SOURCES = \
     libass/c/c_blend_bitmaps.c \
     libass/c/c_be_blur.c \
     libass/c/blur_template.h libass/c/c_blur.c \
+    libass/c/c_shift_bitmap.c \
     libass/wyhash.h
 
 if ASM

--- a/libass/aarch64/shift_bitmap.S
+++ b/libass/aarch64/shift_bitmap.S
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2024 rcombs
+ *
+ * This file is part of libass.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "asm.S"
+
+/*
+ * void shift_bitmap(uint8_t *buf, intptr_t stride,
+ *                   intptr_t width, intptr_t height,
+ *                   int32_t shift_x, int32_t shift_y, uint16_t *tmp);
+ */
+
+function shift_bitmap_neon, export=1
+    mov        x8, 0
+    dup        v0.8h, w4 // shift_x
+    dup        v1.8h, w5 // shift_y
+
+0:
+    mov        x7, 0    // x = 0
+    movi       v2.8h, 0 // prev = 0
+    mov        x10, x6  // tmprow = tmp
+
+1:
+    ldr        q4, [x0, x7] // px = buf[x]
+
+    ushll      v20.8h, v4.8b,  1 // px <<= 1
+    ushll2     v21.8h, v4.16b, 1
+
+    mul        v16.8h, v0.8h, v20.8h // b_x = px * shift_x
+    mul        v17.8h, v0.8h, v21.8h
+    ushr       v16.8h, v16.8h, 6 // >> 6
+    ushr       v17.8h, v17.8h, 6
+
+    ext        v2.16b,  v2.16b, v16.16b, 14 // shift prev
+    ext        v3.16b, v16.16b, v17.16b, 14
+
+    add        v20.8h, v20.8h, v2.8h // px += prev
+    add        v21.8h, v21.8h, v3.8h
+    sub        v20.8h, v20.8h, v16.8h // px -= b_x
+    sub        v21.8h, v21.8h, v17.8h
+
+    ld1        {v22.8h, v23.8h}, [x10] // tmpv = tmp[x]
+
+    mul        v18.8h, v1.8h, v20.8h // b_y = px * shift_y
+    mul        v19.8h, v1.8h, v21.8h
+    ushr       v18.8h, v18.8h, 6 // >> 6
+    ushr       v19.8h, v19.8h, 6
+
+    st1        {v18.8h, v19.8h}, [x10], #0x20 // tmp[x] = b_y
+
+    add        v20.8h, v20.8h, v22.8h // px += tmpv
+    add        v21.8h, v21.8h, v23.8h
+    sub        v20.8h, v20.8h, v18.8h // px -= b_y
+    sub        v21.8h, v21.8h, v19.8h
+
+    rshrn      v4.8b,  v20.8h, 1 // px >>= 1
+    rshrn2     v4.16b, v21.8h, 1
+
+    str        q4, [x0, x7] // buf[x] = px
+
+    mov        v2.8h, v17.8h // prev = b_x
+
+    add        x7, x7, #0x10 // x++
+    cmp        x7, x2 // x < w
+    b.lt       1b
+
+    add        x0, x0, x1 // buf += stride
+    add        x8, x8, #0x1 // y++
+    cmp        x8, x3 // y < height
+    b.ne       0b
+
+    ret
+endfunc

--- a/libass/ass_bitmap.h
+++ b/libass/ass_bitmap.h
@@ -48,7 +48,7 @@ void ass_synth_blur(const BitmapEngine *engine, Bitmap *bm,
                     int be, double blur_r2x, double blur_r2y);
 
 bool ass_gaussian_blur(const BitmapEngine *engine, Bitmap *bm, double r2x, double r2y);
-void ass_shift_bitmap(Bitmap *bm, int shift_x, int shift_y);
+void ass_shift_bitmap(const BitmapEngine *engine, Bitmap *bm, int32_t shift_x, int32_t shift_y);
 void ass_fix_outline(Bitmap *bm_g, Bitmap *bm_o);
 
 #endif                          /* LIBASS_BITMAP_H */

--- a/libass/ass_bitmap_engine.c
+++ b/libass/ass_bitmap_engine.c
@@ -58,6 +58,12 @@
     GENERIC_FUNCTION(mul_bitmaps,  suffix) \
     GENERIC_FUNCTION(be_blur,      suffix)
 
+#define SHIFT_PROTOYPES(suffix) \
+    BitmapShiftFunc ass_shift_bitmap_ ## suffix;
+
+#define SHIFT_FUNCTIONS(suffix) \
+    GENERIC_FUNCTION(shift_bitmap, suffix)
+
 
 #define PARAM_BLUR_SET(suffix) \
     ass_blur4_ ## suffix, \
@@ -102,6 +108,7 @@
     RASTERIZER_PROTOTYPES(16, suffix) \
     RASTERIZER_PROTOTYPES(32, suffix) \
     GENERIC_PROTOTYPES(suffix) \
+    SHIFT_PROTOYPES(suffix) \
     BLUR_PROTOTYPES(alignment, suffix)
 
 #define BASE_FUNCTIONS(align_order_, alignment, suffix) \
@@ -110,7 +117,8 @@
     BLUR_FUNCTIONS(align_order_, alignment, suffix)
 
 #define ALL_FUNCTIONS(align_order_, alignment, suffix) \
-    BASE_FUNCTIONS(align_order_, alignment, suffix)
+    BASE_FUNCTIONS(align_order_, alignment, suffix) \
+    SHIFT_FUNCTIONS(suffix)
 
 
 unsigned ass_get_cpu_flags(unsigned mask)

--- a/libass/ass_bitmap_engine.c
+++ b/libass/ass_bitmap_engine.c
@@ -167,13 +167,17 @@ BitmapEngine ass_bitmap_engine_init(unsigned mask)
     BitmapEngine engine = {0};
     engine.tile_order = mask & ASS_FLAG_LARGE_TILES ? 5 : 4;
 
+    ALL_FUNCTIONS(4, 16, c)
+    if (mask & ASS_FLAG_WIDE_STRIPE) {
+        BLUR_FUNCTIONS(5, 32, c)
+    }
+
 #if CONFIG_ASM
     unsigned flags = ass_get_cpu_flags(mask);
 #if ARCH_X86
     if (flags & ASS_CPU_FLAG_X86_AVX2) {
         ALL_PROTOTYPES(32, avx2)
         ALL_FUNCTIONS(5, 32, avx2)
-        return engine;
     } else if (flags & ASS_CPU_FLAG_X86_SSE2) {
         ALL_PROTOTYPES(16, sse2)
         ALL_FUNCTIONS(4, 16, sse2)
@@ -185,20 +189,14 @@ BitmapEngine ass_bitmap_engine_init(unsigned mask)
             BLUR_FUNCTION(expand_horz, 16, ssse3)
             PARAM_BLUR_FUNCTION(horz, 16, ssse3)
         }
-        return engine;
     }
 #elif ARCH_AARCH64
     if (flags & ASS_CPU_FLAG_ARM_NEON) {
         ALL_PROTOTYPES(16, neon)
         ALL_FUNCTIONS(4, 16, neon)
-        return engine;
     }
 #endif
 #endif
 
-    ALL_FUNCTIONS(4, 16, c)
-    if (mask & ASS_FLAG_WIDE_STRIPE) {
-        BLUR_FUNCTIONS(5, 32, c)
-    }
     return engine;
 }

--- a/libass/ass_bitmap_engine.c
+++ b/libass/ass_bitmap_engine.c
@@ -104,10 +104,13 @@
     GENERIC_PROTOTYPES(suffix) \
     BLUR_PROTOTYPES(alignment, suffix)
 
-#define ALL_FUNCTIONS(align_order_, alignment, suffix) \
+#define BASE_FUNCTIONS(align_order_, alignment, suffix) \
     RASTERIZER_FUNCTIONS(suffix) \
     GENERIC_FUNCTIONS(suffix) \
     BLUR_FUNCTIONS(align_order_, alignment, suffix)
+
+#define ALL_FUNCTIONS(align_order_, alignment, suffix) \
+    BASE_FUNCTIONS(align_order_, alignment, suffix)
 
 
 unsigned ass_get_cpu_flags(unsigned mask)
@@ -177,10 +180,10 @@ BitmapEngine ass_bitmap_engine_init(unsigned mask)
 #if ARCH_X86
     if (flags & ASS_CPU_FLAG_X86_AVX2) {
         ALL_PROTOTYPES(32, avx2)
-        ALL_FUNCTIONS(5, 32, avx2)
+        BASE_FUNCTIONS(5, 32, avx2)
     } else if (flags & ASS_CPU_FLAG_X86_SSE2) {
         ALL_PROTOTYPES(16, sse2)
-        ALL_FUNCTIONS(4, 16, sse2)
+        BASE_FUNCTIONS(4, 16, sse2)
         if (flags & ASS_CPU_FLAG_X86_SSSE3) {
             ALL_PROTOTYPES(16, ssse3)
             RASTERIZER_FUNCTION(fill_generic, ssse3)
@@ -193,7 +196,7 @@ BitmapEngine ass_bitmap_engine_init(unsigned mask)
 #elif ARCH_AARCH64
     if (flags & ASS_CPU_FLAG_ARM_NEON) {
         ALL_PROTOTYPES(16, neon)
-        ALL_FUNCTIONS(4, 16, neon)
+        BASE_FUNCTIONS(4, 16, neon)
     }
 #endif
 #endif

--- a/libass/ass_bitmap_engine.c
+++ b/libass/ass_bitmap_engine.c
@@ -205,6 +205,7 @@ BitmapEngine ass_bitmap_engine_init(unsigned mask)
     if (flags & ASS_CPU_FLAG_ARM_NEON) {
         ALL_PROTOTYPES(16, neon)
         BASE_FUNCTIONS(4, 16, neon)
+        SHIFT_FUNCTIONS(neon)
     }
 #endif
 #endif

--- a/libass/ass_bitmap_engine.h
+++ b/libass/ass_bitmap_engine.h
@@ -49,6 +49,10 @@ typedef void BitmapMulFunc(uint8_t *restrict dst, ptrdiff_t dst_stride,
 typedef void BeBlurFunc(uint8_t *restrict buf, ptrdiff_t stride,
                         size_t width, size_t height, uint16_t *restrict tmp);
 
+typedef void BitmapShiftFunc(uint8_t *restrict buf, ptrdiff_t stride,
+                             size_t width, size_t height,
+                             uint32_t shift_x, uint32_t shift_y, uint16_t *restrict tmp);
+
 // intermediate bitmaps represented as sets of vertical stripes of int16_t[alignment / 2]
 typedef void Convert8to16Func(int16_t *restrict dst, const uint8_t *restrict src,
                               ptrdiff_t src_stride, size_t width, size_t height);
@@ -76,6 +80,9 @@ typedef struct {
 
     // be blur function
     BeBlurFunc *be_blur;
+
+    // bitmap shift function
+    BitmapShiftFunc *shift_bitmap;
 
     // gaussian blur functions
     Convert8to16Func *stripe_unpack;

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -2767,7 +2767,7 @@ size_t ass_composite_construct(void *key, void *value, void *priv)
         // '>>' rounds toward negative infinity, '&' returns correct remainder
         v->bm_s.left += k->filter.shadow.x >> 6;
         v->bm_s.top  += k->filter.shadow.y >> 6;
-        ass_shift_bitmap(&v->bm_s, k->filter.shadow.x & SUBPIXEL_MASK, k->filter.shadow.y & SUBPIXEL_MASK);
+        ass_shift_bitmap(&render_priv->engine, &v->bm_s, k->filter.shadow.x & SUBPIXEL_MASK, k->filter.shadow.y & SUBPIXEL_MASK);
     }
 
     if ((flags & FILTER_FILL_IN_SHADOW) && !(flags & FILTER_FILL_IN_BORDER))

--- a/libass/c/c_shift_bitmap.c
+++ b/libass/c/c_shift_bitmap.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2024 libass contributors
+ *
+ * This file is part of libass.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "config.h"
+#include "ass_compat.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "ass_utils.h"
+
+
+/**
+ * \brief Shift a bitmap by a fraction of a pixel in x and y directions
+ * expressed in 26.6 fixed point.
+ * Pure C implementation.
+ */
+void ass_shift_bitmap_c(uint8_t *restrict buf, ptrdiff_t s,
+                        size_t w, size_t h,
+                        uint32_t shift_x, uint32_t shift_y, uint16_t *restrict tmp)
+{
+    assert((shift_x & ~63) == 0 && (shift_y & ~63) == 0);
+
+    // Shift in x direction
+    if (shift_x)
+        for (int32_t y = 0; y < h; y++) {
+            for (int32_t x = w - 1; x > 0; x--) {
+                uint8_t b = buf[x + y * s - 1] * shift_x >> 6;
+                buf[x + y * s - 1] -= b;
+                buf[x + y * s] += b;
+            }
+        }
+
+    // Shift in y direction
+    if (shift_y)
+        for (int32_t x = 0; x < w; x++) {
+            for (int32_t y = h - 1; y > 0; y--) {
+                uint8_t b = buf[x + y * s - s] * shift_y >> 6;
+                buf[x + y * s - s] -= b;
+                buf[x + y * s] += b;
+            }
+        }
+}

--- a/libass/meson.build
+++ b/libass/meson.build
@@ -46,6 +46,7 @@ libass_src = files(
     'c/c_blend_bitmaps.c',
     'c/c_blur.c',
     'c/c_rasterizer.c',
+    'c/c_shift_bitmap.c',
     'ass.c',
     'ass_bitmap.c',
     'ass_bitmap_engine.c',

--- a/libass/meson.build
+++ b/libass/meson.build
@@ -36,6 +36,7 @@ src_aarch64 = files(
     'aarch64/blend_bitmaps.S',
     'aarch64/blur.S',
     'aarch64/rasterizer.S',
+    'aarch64/shift_bitmap.S',
 )
 src_fontconfig = files('ass_fontconfig.c')
 src_directwrite = files('ass_directwrite.c')


### PR DESCRIPTION
Followup from #820 (which was originally part of this before being split out).

Rewrites `shift_bitmap` for >20x perf gains. Notable improvements:
- Perform the shift in a single pass instead of splitting into x and y (this also avoids intermediate rounding error)
- Process the shift linearly from top-left to bottom-right, rather than bottom-to-top and right-to-left
- Avoid iterating 2 adjacent rows of the bitmap at once (this confuses the prefetcher); instead use a separate scratch array to store state from the previous row, as in be_blur
- Add ASSUMEs informing the compiler that the stride is 16-byte aligned
- Provide a NEON implementation

The NEON implementation is:
- ~23x as fast as the previous code
- ~2.5x as fast as clang's autovectorized version

This currently only provides C and arm64 implementations; the bitmap_engine code is adjusted to allow for different architectures to have different sets of functions be implemented again. I had some trouble figuring out how this could work on 32-bit x86, since it's extremely SIMD-register-starved; I think in theory it _should_ be doable, but uuuuuuuuugh. Does anyone even care about 32-bit anymore? Anyway, patches welcome, but it shouldn't block merge.