### PR TITLE
Cache per-size metrics in shaper

### DIFF
--- a/libass/ass_cache.c
+++ b/libass/ass_cache.c
@@ -263,6 +263,37 @@ const CacheDesc outline_cache_desc = {
 };
 
 
+// font-face size metric cache
+static bool face_size_metrics_key_move(void *dst, void *src)
+{
+    FaceSizeMetricsHashKey *d = dst, *s = src;
+    if (!d)
+        return true;
+
+    *d = *s;
+    ass_cache_inc_ref(s->font);
+    return true;
+}
+
+static void face_size_metrics_destruct(void *key, void *value)
+{
+    FaceSizeMetricsHashKey *k = key;
+    ass_cache_dec_ref(k->font);
+}
+
+size_t ass_face_size_metrics_construct(void *key, void *value, void *priv);
+
+const CacheDesc face_size_metrics_cache_desc = {
+    .hash_func = face_size_metrics_hash,
+    .compare_func = face_size_metrics_compare,
+    .key_move_func = face_size_metrics_key_move,
+    .construct_func = ass_face_size_metrics_construct,
+    .destruct_func = face_size_metrics_destruct,
+    .key_size = sizeof(FaceSizeMetricsHashKey),
+    .value_size = sizeof(FT_Size_Metrics)
+};
+
+
 // glyph metric cache
 static bool glyph_metrics_key_move(void *dst, void *src)
 {
@@ -527,6 +558,11 @@ Cache *ass_outline_cache_create(void)
 Cache *ass_glyph_metrics_cache_create(void)
 {
     return ass_cache_create(&glyph_metrics_cache_desc);
+}
+
+Cache *ass_face_size_metrics_cache_create(void)
+{
+    return ass_cache_create(&face_size_metrics_cache_desc);
 }
 
 Cache *ass_bitmap_cache_create(void)

--- a/libass/ass_cache.h
+++ b/libass/ass_cache.h
@@ -104,6 +104,7 @@ void ass_cache_empty(Cache *cache);
 void ass_cache_done(Cache *cache);
 Cache *ass_font_cache_create(void);
 Cache *ass_outline_cache_create(void);
+Cache *ass_face_size_metrics_cache_create(void);
 Cache *ass_glyph_metrics_cache_create(void);
 Cache *ass_bitmap_cache_create(void);
 Cache *ass_composite_cache_create(void);

--- a/libass/ass_cache.h
+++ b/libass/ass_cache.h
@@ -55,6 +55,7 @@ typedef void (*CacheItemDestructor)(void *key, void *value);
 
 // cache hash keys
 
+// ownership of members of the types in the union is documented in ass_cache_template.h
 typedef struct outline_hash_key {
     enum {
         OUTLINE_GLYPH,
@@ -77,6 +78,9 @@ enum {
     FILTER_FILL_IN_BORDER = 0x10,
 };
 
+// ass_cache_get() takes ownership of the bitmaps array and either frees it
+// or persists it in the item key; individual bitmaps in the array behave
+// as documented in ass_cache_template.h
 typedef struct {
     FilterDesc filter;
     size_t bitmap_count;

--- a/libass/ass_cache_template.h
+++ b/libass/ass_cache_template.h
@@ -67,6 +67,12 @@ START(bitmap, bitmap_hash_key)
     VECTOR(matrix_z)
 END(BitmapHashKey)
 
+START(face_size_metrics, face_size_metrics_hash_key)
+    GENERIC(ASS_Font *, font)
+    GENERIC(double, size)
+    GENERIC(int, face_index)
+END(FaceSizeMetricsHashKey)
+
 START(glyph_metrics, glyph_metrics_hash_key)
     GENERIC(ASS_Font *, font)
     GENERIC(double, size)

--- a/libass/ass_cache_template.h
+++ b/libass/ass_cache_template.h
@@ -58,6 +58,7 @@ START(font, ass_font_desc )
 END(ASS_FontDesc)
 
 // describes an outline bitmap
+// outline is refed when inserted and unrefed when dropped
 START(bitmap, bitmap_hash_key)
     GENERIC(OutlineHashValue *, outline)
     // quantized transform matrix
@@ -67,12 +68,14 @@ START(bitmap, bitmap_hash_key)
     VECTOR(matrix_z)
 END(BitmapHashKey)
 
+// font is refed when inserted and unrefed when dropped
 START(face_size_metrics, face_size_metrics_hash_key)
     GENERIC(ASS_Font *, font)
     GENERIC(double, size)
     GENERIC(int, face_index)
 END(FaceSizeMetricsHashKey)
 
+// font is refed when inserted and unrefed when dropped
 START(glyph_metrics, glyph_metrics_hash_key)
     GENERIC(ASS_Font *, font)
     GENERIC(double, size)
@@ -81,6 +84,7 @@ START(glyph_metrics, glyph_metrics_hash_key)
 END(GlyphMetricsHashKey)
 
 // describes an outline glyph
+// font is refed when inserted and unrefed when dropped
 START(glyph, glyph_hash_key)
     GENERIC(ASS_Font *, font)
     GENERIC(double, size) // font size
@@ -92,11 +96,14 @@ START(glyph, glyph_hash_key)
 END(GlyphHashKey)
 
 // describes an outline drawing
+// on call to ass_cache_get(), text is a non-owning view;
+// its content is duplicated when inserted; the copy is freed when dropped
 START(drawing, drawing_hash_key)
     STRING(text)
 END(DrawingHashKey)
 
 // describes an offset outline
+// outline is refed when inserted and unrefed when dropped
 START(border, border_hash_key)
     GENERIC(OutlineHashValue *, outline)
     // outline is scaled by 2^scale_ord_x|y before stroking
@@ -116,6 +123,7 @@ START(filter, filter_desc)
 END(FilterDesc)
 
 // describes glyph bitmap reference
+// bm and bm_o are refed when inserted and unrefed when dropped
 START(bitmap_ref, bitmap_ref_key)
     GENERIC(Bitmap *, bm)
     GENERIC(Bitmap *, bm_o)

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -83,7 +83,7 @@ static bool render_context_init(RenderContext *state, ASS_Renderer *priv)
     if (!text_info_init(&state->text_info))
         return false;
 
-    if (!(state->shaper = ass_shaper_new(priv->cache.metrics_cache)))
+    if (!(state->shaper = ass_shaper_new(priv->cache.metrics_cache, priv->cache.face_size_metrics_cache)))
         return false;
 
     return ass_rasterizer_init(&priv->engine, &state->rasterizer, RASTERIZER_PRECISION);
@@ -139,8 +139,11 @@ ASS_Renderer *ass_renderer_init(ASS_Library *library)
     priv->cache.bitmap_cache = ass_bitmap_cache_create();
     priv->cache.composite_cache = ass_composite_cache_create();
     priv->cache.outline_cache = ass_outline_cache_create();
+    priv->cache.face_size_metrics_cache = ass_face_size_metrics_cache_create();
     priv->cache.metrics_cache = ass_glyph_metrics_cache_create();
-    if (!priv->cache.font_cache || !priv->cache.bitmap_cache || !priv->cache.composite_cache || !priv->cache.outline_cache || !priv->cache.metrics_cache)
+    if (!priv->cache.font_cache || !priv->cache.bitmap_cache ||
+        !priv->cache.composite_cache || !priv->cache.outline_cache ||
+        !priv->cache.face_size_metrics_cache || !priv->cache.metrics_cache)
         goto fail;
 
     priv->cache.glyph_max = GLYPH_CACHE_MAX;
@@ -180,6 +183,7 @@ void ass_renderer_done(ASS_Renderer *render_priv)
     ass_cache_done(render_priv->cache.composite_cache);
     ass_cache_done(render_priv->cache.bitmap_cache);
     ass_cache_done(render_priv->cache.outline_cache);
+    ass_cache_done(render_priv->cache.face_size_metrics_cache);
     ass_cache_done(render_priv->cache.metrics_cache);
     ass_cache_done(render_priv->cache.font_cache);
 

--- a/libass/ass_render.h
+++ b/libass/ass_render.h
@@ -303,6 +303,7 @@ typedef struct {
     Cache *outline_cache;
     Cache *bitmap_cache;
     Cache *composite_cache;
+    Cache *face_size_metrics_cache;
     Cache *metrics_cache;
     size_t glyph_max;
     size_t bitmap_max_size;

--- a/libass/ass_shaper.c
+++ b/libass/ass_shaper.c
@@ -221,8 +221,13 @@ get_cached_metrics(struct ass_shaper_metrics_data *metrics,
     if (metrics->vertical && unicode >= VERTICAL_LOWER_BOUND)
         rotate = true;
 
-    metrics->hash_key.glyph_index = glyph;
-    FT_Glyph_Metrics *val = ass_cache_get(metrics->metrics_cache, &metrics->hash_key,
+    GlyphMetricsHashKey key = {
+        .font = metrics->hash_key.font,
+        .face_index = metrics->hash_key.face_index,
+        .size = metrics->hash_key.size,
+        .glyph_index = glyph,
+    };
+    FT_Glyph_Metrics *val = ass_cache_get(metrics->metrics_cache, &key,
                                           rotate ? metrics : NULL);
     if (!val || val->width < 0)
         return NULL;

--- a/libass/ass_shaper.c
+++ b/libass/ass_shaper.c
@@ -458,18 +458,13 @@ bool ass_create_hb_font(ASS_Font *font, int index)
 }
 
 /**
- * \brief Retrieve HarfBuzz font from cache.
- * Create it from FreeType font, if needed.
+ * \brief Create HarfBuzz sub-font for current face and size.
  * \param info glyph cluster
  * \return HarfBuzz font
  */
 static hb_font_t *get_hb_font(ASS_Shaper *shaper, GlyphInfo *info)
 {
     ASS_Font *font = info->font;
-    hb_font_t *hb_font = font->hb_fonts[info->face_index];
-
-    if (!hb_font)
-        return NULL;
 
     FaceSizeMetricsHashKey key = {
         .font = info->font,
@@ -480,10 +475,16 @@ static hb_font_t *get_hb_font(ASS_Shaper *shaper, GlyphInfo *info)
     if (!m)
         return NULL;
 
+    hb_font_t *hb_font = hb_font_create_sub_font(font->hb_fonts[info->face_index]);
+    if (hb_font_is_immutable(hb_font))
+        return NULL;
+
     // set up cached metrics access
     struct ass_shaper_metrics_data *metrics = calloc(1, sizeof(struct ass_shaper_metrics_data));
-    if (!metrics)
+    if (!metrics) {
+        hb_font_destroy(hb_font);
         return NULL;
+    }
     metrics->metrics_cache = shaper->metrics_cache;
     metrics->hash_key.font = info->font;
     metrics->hash_key.face_index = info->face_index;
@@ -718,6 +719,8 @@ static bool shape_harfbuzz(ASS_Shaper *shaper, GlyphInfo *glyphs, size_t len)
         shape_harfbuzz_process_run(glyphs, buf,
                 shaper->whole_text_layout ? 0 : offset - lead_context);
         hb_buffer_reset(buf);
+
+        hb_font_destroy(font);
     }
 
     return true;

--- a/libass/ass_shaper.c
+++ b/libass/ass_shaper.c
@@ -79,7 +79,7 @@ struct ass_shaper {
 
 struct ass_shaper_metrics_data {
     Cache *metrics_cache;
-    GlyphMetricsHashKey hash_key;
+    FaceSizeMetricsHashKey hash_key;
 };
 
 /**
@@ -486,9 +486,7 @@ static hb_font_t *get_hb_font(ASS_Shaper *shaper, GlyphInfo *info)
         return NULL;
     }
     metrics->metrics_cache = shaper->metrics_cache;
-    metrics->hash_key.font = info->font;
-    metrics->hash_key.face_index = info->face_index;
-    metrics->hash_key.size = info->font_size;
+    metrics->hash_key = key;
 
     hb_font_set_funcs(hb_font, shaper->font_funcs, metrics, free);
 

--- a/libass/ass_shaper.c
+++ b/libass/ass_shaper.c
@@ -79,7 +79,6 @@ struct ass_shaper {
 struct ass_shaper_metrics_data {
     Cache *metrics_cache;
     GlyphMetricsHashKey hash_key;
-    int vertical;
 };
 
 /**
@@ -218,7 +217,7 @@ get_cached_metrics(struct ass_shaper_metrics_data *metrics,
     bool rotate = false;
     // if @font rendering is enabled and the glyph should be rotated,
     // make cached_h_advance pick up the right advance later
-    if (metrics->vertical && unicode >= VERTICAL_LOWER_BOUND)
+    if (metrics->hash_key.font->desc.vertical && unicode >= VERTICAL_LOWER_BOUND)
         rotate = true;
 
     GlyphMetricsHashKey key = {
@@ -464,7 +463,6 @@ static hb_font_t *get_hb_font(ASS_Shaper *shaper, GlyphInfo *info)
     metrics->hash_key.font = info->font;
     metrics->hash_key.face_index = info->face_index;
     metrics->hash_key.size = info->font_size;
-    metrics->vertical = info->font->desc.vertical;
 
     hb_font_set_funcs(hb_font, shaper->font_funcs, metrics, free);
 

--- a/libass/ass_shaper.h
+++ b/libass/ass_shaper.h
@@ -31,7 +31,7 @@ typedef struct ass_shaper ASS_Shaper;
 #endif
 
 void ass_shaper_info(ASS_Library *lib);
-ASS_Shaper *ass_shaper_new(Cache *metrics_cache);
+ASS_Shaper *ass_shaper_new(Cache *metrics_cache, Cache *face_size_metrics_cache);
 void ass_shaper_free(ASS_Shaper *shaper);
 bool ass_create_hb_font(ASS_Font *font, int index);
 void ass_shaper_set_kerning(ASS_Shaper *shaper, bool kern);


### PR DESCRIPTION
More extracts from #636. This is on top of #783.