### PR TITLE
ass_utils: add ass_malloc and ass_free routines

### DIFF
--- a/libass/Makefile_library.am
+++ b/libass/Makefile_library.am
@@ -1,6 +1,6 @@
-LIBASS_LT_CURRENT = 11
-LIBASS_LT_REVISION = 2
-LIBASS_LT_AGE = 2
+LIBASS_LT_CURRENT = 12
+LIBASS_LT_REVISION = 0
+LIBASS_LT_AGE = 3
 
 .asm.lo:
 	$(nasm_verbose)$(LIBTOOL) $(AM_V_lt) --tag=CC --mode=compile $(top_srcdir)/ltnasm.sh $(AS) $(ASFLAGS) -I$(top_srcdir)/libass/ -Dprivate_prefix=ass -o $@ $<

--- a/libass/ass.h
+++ b/libass/ass.h
@@ -24,7 +24,7 @@
 #include <stdarg.h>
 #include "ass_types.h"
 
-#define LIBASS_VERSION 0x01702010
+#define LIBASS_VERSION 0x01702020
 
 #ifdef __cplusplus
 extern "C" {
@@ -806,6 +806,22 @@ void ass_clear_fonts(ASS_Library *library);
  * \return timeshift in milliseconds
  */
 long long ass_step_sub(ASS_Track *track, long long now, int movement);
+
+/**
+ * \brief Allocates memory that can be safely freed by libass later.
+ * Use this to allocate buffers you'll use to manually modify ASS_Track events
+ * or related structures.
+ * \param size number of bytes to allocate
+ * \return pointer to the allocated buffer, or NULL on failure
+ */
+void *ass_malloc(size_t size);
+
+/**
+ * \brief Releases memory previously allocated within libass.
+ * Use this to free memory allocated using ass_malloc.
+ * \param ptr pointer to the buffer to release; passing NULL is a no-op
+ */
+void ass_free(void *ptr);
 
 #undef ASS_DEPRECATED
 #undef ASS_DEPRECATED_ENUM

--- a/libass/ass_library.c
+++ b/libass/ass_library.c
@@ -158,3 +158,13 @@ void ass_set_message_cb(ASS_Library *priv,
         priv->msg_callback_data = data;
     }
 }
+
+void *ass_malloc(size_t size)
+{
+    return malloc(size);
+}
+
+void ass_free(void *ptr)
+{
+    free(ptr);
+}

--- a/libass/ass_types.h
+++ b/libass/ass_types.h
@@ -38,6 +38,11 @@
  * By nature of direct struct modifications working closer to library internals,
  * workflows that make use of this possibility are also more likely to be
  * affected by future API breaks than those which do not.
+ * If modifying a libass struct to contain a pointer to a user-allocated buffer,
+ * the buffer should be allocated using ass_malloc(). Failing to do so may result
+ * in undefined behavior if the buffer is later freed within libass, and the caller
+ * is linked against a different libc instance than libass itself. Similarly, any
+ * existing buffer being replaced or removed should be released using ass_free().
  *
  * To avoid desynchronisation with internal states, there are some restrictions
  * on when and how direct struct modification can be performed.

--- a/libass/libass.sym
+++ b/libass/libass.sym
@@ -44,3 +44,5 @@ ass_set_selective_style_override_enabled
 ass_set_selective_style_override
 ass_set_check_readorder
 ass_track_set_feature
+ass_malloc
+ass_free


### PR DESCRIPTION
These are simple wrappers around the libc malloc/free routines. Exposing them allows for safe heap usage across shared library boundaries in cases where there may be multiple instances of the libc functions present in the same process (e.g. libc statically linked into a shared lib). This mostly affects Windows.