### PR TITLE
blend_bitmaps: allow compiler to optimize C variants

### DIFF
--- a/libass/c/c_blend_bitmaps.c
+++ b/libass/c/c_blend_bitmaps.c
@@ -29,8 +29,8 @@
  * \brief Add two bitmaps together at a given position
  * Uses additive blending, clipped to [0,255]. Pure C implementation.
  */
-void ass_add_bitmaps_c(uint8_t *dst, ptrdiff_t dst_stride,
-                       const uint8_t *src, ptrdiff_t src_stride,
+void ass_add_bitmaps_c(uint8_t *restrict dst, ptrdiff_t dst_stride,
+                       const uint8_t *restrict src, ptrdiff_t src_stride,
                        size_t width, size_t height)
 {
     uint8_t *end = dst + dst_stride * height;
@@ -44,8 +44,8 @@ void ass_add_bitmaps_c(uint8_t *dst, ptrdiff_t dst_stride,
     }
 }
 
-void ass_imul_bitmaps_c(uint8_t *dst, ptrdiff_t dst_stride,
-                        const uint8_t *src, ptrdiff_t src_stride,
+void ass_imul_bitmaps_c(uint8_t *restrict dst, ptrdiff_t dst_stride,
+                        const uint8_t *restrict src, ptrdiff_t src_stride,
                         size_t width, size_t height)
 {
     uint8_t *end = dst + dst_stride * height;
@@ -58,9 +58,9 @@ void ass_imul_bitmaps_c(uint8_t *dst, ptrdiff_t dst_stride,
     }
 }
 
-void ass_mul_bitmaps_c(uint8_t *dst, ptrdiff_t dst_stride,
-                       const uint8_t *src1, ptrdiff_t src1_stride,
-                       const uint8_t *src2, ptrdiff_t src2_stride,
+void ass_mul_bitmaps_c(uint8_t *restrict dst, ptrdiff_t dst_stride,
+                       const uint8_t *restrict src1, ptrdiff_t src1_stride,
+                       const uint8_t *restrict src2, ptrdiff_t src2_stride,
                        size_t width, size_t height)
 {
     uint8_t *end = dst + dst_stride * height;


### PR DESCRIPTION
There are hand-optimized version, but it is good to have optimized baseline too. The difference is not big, but marking those pointers with restrict give compiler more freedom.