### PR TITLE
[ass_filesystem] Remove unused include

### DIFF
--- a/libass/ass_filesystem.c
+++ b/libass/ass_filesystem.c
@@ -118,7 +118,6 @@ void ass_close_dir(ASS_Dir *dir)
 #else  // Windows
 
 #include <windows.h>
-#include "ass_directwrite.h"  // for ASS_WINAPI_DESKTOP
 
 
 static const uint8_t wtf8_len_table[256] = {


### PR DESCRIPTION
Since ASS_WINAPI_DESKTOP has been centralized, we don't need to include ass_directwrite.h anymore. We only need to include ass_compat.h