### PR TITLE
ass_filesystem: Fix add_separator compilation warning 

### DIFF
--- a/libass/ass_filesystem.c
+++ b/libass/ass_filesystem.c
@@ -302,13 +302,16 @@ static bool open_dir_wtf8(ASS_Dir *dir, ASS_StringView path)
     if (!wpath)
         return false;
 
-    bool add_separator;
     WIN32_FIND_DATAW data;
     WCHAR *end = convert_wtf8to16(wpath, path);
-    if (end) {
-        add_separator = append_tail(wpath, end - wpath);
-        dir->handle = FindFirstFileExW(wpath, FindExInfoBasic, &data, FindExSearchNameMatch, NULL, 0);
+    if (!end) {
+        free(wpath);
+        return false;
     }
+
+    bool add_separator = append_tail(wpath, end - wpath);
+    dir->handle = FindFirstFileExW(wpath, FindExInfoBasic, &data, FindExSearchNameMatch, NULL, 0);
+
     free(wpath);
     if (dir->handle == INVALID_HANDLE_VALUE)
         return false;


### PR DESCRIPTION
```
In function 'open_dir_wtf8',
    inlined from 'ass_open_dir' at ../libass-0.17.2/libass/ass_filesystem.c:339:9:
../libass-0.17.2/libass/ass_filesystem.c:325:8: warning: 'add_separator' may be used uninitialized [-Wmaybe-uninitialized]
  325 |     if (add_separator)
      |        ^
../libass-0.17.2/libass/ass_filesystem.c: In function 'ass_open_dir':
../libass-0.17.2/libass/ass_filesystem.c:305:10: note: 'add_separator' was declared here
  305 |     bool add_separator;
```

`add_separator` will never be used uninitialized as the function starts with the assert. But that's not ideal nonetheless.