### PR TITLE
build: warn about non-ISO format strings with clang

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -59,6 +59,8 @@ AX_APPEND_COMPILE_FLAGS([ \
     -Wall -Wextra -Wno-sign-compare -Wno-unused-parameter -Wstrict-prototypes \
     -Wpointer-arith -Werror-implicit-function-declaration -Wredundant-decls \
     -Wno-missing-field-initializers \
+    dnl clang-specific, gcc currently has no fine-grained toggle for this, only -Wpedantic
+    -Wformat-non-iso -Werror=format-non-iso \
 ])
 
 # Checks for available libraries and define corresponding C Macros

--- a/meson.build
+++ b/meson.build
@@ -40,6 +40,8 @@ if cc.get_argument_syntax() == 'gcc'
         '-Wpointer-arith',
         '-Wredundant-decls',
         '-Wno-missing-field-initializers',
+        '-Wformat-non-iso',
+        '-Werror=format-non-iso',
     ]
 endif
 


### PR DESCRIPTION
With `-Wpedantic` instead to also cover GCC, we get three warnings about missing `(void *)` casts for printf arguments in both GCC and clang *(since different pointer types are allowed to have different representations, `%p` only taking `void *` and due to varargs no implicit cast can occur)*. While afaik no modern arch actually has different representations, the warning is entirely valid and easy enough to fix; imho we should add a cast here.

Only with GCC we additionally get 5 instances of `invalid use of pointers to arrays with different qualifiers in ISO C before C2X`. I haven’t looked into this but C23 adopting this as safe suggests there might not be much of at all problems in practice.

If `-Wpedantic` continues to be too contentious, we can at least enable this warning for clang; with `AX_APPEND_COMPILE_FLAG` this is now trivial enough.