### PR TITLE
Deal with shared-only checkasm

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -20,6 +20,7 @@ nasm_verbose_ = $(nasm_verbose_$(AM_DEFAULT_VERBOSITY))
 nasm_verbose_0 = @echo "  NASM    " $@;
 
 lib_LTLIBRARIES =
+noinst_LTLIBRARIES =
 noinst_PROGRAMS =
 check_PROGRAMS =
 TESTS =

--- a/Makefile_util.am
+++ b/Makefile_util.am
@@ -54,7 +54,8 @@ checkasm_checkasm_SOURCES = \
     checkasm/blend_bitmaps.c \
     checkasm/be_blur.c \
     checkasm/blur.c \
-    checkasm/checkasm.h checkasm/checkasm.c
+    checkasm/checkasm.h checkasm/checkasm.c \
+    libass/ass_rasterizer.h libass/ass_utils.h
 
 checkasm_checkasm_CPPFLAGS = -I$(top_srcdir)/libass
 checkasm_checkasm_LDADD = libass/libass.la

--- a/Makefile_util.am
+++ b/Makefile_util.am
@@ -58,7 +58,7 @@ checkasm_checkasm_SOURCES = \
     libass/ass_rasterizer.h libass/ass_utils.h
 
 checkasm_checkasm_CPPFLAGS = -I$(top_srcdir)/libass
-checkasm_checkasm_LDADD = libass/libass.la
+checkasm_checkasm_LDADD = libass/libass_internal.la
 checkasm_checkasm_LDFLAGS = $(AM_LDFLAGS) -static
 
 if X86

--- a/checkasm/be_blur.c
+++ b/checkasm/be_blur.c
@@ -18,6 +18,8 @@
 
 #include "checkasm.h"
 
+#include <string.h>
+
 #define HEIGHT 8
 #define STRIDE 64
 #define MIN_WIDTH 2

--- a/checkasm/blend_bitmaps.c
+++ b/checkasm/blend_bitmaps.c
@@ -18,6 +18,8 @@
 
 #include "checkasm.h"
 
+#include <string.h>
+
 #define HEIGHT 8
 #define DST_STRIDE 64
 #define MIN_WIDTH  1

--- a/checkasm/blur.c
+++ b/checkasm/blur.c
@@ -16,7 +16,10 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#include "ass_utils.h"
 #include "checkasm.h"
+
+#include <string.h>
 
 #define HEIGHT 13
 #define STRIDE 64

--- a/checkasm/checkasm.c
+++ b/checkasm/checkasm.c
@@ -25,6 +25,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "ass_utils.h"
 #include "checkasm.h"
 
 #include <math.h>

--- a/checkasm/checkasm.h
+++ b/checkasm/checkasm.h
@@ -30,7 +30,7 @@
 
 #include "config.h"
 
-#include "ass_bitmap.h"
+#include "ass_bitmap_engine.h"
 
 #include <stdint.h>
 #include <stdlib.h>

--- a/libass/Makefile_library.am
+++ b/libass/Makefile_library.am
@@ -5,8 +5,8 @@ LIBASS_LT_AGE = 2
 .asm.lo:
 	$(nasm_verbose)$(LIBTOOL) $(AM_V_lt) --tag=CC --mode=compile $(top_srcdir)/ltnasm.sh $(AS) $(ASFLAGS) -I$(top_srcdir)/libass/ -Dprivate_prefix=ass -o $@ $<
 
-lib_LTLIBRARIES += libass/libass.la
-libass_libass_la_SOURCES = \
+noinst_LTLIBRARIES += libass/libass_internal.la
+libass_libass_internal_la_SOURCES = \
     libass/ass_utils.h libass/ass_utils.c \
     libass/ass_string.h libass/ass_string.c \
     libass/ass_compat.h libass/ass_strtod.c \
@@ -32,7 +32,7 @@ libass_libass_la_SOURCES = \
 
 if ASM
 if X86
-libass_libass_la_SOURCES += \
+libass_libass_internal_la_SOURCES += \
     libass/x86/rasterizer.asm \
     libass/x86/blend_bitmaps.asm \
     libass/x86/be_blur.asm \
@@ -40,7 +40,7 @@ libass_libass_la_SOURCES += \
     libass/x86/cpuid.h libass/x86/cpuid.asm
 endif
 if AARCH64
-libass_libass_la_SOURCES += \
+libass_libass_internal_la_SOURCES += \
     libass/aarch64/rasterizer.S \
     libass/aarch64/blend_bitmaps.S \
     libass/aarch64/be_blur.S \
@@ -50,20 +50,23 @@ endif
 endif
 
 if FONTCONFIG
-libass_libass_la_SOURCES += libass/ass_fontconfig.h libass/ass_fontconfig.c
+libass_libass_internal_la_SOURCES += libass/ass_fontconfig.h libass/ass_fontconfig.c
 endif
 
 if DIRECTWRITE
-libass_libass_la_SOURCES += \
+libass_libass_internal_la_SOURCES += \
     libass/dwrite_c.h \
     libass/ass_directwrite_info_template.h \
     libass/ass_directwrite.h libass/ass_directwrite.c
 endif
 
 if CORETEXT
-libass_libass_la_SOURCES += libass/ass_coretext.h libass/ass_coretext.c
+libass_libass_internal_la_SOURCES += libass/ass_coretext.h libass/ass_coretext.c
 endif
 
+lib_LTLIBRARIES += libass/libass.la
+libass_libass_la_LIBADD = libass/libass_internal.la
+libass_libass_la_SOURCES =
 libass_libass_la_LDFLAGS = -no-undefined -version-info $(LIBASS_LT_CURRENT):$(LIBASS_LT_REVISION):$(LIBASS_LT_AGE)
 libass_libass_la_LDFLAGS += -export-symbols $(top_srcdir)/libass/libass.sym
 


### PR DESCRIPTION
Take this PR more as a place for discussion about the right approach rather than pushing for the approach of the current patch

The simple way to fix this: just don’t run `checkasm` if there’s no static lib. *(what this PR currently does)*

iirc, originally (before merge) all relevant libass source files were also included in checkasm sources and there was no library link. This would have avoided this issue but introduced possible mismatches between lib and checkasm compile flags and thus changed.

To avoid both we could build just the bitmap engine + assembly as a always static-only internal lib and reuse it for checkasm. ~~However, at first glance I’m not sure how to tell libtool to build a library always static and if we use regular automake static libs, some flags (like PIC) might not be set automatically for source files of this internal static lib... *(but on the upside, i believe we could drop `ltnasm.sh`)*~~
`noinst_LTLIBRARIES` ~~or `EXTRA_LTLIBRARIES`~~ maybe work?

