### PR TITLE
fontconfig: query a sorted list

### DIFF
--- a/libass/ass_fontconfig.c
+++ b/libass/ass_fontconfig.c
@@ -94,9 +94,18 @@ static bool scan_fonts(FcConfig *config, ASS_FontProvider *provider)
     FcFontSet *fonts;
     ASS_FontProviderMetaData meta = {0};
 
-    // get list of fonts
-    fonts = FcConfigGetFonts(config, FcSetSystem);
-    if (!fonts)
+    // get list of fonts;
+    // sorting by default pattern prefers regular variants
+    FcPattern *pat = FcPatternCreate();
+    if (!pat)
+        return false;
+
+    FcDefaultSubstitute(pat);
+    FcResult res;
+    // trim=FcFalse returns all system fonts
+    fonts = FcFontSort(config, pat, FcFalse, NULL, &res);
+    FcPatternDestroy(pat);
+    if (res != FcResultMatch)
         return false;
 
     // fill font_info list
@@ -200,6 +209,7 @@ static bool scan_fonts(FcConfig *config, ASS_FontProvider *provider)
         ass_font_provider_add_font(provider, &meta, path, index, (void *)pat);
     }
 
+    FcFontSetDestroy(fonts);
     return true;
 }
 

--- a/libass/ass_fontconfig.c
+++ b/libass/ass_fontconfig.c
@@ -351,7 +351,7 @@ ass_fontconfig_add_provider(ASS_Library *lib, ASS_FontSelector *selector,
         rc = FcConfigBuildFonts(fc->config);
 
     if (!rc || !fc->config) {
-        ass_msg(lib, MSGL_FATAL,
+        ass_msg(lib, MSGL_ERR,
                 "No valid fontconfig configuration found!");
         FcConfigDestroy(fc->config);
         free(fc);

--- a/libass/ass_fontconfig.c
+++ b/libass/ass_fontconfig.c
@@ -71,6 +71,11 @@ static bool check_glyph(void *priv, uint32_t code)
     return false;
 }
 
+static void destroy_font(void *priv)
+{
+    FcPatternDestroy((FcPattern *) priv);
+}
+
 static void destroy(void *priv)
 {
     ProviderPrivate *fc = (ProviderPrivate *)priv;
@@ -189,6 +194,7 @@ static void scan_fonts(FcConfig *config, ASS_FontProvider *provider)
         if (result != FcResultMatch)
             meta.postscript_name = NULL;
 
+        FcPatternReference(pat);
         ass_font_provider_add_font(provider, &meta, path, index, (void *)pat);
     }
 }
@@ -314,6 +320,7 @@ cleanup:
 static ASS_FontProviderFuncs fontconfig_callbacks = {
     .check_postscript   = check_postscript,
     .check_glyph        = check_glyph,
+    .destroy_font       = destroy_font,
     .destroy_provider   = destroy,
     .get_substitutions  = get_substitutions,
     .get_fallback       = get_fallback,

--- a/libass/ass_fontselect.c
+++ b/libass/ass_fontselect.c
@@ -196,6 +196,8 @@ ASS_FontProvider *
 ass_font_provider_new(ASS_FontSelector *selector, ASS_FontProviderFuncs *funcs,
                       void *data)
 {
+    assert(funcs->check_glyph && funcs->destroy_font);
+
     ASS_FontProvider *provider = calloc(1, sizeof(ASS_FontProvider));
     if (provider == NULL)
         return NULL;

--- a/libass/ass_fontselect.c
+++ b/libass/ass_fontselect.c
@@ -521,9 +521,7 @@ error:
 
     free_font_info(&implicit_meta);
     free(implicit_meta.postscript_name);
-
-    if (provider->funcs.destroy_font)
-        provider->funcs.destroy_font(data);
+    provider->funcs.destroy_font(data);
 
     return false;
 }
@@ -565,10 +563,7 @@ void ass_font_provider_free(ASS_FontProvider *provider)
 
         if (info->provider == provider) {
             ass_font_provider_free_fontinfo(info);
-
-            if (info->provider->funcs.destroy_font)
-                info->provider->funcs.destroy_font(info->priv);
-
+            info->provider->funcs.destroy_font(info->priv);
             info->provider = NULL;
         }
 

--- a/libass/ass_fontselect.h
+++ b/libass/ass_fontselect.h
@@ -159,7 +159,7 @@ typedef struct font_provider_funcs {
     GetDataFunc         get_data;               /* optional/mandatory */
     CheckPostscriptFunc check_postscript;       /* optional */
     CheckGlyphFunc      check_glyph;            /* mandatory */
-    DestroyFontFunc     destroy_font;           /* optional */
+    DestroyFontFunc     destroy_font;           /* mandatory */
     DestroyProviderFunc destroy_provider;       /* optional */
     MatchFontsFunc      match_fonts;            /* optional */
     SubstituteFontFunc  get_substitutions;      /* optional */


### PR DESCRIPTION
Based on IRC discussion an alternative to #777.
Posted as a new PR to make it easier to compare both approaches

Notably this adds language as a sorting parameter, which our existing `cache_fallbacks` logic makes an explicit effort to remove, but discussion in the RedHat issue linked from #737 suggests we might actually want this.
Also this omits any `FcConfigSubstitute` calls even though Fontconfig docs require it

Given the question of efficiency (re repeated width queries) was raised over in #777: i’d expect, but haven’t verified, this approach to be more perf costly given it does more (than we actually need). Not sure if the impact is relevant though