### PR TITLE
ass_fontselect: add LIBASS_FORCE_FONTCONFIG env var

### DIFF
--- a/libass/ass.h
+++ b/libass/ass.h
@@ -209,11 +209,12 @@ int ass_library_version(void);
  *
  * NONE don't use any default font provider for font lookup
  * AUTODETECT use the first available font provider
- * CORETEXT force a CoreText based font provider (OS X only)
+ * CORETEXT force a CoreText based font provider (Apple platforms only)
  * DIRECTWRITE force a DirectWrite based font provider (Microsoft Win32 only)
  * FONTCONFIG force a Fontconfig based font provider
  *
- * libass uses the best shaper available by default.
+ * In the AUTODETECT case, fontconfig will be preferred over other available providers
+ * if the environment variable "LIBASS_FORCE_FONTCONFIG" is set to any value.
  */
 typedef enum {
     ASS_FONTPROVIDER_NONE       = 0,

--- a/libass/ass_fontselect.c
+++ b/libass/ass_fontselect.c
@@ -1095,6 +1095,11 @@ ass_fontselect_init(ASS_Library *library, FT_Library ftlibrary, size_t *num_emfo
         goto fail;
     }
 
+#ifdef CONFIG_FONTCONFIG
+    if (dfp == ASS_FONTPROVIDER_AUTODETECT && getenv("LIBASS_FORCE_FONTCONFIG"))
+        dfp = ASS_FONTPROVIDER_FONTCONFIG;
+#endif
+
     if (dfp >= ASS_FONTPROVIDER_AUTODETECT) {
         for (int i = 0; font_constructors[i].constructor; i++ )
             if (dfp == font_constructors[i].id ||


### PR DESCRIPTION
This simplifies testing fontconfig when on a platform with another preferred font provider.

Also improves docs for ASS_DefaultFontProvider.