### PR TITLE
ass_parse: use memchr in ass_parse_tags

### DIFF
--- a/libass/ass_parse.c
+++ b/libass/ass_parse.c
@@ -333,8 +333,11 @@ char *ass_parse_tags(RenderContext *state, char *p, char *end, double pwr,
                     // be either a backslash-argument or simply the last argument.
                     if (*r == '\\') {
                         has_backslash_arg = true;
-                        while (*r != ')' && r != end)
-                            ++r;
+                        char *paren = memchr(r, ')', end - r);
+                        if (paren)
+                            r = paren;
+                        else
+                            r = end;
                     }
                     push_arg(args, &nargs, q, r);
                     q = r;


### PR DESCRIPTION
I don't have a sample that's affected by this, but I'd expect it to be a little faster in some cases relating to clips. Hard to imagine this *hurts*, at any rate.