### PR TITLE
meson: Add support for android, simplify some nasm detection logic

### DIFF
--- a/libass/meson.build
+++ b/libass/meson.build
@@ -83,9 +83,9 @@ endif
 
 if enable_asm
     asm_sources = []
-    if cpu_family == 'x86'
+    if generic_cpu_family == 'x86'
         asm_sources = src_x86
-    elif cpu_subfamily == 'aarch64'
+    elif generic_cpu_family == 'aarch64'
         asm_sources = src_aarch64
     endif
 

--- a/meson.build
+++ b/meson.build
@@ -293,7 +293,7 @@ if not asm_option.disabled()
                 error(
                     'Please contact libass upstream to figure out if ASM support ' +
                     'for your platform @0@ can be added. '.format(host_system) +
-                    'In the meantime you will need to use -Dasm=disabled.'
+                    'In the meantime you will need to use -Dasm=disabled.',
                 )
             endif
 

--- a/meson.build
+++ b/meson.build
@@ -237,15 +237,15 @@ asm_args = []
 
 # ASM architecture variables
 asm_option = get_option('asm')
-cpu_subfamily = host_machine.cpu_family()
-if cpu_subfamily.startswith('x86')
-    cpu_family = 'x86'
+cpu_family = host_machine.cpu_family()
+if cpu_family.startswith('x86')
+    generic_cpu_family = 'x86'
 else
-    cpu_family = cpu_subfamily
+    generic_cpu_family = cpu_family
 endif
 
 if not asm_option.disabled()
-    if cpu_family == 'x86'
+    if generic_cpu_family == 'x86'
         asm_is_nasm = add_languages(
             'nasm',
             required: false,
@@ -272,7 +272,7 @@ if not asm_option.disabled()
             conf.set('ARCH_X86', 1)
             nasm_args = ['-Dprivate_prefix=ass', '-DPIC=1']
 
-            if cpu_subfamily == 'x86_64'
+            if cpu_family == 'x86_64'
                 conf.set('ARCH_X86_64', 1)
                 nasm_args += '-DARCH_X86_64=1'
             else
@@ -280,7 +280,7 @@ if not asm_option.disabled()
             endif
 
             if host_system in ['windows', 'cygwin']
-                if cpu_subfamily == 'x86'
+                if cpu_family == 'x86'
                     nasm_args += '-DPREFIX'
                 endif
             elif host_system == 'darwin'
@@ -299,7 +299,7 @@ if not asm_option.disabled()
 
             add_project_arguments(nasm_args, language: 'nasm')
         endif
-    elif cpu_subfamily == 'aarch64'
+    elif generic_cpu_family == 'aarch64'
         enable_asm = true
         conf.set('ARCH_AARCH64', 1)
         if host_system == 'darwin'
@@ -308,7 +308,7 @@ if not asm_option.disabled()
     else
         warning(
             'Assembly optimizations are not yet supported for the "@0@" architecture; disabling.'.format(
-                cpu_subfamily,
+                cpu_family,
             ),
         )
     endif


### PR DESCRIPTION
1. Redefining the meaning of `cpu_family` is a bit confusing, and unnecessary
2. Now setting `-Dasm=enabled` will error out early, so people know exactly what is wrong
3. When erroring out due to platform support, print the platform name