### PR TITLE
ci/gha: run on arm64 macOS

### DIFF
--- a/.github/workflows/ghci.yml
+++ b/.github/workflows/ghci.yml
@@ -41,8 +41,11 @@ jobs:
             # Crash Tests detect (false?) leaks in Fontconfig, and
             # various regression test fail, assumed due to older deps
             skip_tests: yes
-          # MacOS build
-          - os: macos-latest
+          # MacOS Intel
+          - os: macos-13
+            cc: clang
+          # MacOS arm64
+          - os: macos-14
             cc: clang
           # Add a Windows build (MinGW-gcc via MSYS2) with no extras
           - os: windows-2019


### PR DESCRIPTION
It looks like `-latest` is only just now updating from 12: https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image/

The 12 and 13 runners are Intel, while 14 is arm64. Once `-latest` is reliably 14, we can switch back to using that, but keep the 13 runner for Intel.