### PR TITLE
Cache changes extracted from threading PR

### DIFF
--- a/libass/ass_cache.h
+++ b/libass/ass_cache.h
@@ -100,8 +100,6 @@ void *ass_cache_key(void *value);
 void ass_cache_inc_ref(void *value);
 void ass_cache_dec_ref(void *value);
 void ass_cache_cut(Cache *cache, size_t max_size);
-void ass_cache_stats(Cache *cache, size_t *size, unsigned *hits,
-                     unsigned *misses, unsigned *count);
 void ass_cache_empty(Cache *cache);
 void ass_cache_done(Cache *cache);
 Cache *ass_font_cache_create(void);

--- a/libass/ass_font.c
+++ b/libass/ass_font.c
@@ -481,7 +481,6 @@ ASS_Font *ass_font_new(ASS_Renderer *render_priv, ASS_FontDesc *desc)
         return NULL;
     if (font->library)
         return font;
-    ass_cache_dec_ref(font);
     return NULL;
 }
 

--- a/libass/ass_parse.c
+++ b/libass/ass_parse.c
@@ -111,7 +111,6 @@ void ass_update_font(RenderContext *state)
         val = 0;                // normal
     desc.italic = val;
 
-    ass_cache_dec_ref(state->font);
     state->font = ass_font_new(state->renderer, &desc);
 }
 


### PR DESCRIPTION
I'm continuing to break up #636 into more-digestible chunks. This is a small portion of the changes to cache infrastructure, but includes the bulk of the changes to the cache's actual externally-visible behavior, which will make other chunks easier to break out from here.

- Remove unused stats functionality
- Don't increment refcount on cache hits