### PR TITLE
build: move warning flags to configure.ac

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,9 +1,6 @@
 ACLOCAL_AMFLAGS = -I m4
 AM_CPPFLAGS = -I$(top_srcdir)/libass
-AM_CFLAGS = -std=gnu99 -Wall -Wextra -Wno-sign-compare -Wno-unused-parameter \
-            -Werror-implicit-function-declaration -Wstrict-prototypes        \
-            -Wpointer-arith -Wredundant-decls -Wno-missing-field-initializers\
-            -D_GNU_SOURCE
+AM_CFLAGS = -std=gnu99 -D_GNU_SOURCE
 
 EXTRA_DIST = libass.pc.in Changelog MAINTAINERS RELEASEVERSION ltnasm.sh
 

--- a/configure.ac
+++ b/configure.ac
@@ -53,6 +53,13 @@ FUZZ_CPPFLAGS="${FUZZ_CPPFLAGS:--DASS_FUZZMODE=0}"
 # Checks for flags support
 AX_APPEND_COMPILE_FLAGS([-fno-math-errno])
 
+# Enable some warnings
+AX_APPEND_COMPILE_FLAGS([ \
+    -Wall -Wextra -Wno-sign-compare -Wno-unused-parameter -Wstrict-prototypes \
+    -Wpointer-arith -Werror-implicit-function-declaration -Wredundant-decls \
+    -Wno-missing-field-initializers \
+])
+
 # Checks for available libraries and define corresponding C Macros
 # Start with system libs, then check everything else via pkg-config
 AS_IF([test "x$ac_cv_header_iconv_h" = xyes], [


### PR DESCRIPTION
This lets us check for warning flags at configure-time, avoiding introducing errors if a compiler doesn't support a particular flag.