### PR TITLE
ass_shaper improvements extracted from threading PR

### DIFF
--- a/libass/ass_font.h
+++ b/libass/ass_font.h
@@ -44,7 +44,7 @@ struct ass_font {
     FT_Library ftlibrary;
     int faces_uid[ASS_FONT_MAX_FACES];
     FT_Face faces[ASS_FONT_MAX_FACES];
-    ASS_ShaperFontData *shaper_priv;
+    struct hb_font_t *hb_fonts[ASS_FONT_MAX_FACES];
     int n_faces;
 };
 

--- a/libass/ass_fontselect.h
+++ b/libass/ass_fontselect.h
@@ -24,7 +24,6 @@
 #include <ft2build.h>
 #include FT_FREETYPE_H
 
-typedef struct ass_shaper_font_data ASS_ShaperFontData;
 typedef struct font_selector ASS_FontSelector;
 typedef struct font_info ASS_FontInfo;
 typedef struct ass_font_stream ASS_FontStream;

--- a/libass/ass_shaper.h
+++ b/libass/ass_shaper.h
@@ -33,6 +33,7 @@ typedef struct ass_shaper ASS_Shaper;
 void ass_shaper_info(ASS_Library *lib);
 ASS_Shaper *ass_shaper_new(Cache *metrics_cache);
 void ass_shaper_free(ASS_Shaper *shaper);
+bool ass_create_hb_font(ASS_Font *font, int index);
 void ass_shaper_set_kerning(ASS_Shaper *shaper, bool kern);
 void ass_shaper_find_runs(ASS_Shaper *shaper, ASS_Renderer *render_priv,
                           GlyphInfo *glyphs, size_t len);
@@ -48,7 +49,5 @@ void ass_shaper_cleanup(ASS_Shaper *shaper, TextInfo *text_info);
 FriBidiStrIndex *ass_shaper_reorder(ASS_Shaper *shaper, TextInfo *text_info);
 FriBidiStrIndex *ass_shaper_get_reorder_map(ASS_Shaper *shaper);
 FriBidiParType ass_resolve_base_direction(int font_encoding);
-
-void ass_shaper_font_data_free(ASS_ShaperFontData *priv);
 
 #endif


### PR DESCRIPTION
Changes to `ass_shaper` made during work on #636 which don't require threading/atomics/locks:
- Keep the `hb_buffer_t` around between calls (it turns out to be fairly expensive to free and re-create in some cases)
- Create the `hb_font_t` eagerly during `add_face`
- Some consolidation of how we access the `FT_Face` and other data during font callbacks

The later changes are required for efficient access to the font object during shaping when running multi-threaded (they allow us to use lock-free cacheing for reads, which avoids most of the locking overhead around the `FT_Face` that we'd otherwise see).