### PR TITLE
fuzz: avoid Coverity warning about umask-less mkstemp

### DIFF
--- a/fuzz/writeout.c
+++ b/fuzz/writeout.c
@@ -22,6 +22,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/stat.h>
 
 #include "writeout.h"
 
@@ -177,6 +178,8 @@ void write_out_track(ASS_Track *track, const char *outpath)
         printf("Parsed File will be written to:  %s\n", outpath);
     } else {
         char filename[] = "/tmp/parsedSubs_XXXXXX";
+        // POSIX Issue 6 and earlier did not forbid read/write for non-owners
+        umask(S_IRUSR | S_IWUSR);
         int fd = mkstemp(filename);
         if (fd == -1) {
             printf("Failed to acquire temporary file!\n");


### PR DESCRIPTION
Coverity is content with this, but tbh it seems _almost_ useless considering *(a)* this is no confidential data and files for an explicit output path are created with default umask (without Coverity complaining) and *(b)* POSIX Issue 7 (2008) already requires `600` perms anyway. The only benefit, other than pleasing Coverity, is consistency with across Issue ≤6 POSIX and ≥7

Opening PR for comments and if we dismiss the issue instead of pushing this, I’m not sure if “false positive” or “intentional” is a better fit