### PR TITLE
Match VSFilter’s faux italics on PostScript-outline fonts, too

### DIFF
--- a/libass/ass_font.h
+++ b/libass/ass_font.h
@@ -53,6 +53,7 @@ ASS_Font *ass_font_new(ASS_Renderer *render_priv, ASS_FontDesc *desc);
 void ass_face_set_size(FT_Face face, double size);
 int ass_face_get_weight(FT_Face face);
 FT_Long ass_face_get_style_flags(FT_Face face);
+bool ass_face_is_postscript(FT_Face face);
 void ass_font_get_asc_desc(ASS_Font *font, int face_index,
                            int *asc, int *desc);
 int ass_font_get_index(ASS_FontSelector *fontsel, ASS_Font *font,

--- a/libass/ass_fontselect.c
+++ b/libass/ass_fontselect.c
@@ -35,7 +35,6 @@
 #include FT_SFNT_NAMES_H
 #include FT_TRUETYPE_IDS_H
 #include FT_TRUETYPE_TABLES_H
-#include FT_TYPE1_TABLES_H
 
 #include "ass_utils.h"
 #include "ass.h"
@@ -259,7 +258,6 @@ get_font_info(FT_Library lib, FT_Face face, const char *fallback_family_name,
     int num_names = FT_Get_Sfnt_Name_Count(face);
     char *fullnames[MAX_FULLNAME];
     char *families[MAX_FULLNAME];
-    PS_FontInfoRec postscript_info;
 
     // we're only interested in outlines
     if (!(face->face_flags & FT_FACE_FLAG_SCALABLE))
@@ -314,7 +312,7 @@ get_font_info(FT_Library lib, FT_Face face, const char *fallback_family_name,
     info->style_flags = ass_face_get_style_flags(face);
 
     info->postscript_name = (char *)FT_Get_Postscript_Name(face);
-    info->is_postscript = !FT_Get_PS_Font_Info(face, &postscript_info);
+    info->is_postscript = ass_face_is_postscript(face);
 
     if (num_family) {
         info->families = calloc(sizeof(char *), num_family);


### PR DESCRIPTION
#676 previously adjusted our faux italics to match GDI/VSFilter on TrueType fonts, but we later discovered that PostScript-outline fonts behave differently (font driver differences strike again) and our rendering became _less_ similar to VSFilter’s after that change. This should fix it.

I derived the coefficient experimentally using Fansub Block. The first-approximation value I got was awfully close to 10° (9.998°), so I figure it’s probably exactly 10°. Thus, I’ve hardcoded the closest fixed-point representation of tan(10°) in this commit.

TrueType:
![A screenshot shows a parallelogram whose interior angle is about 71.2°.](https://github.com/libass/libass/assets/515193/3e6af538-5c66-4d4f-b56f-656596379081)

PostScript:
![A screenshot shows a parallelogram whose interior angle is about 80.0°.](https://github.com/libass/libass/assets/515193/dd723623-b7a5-4188-a72e-d54b84340f43)