### PR TITLE
Add event pruning system and API.

### DIFF
--- a/libass/Makefile_library.am
+++ b/libass/Makefile_library.am
@@ -1,6 +1,6 @@
-LIBASS_LT_CURRENT = 12
-LIBASS_LT_REVISION = 1
-LIBASS_LT_AGE = 3
+LIBASS_LT_CURRENT = 13
+LIBASS_LT_REVISION = 0
+LIBASS_LT_AGE = 4
 
 .asm.lo:
 	$(nasm_verbose)$(LIBTOOL) $(AM_V_lt) --tag=CC --mode=compile $(top_srcdir)/ltnasm.sh $(AS) $(ASFLAGS) -I$(top_srcdir)/libass/ -Dprivate_prefix=ass -o $@ $<

--- a/libass/ass.h
+++ b/libass/ass.h
@@ -24,7 +24,7 @@
 #include <stdarg.h>
 #include "ass_types.h"
 
-#define LIBASS_VERSION 0x01703000
+#define LIBASS_VERSION 0x01703010
 
 #ifdef __cplusplus
 extern "C" {
@@ -733,6 +733,24 @@ void ass_process_chunk(ASS_Track *track, const char *data, int size,
  * If this function is not called, the default value is 1.
  */
 void ass_set_check_readorder(ASS_Track *track, int check_readorder);
+
+/**
+ * \brief Prune events that preceed deadline.
+ * \param track track
+ * \param deadline cut-off timestamp in milliseconds.
+*/
+void ass_prune_events(ASS_Track *track, long long deadline);
+
+/**
+ * \brief Configure automatic pruning of events.
+ * \param track track
+ * \param delay delay from "now" (ass_render_frame) in milliseconds.
+ * After every render, events whose undisplay timestamp predate
+ * "now - delay" will be deleted. A delay of 0 prunes aggressively.
+ * Negative delays disable automatic pruning.
+ * Disabled by default (no removal of events from memory).
+ */
+void ass_configure_prune(ASS_Track *track, long long delay);
 
 /**
  * \brief Flush buffered events.

--- a/libass/ass_priv.h
+++ b/libass/ass_priv.h
@@ -65,6 +65,9 @@ struct parser_priv {
     uint32_t header_flags;
 
     uint32_t feature_flags;
+
+    long long prune_delay;
+    long long prune_next_ts;
 };
 
 #endif /* LIBASS_PRIV_H */

--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -3428,6 +3428,9 @@ ASS_Image *ass_render_frame(ASS_Renderer *priv, ASS_Track *track,
     ass_frame_unref(priv->prev_images_root);
     priv->prev_images_root = NULL;
 
+    if (track->parser_priv->prune_delay >= 0)
+        ass_prune_events(track, now - track->parser_priv->prune_delay);
+
     return priv->images_root;
 }
 


### PR DESCRIPTION
An attempt to address #747, and to manage bloated scripts embedded in mkvs, like DataHoarder's. 

Motivations supporting the proposed solution:
- The default behaviour matches the current one: no collection is ever performed. It has to be explicitly enabled.
- The user is free to prune events at will, or rely on the automatic process after every render.
- Can be configured per track.

Point open for discussion:
- The prune function is not thread safe [to changes made to the events array].