### PR TITLE
drawing: implement EXTEND_SPLINE

### DIFF
--- a/libass/ass_drawing.c
+++ b/libass/ass_drawing.c
@@ -378,9 +378,6 @@ bool ass_drawing_parse(ASS_Outline *outline, ASS_Rect *cbox,
             token = token->next;
             started = true;
             break;
-        default:
-            token = token->next;
-            break;
         }
     }
 

--- a/libass/ass_drawing.c
+++ b/libass/ass_drawing.c
@@ -31,19 +31,6 @@
 #define DRAWING_INITIAL_SEGMENTS 100
 
 /*
- * \brief Check whether a number of items on the list is available
- */
-static bool token_check_values(ASS_DrawingToken *token, int i, ASS_TokenType type)
-{
-    for (int j = 0; j < i; j++) {
-        if (!token || token->type != type) return false;
-        token = token->next;
-    }
-
-    return true;
-}
-
-/*
  * \brief Free a list of tokens
  */
 static void drawing_free_tokens(ASS_DrawingToken *token)
@@ -367,16 +354,13 @@ bool ass_drawing_parse(ASS_Outline *outline, ASS_Rect *cbox,
             break;
         }
         case TOKEN_CUBIC_BEZIER:
-            if (token_check_values(token, 3, TOKEN_CUBIC_BEZIER) &&
-                token->prev) {
-                if (!drawing_add_curve(outline, cbox, token->prev, false, started))
-                    goto error;
-                token = token->next;
-                token = token->next;
-                token = token->next;
-                started = true;
-            } else
-                token = token->next;
+            assert_3_forward(token);
+            if (!drawing_add_curve(outline, cbox, token->prev, false, started))
+                goto error;
+            token = token->next;
+            token = token->next;
+            token = token->next;
+            started = true;
             break;
         case TOKEN_B_SPLINE:
             assert_3_forward(token);

--- a/libass/ass_drawing.c
+++ b/libass/ass_drawing.c
@@ -303,8 +303,7 @@ static bool drawing_add_curve(ASS_Outline *outline, ASS_Rect *cbox,
         p[2].y -= y12;
     }
 
-    return (started ||
-        ass_outline_add_point(outline, p[0], 0)) &&
+    return (started || ass_outline_add_point(outline, p[0], 0)) &&
         ass_outline_add_point(outline, p[1], 0) &&
         ass_outline_add_point(outline, p[2], 0) &&
         ass_outline_add_point(outline, p[3], OUTLINE_CUBIC_SPLINE);

--- a/libass/ass_drawing.h
+++ b/libass/ass_drawing.h
@@ -29,8 +29,7 @@ typedef enum {
     TOKEN_LINE,
     TOKEN_CUBIC_BEZIER,
     TOKEN_B_SPLINE,
-    TOKEN_EXTEND_SPLINE,
-    TOKEN_CLOSE
+    TOKEN_EXTEND_SPLINE
 } ASS_TokenType;
 
 typedef struct ass_drawing_token {


### PR DESCRIPTION
This is the easiest part of our drawing discrepancies and _partially_ fixes the "s ... s ..." case from #202. However the upper left dip is still round and small, instead of a long spike. This probably comes from an unrelated difference in shape closing.

Plus some more cleanup

Relevant [VSFilter code](https://github.com/pinterf/xy-VSFilter/blob/45917d77083d93215738efb140486aba7614947e/src/subtitles/Rasterizer.cpp#L3303-L3309) for reference

Before, After, VSFilter *(from #202)*
![202_before](https://github.com/libass/libass/assets/1668471/adf41447-97f7-4b4d-b4c3-546d72e1c31d)
![202_partial](https://github.com/libass/libass/assets/1668471/a700d37a-0758-4970-903e-6ddd60817781)
![202_vsfilter](https://github.com/libass/libass/assets/1668471/8885db6c-9f30-4d68-87ff-9ffca1e6a4e3)
