### PR TITLE
ass_fontselect: lazy-load GDI-compatible metadata for matching

### DIFF
--- a/libass/ass_fontselect.c
+++ b/libass/ass_fontselect.c
@@ -317,7 +317,7 @@ error:
  * created by get_font_info.
  * \param meta metadata created by get_font_info
  */
-static void free_font_info(ASS_FontProviderMetaData *meta)
+static void free_font_name_arrays(ASS_FontProviderMetaData *meta)
 {
     if (meta->families) {
         for (int i = 0; i < meta->n_family; i++)
@@ -340,7 +340,7 @@ static void free_font_info(ASS_FontProviderMetaData *meta)
  */
 static void ass_font_provider_free_fontinfo(ASS_FontInfo *info)
 {
-    free_font_info(&info->meta);
+    free_font_name_arrays(&info->meta);
     free(info->meta.postscript_name);
     free(info->meta.extended_family);
 
@@ -395,7 +395,7 @@ static bool fill_font_info(ASS_FontInfo *font)
                        &local_meta))
         goto cleanup;
 
-    free_font_info(meta);
+    free_font_name_arrays(meta);
     free(meta->postscript_name);
     local_meta.postscript_name = local_meta.postscript_name ? strdup(local_meta.postscript_name) : NULL;
 
@@ -972,7 +972,7 @@ static void process_fontdata(ASS_FontProvider *priv, int idx)
         ft = calloc(1, sizeof(FontDataFT));
 
         if (ft == NULL) {
-            free_font_info(&info);
+            free_font_name_arrays(&info);
             FT_Done_Face(face);
             continue;
         }
@@ -987,7 +987,7 @@ static void process_fontdata(ASS_FontProvider *priv, int idx)
             free(ft);
         }
 
-        free_font_info(&info);
+        free_font_name_arrays(&info);
     }
 }
 

--- a/libass/ass_fontselect.c
+++ b/libass/ass_fontselect.c
@@ -284,8 +284,10 @@ get_font_info(FT_Library lib, FT_Face face, const char *fallback_family_name,
         if (info->fullnames == NULL)
             goto error;
         memcpy(info->fullnames, &fullnames, sizeof(char *) * num_fullname);
-        info->n_fullname = num_fullname;
+    } else {
+        info->fullnames = NULL;
     }
+    info->n_fullname = num_fullname;
 
     return true;
 

--- a/libass/ass_fontselect.h
+++ b/libass/ass_fontselect.h
@@ -214,6 +214,12 @@ struct ass_font_provider_meta_data {
      * Unused if the font provider has a check_postscript function.
      */
     bool is_postscript;
+
+    /*
+     * whether the font's properties have been loaded in directly from the file
+     * (as opposed to filled by a potentially-non-GDI-compatible provider)
+     */
+    bool loaded_from_file;
 };
 
 struct ass_font_stream {


### PR DESCRIPTION
Fixes #315.

Eager-loading font providers can provide more names, but if we get a match on one, we'll load the GDI data and repeat the check using that.