### PR TITLE
fontconfig: fix minor memory leak

### DIFF
--- a/libass/ass_fontconfig.c
+++ b/libass/ass_fontconfig.c
@@ -105,8 +105,11 @@ static bool scan_fonts(FcConfig *config, ASS_FontProvider *provider)
     // trim=FcFalse returns all system fonts
     fonts = FcFontSort(config, pat, FcFalse, NULL, &res);
     FcPatternDestroy(pat);
-    if (res != FcResultMatch)
+    if (res != FcResultMatch) {
+        if (fonts)
+            FcFontSetDestroy(fonts);
         return false;
+    }
 
     // fill font_info list
     for (i = 0; i < fonts->nfont; i++) {


### PR DESCRIPTION
When the used config is completely devoid of fonts, FcFontSort will attempt to allocate an empty set and return it but still set the result to be invalid.

Fortunately this seems unlikely to affect any real-world setups, but we should handle it correctly nevertheless.

Identified-by: kasper93