### PR TITLE
build: add ELF symbol versions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9,6 +9,7 @@ AC_CONFIG_HEADERS([config.h])
 AC_PROG_CC
 AM_PROG_CC_C_O
 AM_PROG_AS
+AC_PROG_EGREP
 
 # Checks for header files.
 AC_CHECK_HEADERS_ONCE([iconv.h])
@@ -47,6 +48,8 @@ AC_ARG_VAR([FUZZ_LDFLAGS],
 AC_ARG_VAR([FUZZ_CPPFLAGS],
     [If fuzzing program is enabled, set this to select alternative modes; see fuzzer source for options.])
 FUZZ_CPPFLAGS="${FUZZ_CPPFLAGS:--DASS_FUZZMODE=0}"
+
+AM_CONDITIONAL([WITH_GNU_LD], [test "$with_gnu_ld" = yes])
 
 # Checks for available libraries and define corresponding C Macros
 # Start with system libs, then check everything else via pkg-config

--- a/gen_defs.py
+++ b/gen_defs.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 
 import sys
+import re
 
 symfile_path = sys.argv[1]
 deffile_path = sys.argv[2]
 
-with open(symfile_path) as symfile:
-    lines = symfile.readlines()
-    lines.insert(0, 'EXPORTS\n')
-    with open(deffile_path, 'w') as deffile:
-        deffile.writelines(lines)
+with open(deffile_path, 'w') as deffile:
+    deffile.write("EXPORTS\n")
+    for line in open(symfile_path, 'r'):
+        a = re.search('(ass_\w+)', line)
+        if a is not None:
+            deffile.write(a.group(1) + "\n")

--- a/libass/Makefile_library.am
+++ b/libass/Makefile_library.am
@@ -65,7 +65,16 @@ libass_libass_la_SOURCES += libass/ass_coretext.h libass/ass_coretext.c
 endif
 
 libass_libass_la_LDFLAGS = -no-undefined -version-info $(LIBASS_LT_CURRENT):$(LIBASS_LT_REVISION):$(LIBASS_LT_AGE)
-libass_libass_la_LDFLAGS += -export-symbols $(top_srcdir)/libass/libass.sym
+if WITH_GNU_LD
+libass_libass_la_LDFLAGS += -Wl,--version-script=$(top_srcdir)/libass/libass.sym
+libass_libass_la_DEPENDENCIES = $(top_srcdir)/libass/libass.sym
+else
+libass_libass_la_LDFLAGS += -export-symbols libass_redux.sym
+libass_libass_la_DEPENDENCIES = libass_redux.sym
+endif
+
+libass_redux.sym: libass.sym
+	$(EGREP) -Eo 'ass([[:alnum:]]|_)+' $@
 
 assheadersdir = $(includedir)/ass
 dist_assheaders_HEADERS = libass/ass_types.h libass/ass.h

--- a/libass/libass.sym
+++ b/libass/libass.sym
@@ -1,46 +1,54 @@
-ass_library_init
-ass_library_done
-ass_library_version
-ass_set_fonts_dir
-ass_set_extract_fonts
-ass_set_style_overrides
-ass_renderer_init
-ass_renderer_done
-ass_set_frame_size
-ass_set_storage_size
-ass_set_margins
-ass_set_use_margins
-ass_set_aspect_ratio
-ass_set_font_scale
-ass_set_hinting
-ass_set_line_spacing
-ass_get_available_font_providers
-ass_set_fonts
-ass_render_frame
-ass_new_track
-ass_free_track
-ass_alloc_style
-ass_alloc_event
-ass_free_style
-ass_free_event
-ass_process_data
-ass_process_codec_private
-ass_process_chunk
-ass_read_file
-ass_read_memory
-ass_read_styles
-ass_add_font
-ass_clear_fonts
-ass_step_sub
-ass_process_force_style
-ass_set_message_cb
-ass_fonts_update
-ass_set_cache_limits
-ass_flush_events
-ass_set_shaper
-ass_set_line_position
-ass_set_pixel_aspect
-ass_set_selective_style_override_enabled
-ass_set_selective_style_override
-ass_set_check_readorder
-ass_track_set_feature
+V_0.13.6 {
+	global:
+	ass_library_init;
+	ass_library_done;
+	ass_library_version;
+	ass_set_fonts_dir;
+	ass_set_extract_fonts;
+	ass_set_style_overrides;
+	ass_renderer_init;
+	ass_renderer_done;
+	ass_set_frame_size;
+	ass_set_storage_size;
+	ass_set_margins;
+	ass_set_use_margins;
+	ass_set_aspect_ratio;
+	ass_set_font_scale;
+	ass_set_hinting;
+	ass_set_line_spacing;
+	ass_get_available_font_providers;
+	ass_set_fonts;
+	ass_render_frame;
+	ass_new_track;
+	ass_free_track;
+	ass_alloc_style;
+	ass_alloc_event;
+	ass_free_style;
+	ass_free_event;
+	ass_process_data;
+	ass_process_codec_private;
+	ass_process_chunk;
+	ass_read_file;
+	ass_read_memory;
+	ass_read_styles;
+	ass_add_font;
+	ass_clear_fonts;
+	ass_step_sub;
+	ass_process_force_style;
+	ass_set_message_cb;
+	ass_fonts_update;
+	ass_set_cache_limits;
+	ass_flush_events;
+	ass_set_shaper;
+	ass_set_line_position;
+	ass_set_pixel_aspect;
+	ass_set_selective_style_override_enabled;
+	ass_set_selective_style_override;
+	ass_set_check_readorder;
+	local:
+	*;
+};
+V_0.16.0 {
+	global:
+	ass_track_set_feature;
+} V_0.13.6;


### PR DESCRIPTION
Building ffmpeg with libass-0.17.0 only encodes "libass.so.9" into ffmpeg. This is a problem when the ffmpeg binary is then taken to run on a system with just libass-0.14.0 (unknown symbol ass_track_set_feature).
    
Adding ELF symbol versions makes ld add extra information to ffmpeg that then e.g. rpm can use to specify additional dependencies and prevent installation of an unworkable combination. ld.so also emits a better error message that the wrong libass version is present.

(Haven't tried the Win32 build, I just have seen to it that gen_defs.py generates the same as before.)