### PR TITLE
Use transparent background in test’s output images

### DIFF
--- a/compare/image.c
+++ b/compare/image.c
@@ -194,6 +194,8 @@ static bool write_png(const char *path, uint32_t width, uint32_t height,
     }
 
     png_init_io(png, fp);
+    png_set_compression_level(png, 9);
+
     png_set_IHDR(png, info, width, height, depth,
                  PNG_COLOR_TYPE_RGBA, PNG_INTERLACE_NONE,
                  PNG_COMPRESSION_TYPE_DEFAULT, PNG_FILTER_TYPE_DEFAULT);

--- a/test/test.c
+++ b/test/test.c
@@ -80,7 +80,7 @@ static void write_png(char *fname, image_t *img)
     }
 
     png_init_io(png_ptr, fp);
-    png_set_compression_level(png_ptr, 0);
+    png_set_compression_level(png_ptr, 9);
 
     png_set_IHDR(png_ptr, info_ptr, img->width, img->height,
                  8, PNG_COLOR_TYPE_RGB, PNG_INTERLACE_NONE,


### PR DESCRIPTION
We discussed this a while ago in IRC wrt how creation of new regression tests can be made easier. With this patch a 320×180 reference image at 1000ms can be generated by running `~1/test sample-1000.png sample.ass 1000  320 180`.
Without this patch first a placeholder image with the desired dimension needs to be created, then `compare` run with output enabled.

(The latter used to be even more painful since only limited input formats were accepted and regenerating reference images needed manual ``compare` invocation. #767 and https://github.com/libass/libass-tests/pull/5 already made this easier)

However, there are caveats considering our utilities also serve as examples for API users and `test` is/was the most approachable one actually blending images:

1. unless i’m missing an obvious mistake in my simple blending code, the output noticeably differs from what e.g. Aegisub or mpv produce. This might mislead some into being subtly incompatible with other renderers
2. the blending procedure is more complicated and fixes inverted alpha late; which might even confuse those familiar with simpler blend methods wrt what’s correct

I imagine `compare`’s blending was intentionally chosen for best quality-comparison results since it’ſ not constrained by compatiblity concerns and we don’t want to adjust it. Alternatively we could leave `test` slightly incompatible with `compare` and rely only on the previous qol improvement mentioned above

<details>
<summary>For reference the simpler blending code i tested against</summary>

Extending the existing opaque variant, but moving the division by 255 out of `k` to avoid loss of precision by truncating intermediate values.
This appears to match mpv, and except for intermediate truncation Aegisub.
```C
static void blend_single(image_t * frame, ASS_Image *img)
{

    unsigned char r = img->color >> 24;
    unsigned char g = (img->color >> 16) & 0xFF;
    unsigned char b = (img->color >> 8) & 0xFF;
    unsigned char a = 255 - (img->color & 0xFF);

    unsigned char *src = img->bitmap;
    unsigned char *dst = frame->buffer + img->dst_y * frame->stride + img->dst_x * 4;

    for (int y = 0; y < img->h; ++y) {
        for (int x = 0; x < img->w; ++x) {
            unsigned k = ((unsigned) src[x]) * a;
            dst[x * 4 + 0] = (k *   r + (255 * 255 - k) * dst[x * 4 + 0]) / (255 * 255);
            dst[x * 4 + 1] = (k *   g + (255 * 255 - k) * dst[x * 4 + 1]) / (255 * 255);
            dst[x * 4 + 2] = (k *   b + (255 * 255 - k) * dst[x * 4 + 2]) / (255 * 255);
            dst[x * 4 + 3] = (k * 255 + (255 * 255 - k) * dst[x * 4 + 3]) / (255 * 255);
        }
        src += img->stride;
        dst += frame->stride;
    }
}
```
</details>