### PR TITLE
Constify API parameters where possible

### DIFF
--- a/libass/ass.c
+++ b/libass/ass.c
@@ -1222,7 +1222,7 @@ static int process_text(ASS_Track *track, char *str)
  * \param data string to parse
  * \param size length of data
 */
-void ass_process_data(ASS_Track *track, char *data, int size)
+void ass_process_data(ASS_Track *track, const char *data, int size)
 {
     char *str = malloc(size + 1);
     if (!str)
@@ -1243,7 +1243,7 @@ void ass_process_data(ASS_Track *track, char *data, int size)
  * \param size length of data
  CodecPrivate section contains [Stream Info] and [V4+ Styles] ([V4 Styles] for SSA) sections
 */
-void ass_process_codec_private(ASS_Track *track, char *data, int size)
+void ass_process_codec_private(ASS_Track *track, const char *data, int size)
 {
     ass_process_data(track, data, size);
 
@@ -1279,7 +1279,7 @@ void ass_set_check_readorder(ASS_Track *track, int check_readorder)
  * \param timecode starting time of the event (milliseconds)
  * \param duration duration of the event (milliseconds)
 */
-void ass_process_chunk(ASS_Track *track, char *data, int size,
+void ass_process_chunk(ASS_Track *track, const char *data, int size,
                        long long timecode, long long duration)
 {
     char *str = NULL;
@@ -1367,7 +1367,7 @@ void ass_flush_events(ASS_Track *track)
  * \return a pointer to recoded buffer, caller is responsible for freeing it
 **/
 static char *sub_recode(ASS_Library *library, char *data, size_t size,
-                        char *codepage)
+                        const char *codepage)
 {
     iconv_t icdsc;
     char *tocp = "UTF-8";
@@ -1535,7 +1535,7 @@ static ASS_Track *parse_memory(ASS_Library *library, char *buf)
  * \return newly allocated track
 */
 ASS_Track *ass_read_memory(ASS_Library *library, char *buf,
-                           size_t bufsize, char *codepage)
+                           size_t bufsize, const char *codepage)
 {
     ASS_Track *track;
     int copied = 0;
@@ -1571,8 +1571,8 @@ ASS_Track *ass_read_memory(ASS_Library *library, char *buf,
     return track;
 }
 
-static char *read_file_recode(ASS_Library *library, char *fname,
-                              char *codepage, size_t *size)
+static char *read_file_recode(ASS_Library *library, const char *fname,
+                              const char *codepage, size_t *size)
 {
     char *buf;
     size_t bufsize;
@@ -1600,8 +1600,8 @@ static char *read_file_recode(ASS_Library *library, char *fname,
  * \param codepage recode buffer contents from given codepage
  * \return newly allocated track
 */
-ASS_Track *ass_read_file(ASS_Library *library, char *fname,
-                         char *codepage)
+ASS_Track *ass_read_file(ASS_Library *library, const char *fname,
+                         const char *codepage)
 {
     char *buf;
     ASS_Track *track;
@@ -1627,7 +1627,7 @@ ASS_Track *ass_read_file(ASS_Library *library, char *fname,
 /**
  * \brief read styles from file into already initialized track
  */
-int ass_read_styles(ASS_Track *track, char *fname, char *codepage)
+int ass_read_styles(ASS_Track *track, const char *fname, const char *codepage)
 {
     char *buf;
     ParserState old_state;

--- a/libass/ass.h
+++ b/libass/ass.h
@@ -24,7 +24,7 @@
 #include <stdarg.h>
 #include "ass_types.h"
 
-#define LIBASS_VERSION 0x01702000
+#define LIBASS_VERSION 0x01702010
 
 #ifdef __cplusplus
 extern "C" {
@@ -324,9 +324,14 @@ void ass_set_extract_fonts(ASS_Library *priv, int extract);
  *   ScaledBorderAndShadow=yes
  *
  * \param priv library handle
- * \param list NULL-terminated list of strings
+ * \param list NULL-terminated list of strings,
+ *             copied and never modified by libass
  */
+#ifdef __cplusplus
+void ass_set_style_overrides(ASS_Library *priv, const char *const *list);
+#else
 void ass_set_style_overrides(ASS_Library *priv, char **list);
+#endif
 
 /**
  * \brief Explicitly process style overrides for a track.
@@ -690,7 +695,7 @@ void ass_free_event(ASS_Track *track, int eid);
  * \param data string to parse
  * \param size length of data
  */
-void ass_process_data(ASS_Track *track, char *data, int size);
+void ass_process_data(ASS_Track *track, const char *data, int size);
 
 /**
  * \brief Parse Codec Private section of the subtitle stream, in Matroska
@@ -699,7 +704,7 @@ void ass_process_data(ASS_Track *track, char *data, int size);
  * \param data string to parse
  * \param size length of data
  */
-void ass_process_codec_private(ASS_Track *track, char *data, int size);
+void ass_process_codec_private(ASS_Track *track, const char *data, int size);
 
 /**
  * \brief Parse a chunk of subtitle stream data. A chunk contains exactly one
@@ -715,7 +720,7 @@ void ass_process_codec_private(ASS_Track *track, char *data, int size);
  * \param timecode starting time of the event (milliseconds)
  * \param duration duration of the event (milliseconds)
  */
-void ass_process_chunk(ASS_Track *track, char *data, int size,
+void ass_process_chunk(ASS_Track *track, const char *data, int size,
                        long long timecode, long long duration);
 
 /**
@@ -747,8 +752,8 @@ void ass_flush_events(ASS_Track *track);
  * if both versions are valid and exist.
  * On all other systems there is no need for special considerations like that.
 */
-ASS_Track *ass_read_file(ASS_Library *library, char *fname,
-                         char *codepage);
+ASS_Track *ass_read_file(ASS_Library *library, const char *fname,
+                         const char *codepage);
 
 /**
  * \brief Read subtitles from memory.
@@ -759,7 +764,7 @@ ASS_Track *ass_read_file(ASS_Library *library, char *fname,
  * \return newly allocated track or NULL on failure
 */
 ASS_Track *ass_read_memory(ASS_Library *library, char *buf,
-                           size_t bufsize, char *codepage);
+                           size_t bufsize, const char *codepage);
 /**
  * \brief Read styles from file into already initialized track.
  * \param fname file name
@@ -771,7 +776,7 @@ ASS_Track *ass_read_memory(ASS_Library *library, char *buf,
  * if both versions are valid and exist.
  * On all other systems there is no need for special considerations like that.
  */
-int ass_read_styles(ASS_Track *track, char *fname, char *codepage);
+int ass_read_styles(ASS_Track *track, const char *fname, const char *codepage);
 
 /**
  * \brief Add a memory font.

--- a/libass/ass_library.c
+++ b/libass/ass_library.c
@@ -78,6 +78,7 @@ void ass_set_extract_fonts(ASS_Library *priv, int extract)
 
 void ass_set_style_overrides(ASS_Library *priv, char **list)
 {
+    // Documentation promises input lists gets copied without modifications
     char **p;
     char **q;
     int cnt;


### PR DESCRIPTION
We constified memory font data before in #448. Prompted by running into filepaths not being `const`, this now constifies most `char*`-related API paramters if they’re already effectively treated as const anyway and the new signature is pointer-compatible with the existing one.