### PR TITLE
Restrict-qualification + ASSUME macro usage in bitmap engine

### DIFF
--- a/libass/ass_bitmap_engine.h
+++ b/libass/ass_bitmap_engine.h
@@ -26,32 +26,32 @@ struct segment;
 typedef void FillSolidTileFunc(uint8_t *buf, ptrdiff_t stride, int set);
 typedef void FillHalfplaneTileFunc(uint8_t *buf, ptrdiff_t stride,
                                    int32_t a, int32_t b, int64_t c, int32_t scale);
-typedef void FillGenericTileFunc(uint8_t *buf, ptrdiff_t stride,
-                                 const struct segment *line, size_t n_lines,
+typedef void FillGenericTileFunc(uint8_t *restrict buf, ptrdiff_t stride,
+                                 const struct segment *restrict line, size_t n_lines,
                                  int winding);
-typedef void MergeTileFunc(uint8_t *buf, ptrdiff_t stride, const uint8_t *tile);
+typedef void MergeTileFunc(uint8_t *restrict buf, ptrdiff_t stride, const uint8_t *restrict tile);
 
-typedef void BitmapBlendFunc(uint8_t *dst, ptrdiff_t dst_stride,
-                             const uint8_t *src, ptrdiff_t src_stride,
+typedef void BitmapBlendFunc(uint8_t *restrict dst, ptrdiff_t dst_stride,
+                             const uint8_t *restrict src, ptrdiff_t src_stride,
                              size_t width, size_t height);
-typedef void BitmapMulFunc(uint8_t *dst, ptrdiff_t dst_stride,
-                           const uint8_t *src1, ptrdiff_t src1_stride,
-                           const uint8_t *src2, ptrdiff_t src2_stride,
+typedef void BitmapMulFunc(uint8_t *restrict dst, ptrdiff_t dst_stride,
+                           const uint8_t *restrict src1, ptrdiff_t src1_stride,
+                           const uint8_t *restrict src2, ptrdiff_t src2_stride,
                            size_t width, size_t height);
 
-typedef void BeBlurFunc(uint8_t *buf, ptrdiff_t stride,
-                        size_t width, size_t height, uint16_t *tmp);
+typedef void BeBlurFunc(uint8_t *restrict buf, ptrdiff_t stride,
+                        size_t width, size_t height, uint16_t *restrict tmp);
 
 // intermediate bitmaps represented as sets of vertical stripes of int16_t[alignment / 2]
-typedef void Convert8to16Func(int16_t *dst, const uint8_t *src, ptrdiff_t src_stride,
-                              size_t width, size_t height);
-typedef void Convert16to8Func(uint8_t *dst, ptrdiff_t dst_stride, const int16_t *src,
-                              size_t width, size_t height);
-typedef void FilterFunc(int16_t *dst, const int16_t *src,
+typedef void Convert8to16Func(int16_t *restrict dst, const uint8_t *restrict src,
+                              ptrdiff_t src_stride, size_t width, size_t height);
+typedef void Convert16to8Func(uint8_t *restrict dst, ptrdiff_t dst_stride,
+                              const int16_t *restrict src, size_t width, size_t height);
+typedef void FilterFunc(int16_t *restrict dst, const int16_t *restrict src,
                         size_t src_width, size_t src_height);
-typedef void ParamFilterFunc(int16_t *dst, const int16_t *src,
+typedef void ParamFilterFunc(int16_t *restrict dst, const int16_t *restrict src,
                              size_t src_width, size_t src_height,
-                             const int16_t *param);
+                             const int16_t *restrict param);
 
 typedef struct {
     int align_order;  // log2(alignment)

--- a/libass/ass_bitmap_engine.h
+++ b/libass/ass_bitmap_engine.h
@@ -22,6 +22,13 @@
 #include <stddef.h>
 #include <stdint.h>
 
+/*
+ * All of these routines require some basic preconditions about their args:
+ * - Widths and heights must be > 0
+ * - For be_blur, width and height must be > 1
+ * - All strides must be multiples of the engine alignment (16 or a greater power of 2)
+ */
+
 struct segment;
 typedef void FillSolidTileFunc(uint8_t *buf, ptrdiff_t stride, int set);
 typedef void FillHalfplaneTileFunc(uint8_t *buf, ptrdiff_t stride,

--- a/libass/ass_utils.h
+++ b/libass/ass_utils.h
@@ -55,6 +55,20 @@
 
 #define FEATURE_MASK(feat) (((uint32_t) 1) << (feat))
 
+#ifndef __has_builtin
+    #define __has_builtin(x) 0
+#endif
+
+#if __has_builtin(__builtin_assume)
+    #define ASSUME(x) __builtin_assume(x)
+#elif defined(_MSC_VER)
+    #define ASSUME(x) __assume(x)
+#elif __has_builtin(__builtin_unreachable)
+    #define ASSUME(x) if (!(x)) __builtin_unreachable()
+#else
+    #define ASSUME(x) (void)0
+#endif
+
 typedef struct {
     const char *str;
     size_t len;

--- a/libass/c/blur_template.h
+++ b/libass/c/blur_template.h
@@ -37,6 +37,8 @@ inline static void SUFFIX(copy_line)(int16_t *buf, const int16_t *ptr, size_t of
 void SUFFIX(ass_stripe_unpack)(int16_t *restrict dst, const uint8_t *restrict src,
                                ptrdiff_t src_stride, size_t width, size_t height)
 {
+    ASSUME(!(src_stride % 16) && width > 0 && height > 0);
+
     for (size_t y = 0; y < height; y++) {
         int16_t *ptr = dst;
         for (size_t x = 0; x < width; x += STRIPE_WIDTH) {
@@ -53,6 +55,8 @@ void SUFFIX(ass_stripe_unpack)(int16_t *restrict dst, const uint8_t *restrict sr
 void SUFFIX(ass_stripe_pack)(uint8_t *restrict dst, ptrdiff_t dst_stride,
                              const int16_t *restrict src, size_t width, size_t height)
 {
+    ASSUME(!(dst_stride % 16) && width > 0 && height > 0);
+
     for (size_t x = 0; x < width; x += STRIPE_WIDTH) {
         uint8_t *ptr = dst;
         for (size_t y = 0; y < height; y++) {
@@ -82,6 +86,8 @@ void SUFFIX(ass_stripe_pack)(uint8_t *restrict dst, ptrdiff_t dst_stride,
 void SUFFIX(ass_shrink_horz)(int16_t *restrict dst, const int16_t *restrict src,
                              size_t src_width, size_t src_height)
 {
+    ASSUME(src_width > 0 && src_height > 0);
+
     size_t dst_width = (src_width + 5) >> 1;
     size_t size = ((src_width + STRIPE_MASK) & ~STRIPE_MASK) * src_height;
     size_t step = STRIPE_WIDTH * src_height;
@@ -108,6 +114,8 @@ void SUFFIX(ass_shrink_horz)(int16_t *restrict dst, const int16_t *restrict src,
 void SUFFIX(ass_shrink_vert)(int16_t *restrict dst, const int16_t *restrict src,
                              size_t src_width, size_t src_height)
 {
+    ASSUME(src_width > 0 && src_height > 0);
+
     size_t dst_height = (src_height + 5) >> 1;
     size_t step = STRIPE_WIDTH * src_height;
 
@@ -138,6 +146,8 @@ void SUFFIX(ass_shrink_vert)(int16_t *restrict dst, const int16_t *restrict src,
 void SUFFIX(ass_expand_horz)(int16_t *restrict dst, const int16_t *restrict src,
                              size_t src_width, size_t src_height)
 {
+    ASSUME(src_width > 0 && src_height > 0);
+
     size_t dst_width = 2 * src_width + 4;
     size_t size = ((src_width + STRIPE_MASK) & ~STRIPE_MASK) * src_height;
     size_t step = STRIPE_WIDTH * src_height;
@@ -178,6 +188,8 @@ void SUFFIX(ass_expand_horz)(int16_t *restrict dst, const int16_t *restrict src,
 void SUFFIX(ass_expand_vert)(int16_t *restrict dst, const int16_t *restrict src,
                              size_t src_width, size_t src_height)
 {
+    ASSUME(src_width > 0 && src_height > 0);
+
     size_t dst_height = 2 * src_height + 4;
     size_t step = STRIPE_WIDTH * src_height;
 
@@ -209,6 +221,8 @@ static inline void SUFFIX(blur_horz)(int16_t *restrict dst, const int16_t *restr
                                      size_t src_width, size_t src_height,
                                      const int16_t *restrict param, const int n)
 {
+    ASSUME(src_width > 0 && src_height > 0);
+
     size_t dst_width = src_width + 2 * n;
     size_t size = ((src_width + STRIPE_MASK) & ~STRIPE_MASK) * src_height;
     size_t step = STRIPE_WIDTH * src_height;
@@ -240,6 +254,8 @@ static inline void SUFFIX(blur_vert)(int16_t *restrict dst, const int16_t *restr
                                      size_t src_width, size_t src_height,
                                      const int16_t *restrict param, const int n)
 {
+    ASSUME(src_width > 0 && src_height > 0);
+
     size_t dst_height = src_height + 2 * n;
     size_t step = STRIPE_WIDTH * src_height;
 

--- a/libass/c/blur_template.h
+++ b/libass/c/blur_template.h
@@ -34,8 +34,8 @@ inline static void SUFFIX(copy_line)(int16_t *buf, const int16_t *ptr, size_t of
  * Each pixel is represented as 16-bit integer in range of [0-0x4000].
  */
 
-void SUFFIX(ass_stripe_unpack)(int16_t *dst, const uint8_t *src, ptrdiff_t src_stride,
-                               size_t width, size_t height)
+void SUFFIX(ass_stripe_unpack)(int16_t *restrict dst, const uint8_t *restrict src,
+                               ptrdiff_t src_stride, size_t width, size_t height)
 {
     for (size_t y = 0; y < height; y++) {
         int16_t *ptr = dst;
@@ -50,8 +50,8 @@ void SUFFIX(ass_stripe_unpack)(int16_t *dst, const uint8_t *src, ptrdiff_t src_s
     }
 }
 
-void SUFFIX(ass_stripe_pack)(uint8_t *dst, ptrdiff_t dst_stride, const int16_t *src,
-                             size_t width, size_t height)
+void SUFFIX(ass_stripe_pack)(uint8_t *restrict dst, ptrdiff_t dst_stride,
+                             const int16_t *restrict src, size_t width, size_t height)
 {
     for (size_t x = 0; x < width; x += STRIPE_WIDTH) {
         uint8_t *ptr = dst;
@@ -79,7 +79,7 @@ void SUFFIX(ass_stripe_pack)(uint8_t *dst, ptrdiff_t dst_stride, const int16_t *
  * Contract image by factor 2 with kernel [1, 5, 10, 10, 5, 1].
  */
 
-void SUFFIX(ass_shrink_horz)(int16_t *dst, const int16_t *src,
+void SUFFIX(ass_shrink_horz)(int16_t *restrict dst, const int16_t *restrict src,
                              size_t src_width, size_t src_height)
 {
     size_t dst_width = (src_width + 5) >> 1;
@@ -105,7 +105,7 @@ void SUFFIX(ass_shrink_horz)(int16_t *dst, const int16_t *src,
     }
 }
 
-void SUFFIX(ass_shrink_vert)(int16_t *dst, const int16_t *src,
+void SUFFIX(ass_shrink_vert)(int16_t *restrict dst, const int16_t *restrict src,
                              size_t src_width, size_t src_height)
 {
     size_t dst_height = (src_height + 5) >> 1;
@@ -135,7 +135,7 @@ void SUFFIX(ass_shrink_vert)(int16_t *dst, const int16_t *src,
  * Expand image by factor 2 with kernel [5, 10, 1], [1, 10, 5].
  */
 
-void SUFFIX(ass_expand_horz)(int16_t *dst, const int16_t *src,
+void SUFFIX(ass_expand_horz)(int16_t *restrict dst, const int16_t *restrict src,
                              size_t src_width, size_t src_height)
 {
     size_t dst_width = 2 * src_width + 4;
@@ -175,7 +175,7 @@ void SUFFIX(ass_expand_horz)(int16_t *dst, const int16_t *src,
     }
 }
 
-void SUFFIX(ass_expand_vert)(int16_t *dst, const int16_t *src,
+void SUFFIX(ass_expand_vert)(int16_t *restrict dst, const int16_t *restrict src,
                              size_t src_width, size_t src_height)
 {
     size_t dst_height = 2 * src_height + 4;
@@ -205,9 +205,9 @@ void SUFFIX(ass_expand_vert)(int16_t *dst, const int16_t *src,
  * number of parameters is part of the function name.
  */
 
-static inline void SUFFIX(blur_horz)(int16_t *dst, const int16_t *src,
+static inline void SUFFIX(blur_horz)(int16_t *restrict dst, const int16_t *restrict src,
                                      size_t src_width, size_t src_height,
-                                     const int16_t *param, const int n)
+                                     const int16_t *restrict param, const int n)
 {
     size_t dst_width = src_width + 2 * n;
     size_t size = ((src_width + STRIPE_MASK) & ~STRIPE_MASK) * src_height;
@@ -236,9 +236,9 @@ static inline void SUFFIX(blur_horz)(int16_t *dst, const int16_t *src,
     }
 }
 
-static inline void SUFFIX(blur_vert)(int16_t *dst, const int16_t *src,
+static inline void SUFFIX(blur_vert)(int16_t *restrict dst, const int16_t *restrict src,
                                      size_t src_width, size_t src_height,
-                                     const int16_t *param, const int n)
+                                     const int16_t *restrict param, const int n)
 {
     size_t dst_height = src_height + 2 * n;
     size_t step = STRIPE_WIDTH * src_height;
@@ -267,23 +267,23 @@ static inline void SUFFIX(blur_vert)(int16_t *dst, const int16_t *src,
     }
 }
 
-void SUFFIX(ass_blur4_horz)(int16_t *dst, const int16_t *src,
+void SUFFIX(ass_blur4_horz)(int16_t *restrict dst, const int16_t *restrict src,
                             size_t src_width, size_t src_height,
-                            const int16_t *param)
+                            const int16_t *restrict param)
 {
     SUFFIX(blur_horz)(dst, src, src_width, src_height, param, 4);
 }
 
-void SUFFIX(ass_blur4_vert)(int16_t *dst, const int16_t *src,
+void SUFFIX(ass_blur4_vert)(int16_t *restrict dst, const int16_t *restrict src,
                             size_t src_width, size_t src_height,
-                            const int16_t *param)
+                            const int16_t *restrict param)
 {
     SUFFIX(blur_vert)(dst, src, src_width, src_height, param, 4);
 }
 
-void SUFFIX(ass_blur5_horz)(int16_t *dst, const int16_t *src,
+void SUFFIX(ass_blur5_horz)(int16_t *restrict dst, const int16_t *restrict src,
                             size_t src_width, size_t src_height,
-                            const int16_t *param)
+                            const int16_t *restrict param)
 {
     SUFFIX(blur_horz)(dst, src, src_width, src_height, param, 5);
 }

--- a/libass/c/c_be_blur.c
+++ b/libass/c/c_be_blur.c
@@ -35,8 +35,8 @@ static inline uint16_t sliding_sum(uint16_t *prev, uint16_t next)
  * This blur is the same as the one employed by vsfilter.
  * Pure C implementation.
  */
-void ass_be_blur_c(uint8_t *buf, ptrdiff_t stride,
-                   size_t width, size_t height, uint16_t *tmp)
+void ass_be_blur_c(uint8_t *restrict buf, ptrdiff_t stride,
+                   size_t width, size_t height, uint16_t *restrict tmp)
 {
     uint16_t *col_pix_buf = tmp;
     uint16_t *col_sum_buf = tmp + stride;

--- a/libass/c/c_be_blur.c
+++ b/libass/c/c_be_blur.c
@@ -18,6 +18,7 @@
 
 #include "config.h"
 #include "ass_compat.h"
+#include "ass_utils.h"
 
 #include <stddef.h>
 #include <stdint.h>
@@ -38,6 +39,8 @@ static inline uint16_t sliding_sum(uint16_t *prev, uint16_t next)
 void ass_be_blur_c(uint8_t *restrict buf, ptrdiff_t stride,
                    size_t width, size_t height, uint16_t *restrict tmp)
 {
+    ASSUME(!(stride % 16) && width > 1 && height > 1);
+
     uint16_t *col_pix_buf = tmp;
     uint16_t *col_sum_buf = tmp + stride;
 

--- a/libass/c/c_blend_bitmaps.c
+++ b/libass/c/c_blend_bitmaps.c
@@ -29,8 +29,8 @@
  * \brief Add two bitmaps together at a given position
  * Uses additive blending, clipped to [0,255]. Pure C implementation.
  */
-void ass_add_bitmaps_c(uint8_t *dst, ptrdiff_t dst_stride,
-                       const uint8_t *src, ptrdiff_t src_stride,
+void ass_add_bitmaps_c(uint8_t *restrict dst, ptrdiff_t dst_stride,
+                       const uint8_t *restrict src, ptrdiff_t src_stride,
                        size_t width, size_t height)
 {
     uint8_t *end = dst + dst_stride * height;
@@ -44,8 +44,8 @@ void ass_add_bitmaps_c(uint8_t *dst, ptrdiff_t dst_stride,
     }
 }
 
-void ass_imul_bitmaps_c(uint8_t *dst, ptrdiff_t dst_stride,
-                        const uint8_t *src, ptrdiff_t src_stride,
+void ass_imul_bitmaps_c(uint8_t *restrict dst, ptrdiff_t dst_stride,
+                        const uint8_t *restrict src, ptrdiff_t src_stride,
                         size_t width, size_t height)
 {
     uint8_t *end = dst + dst_stride * height;
@@ -58,9 +58,9 @@ void ass_imul_bitmaps_c(uint8_t *dst, ptrdiff_t dst_stride,
     }
 }
 
-void ass_mul_bitmaps_c(uint8_t *dst, ptrdiff_t dst_stride,
-                       const uint8_t *src1, ptrdiff_t src1_stride,
-                       const uint8_t *src2, ptrdiff_t src2_stride,
+void ass_mul_bitmaps_c(uint8_t *restrict dst, ptrdiff_t dst_stride,
+                       const uint8_t *restrict src1, ptrdiff_t src1_stride,
+                       const uint8_t *restrict src2, ptrdiff_t src2_stride,
                        size_t width, size_t height)
 {
     uint8_t *end = dst + dst_stride * height;

--- a/libass/c/c_blend_bitmaps.c
+++ b/libass/c/c_blend_bitmaps.c
@@ -33,6 +33,8 @@ void ass_add_bitmaps_c(uint8_t *restrict dst, ptrdiff_t dst_stride,
                        const uint8_t *restrict src, ptrdiff_t src_stride,
                        size_t width, size_t height)
 {
+    ASSUME(!(dst_stride % 16) && !(src_stride % 16) && width > 0 && height > 0);
+
     uint8_t *end = dst + dst_stride * height;
     while (dst < end) {
         for (size_t x = 0; x < width; x++) {
@@ -48,6 +50,8 @@ void ass_imul_bitmaps_c(uint8_t *restrict dst, ptrdiff_t dst_stride,
                         const uint8_t *restrict src, ptrdiff_t src_stride,
                         size_t width, size_t height)
 {
+    ASSUME(!(dst_stride % 16) && !(src_stride % 16) && width > 0 && height > 0);
+
     uint8_t *end = dst + dst_stride * height;
     while (dst < end) {
         for (size_t x = 0; x < width; x++) {
@@ -63,6 +67,9 @@ void ass_mul_bitmaps_c(uint8_t *restrict dst, ptrdiff_t dst_stride,
                        const uint8_t *restrict src2, ptrdiff_t src2_stride,
                        size_t width, size_t height)
 {
+    ASSUME(!(dst_stride % 16) && !(src1_stride % 16) && !(src2_stride % 16) &&
+           width > 0 && height > 0);
+
     uint8_t *end = dst + dst_stride * height;
     while (dst < end) {
         for (size_t x = 0; x < width; x++) {

--- a/libass/c/c_blur.c
+++ b/libass/c/c_blur.c
@@ -18,6 +18,7 @@
 
 #include "config.h"
 #include "ass_compat.h"
+#include "ass_utils.h"
 
 #include <stddef.h>
 #include <stdint.h>

--- a/libass/c/rasterizer_template.h
+++ b/libass/c/rasterizer_template.h
@@ -134,8 +134,8 @@ static inline void SUFFIX(update_border_line)(int16_t res[TILE_SIZE],
     }
 }
 
-void SUFFIX(ass_fill_generic_tile)(uint8_t *buf, ptrdiff_t stride,
-                                   const struct segment *line, size_t n_lines,
+void SUFFIX(ass_fill_generic_tile)(uint8_t *restrict buf, ptrdiff_t stride,
+                                   const struct segment *restrict line, size_t n_lines,
                                    int winding)
 {
     int16_t res[TILE_SIZE][TILE_SIZE] = {0};
@@ -218,7 +218,8 @@ void SUFFIX(ass_fill_generic_tile)(uint8_t *buf, ptrdiff_t stride,
 }
 
 
-void SUFFIX(ass_merge_tile)(uint8_t *buf, ptrdiff_t stride, const uint8_t *tile)
+void SUFFIX(ass_merge_tile)(uint8_t *restrict buf, ptrdiff_t stride,
+                            const uint8_t *restrict tile)
 {
     for (int y = 0; y < TILE_SIZE; y++) {
         for (int x = 0; x < TILE_SIZE; x++)

--- a/libass/c/rasterizer_template.h
+++ b/libass/c/rasterizer_template.h
@@ -35,6 +35,8 @@
 
 void SUFFIX(ass_fill_solid_tile)(uint8_t *buf, ptrdiff_t stride, int set)
 {
+    ASSUME(!(stride % 16));
+
     uint8_t value = set ? 255 : 0;
     for (int y = 0; y < TILE_SIZE; y++) {
         for (int x = 0; x < TILE_SIZE; x++)
@@ -69,6 +71,8 @@ void SUFFIX(ass_fill_solid_tile)(uint8_t *buf, ptrdiff_t stride, int set)
 void SUFFIX(ass_fill_halfplane_tile)(uint8_t *buf, ptrdiff_t stride,
                                      int32_t a, int32_t b, int64_t c, int32_t scale)
 {
+    ASSUME(!(stride % 16));
+
     int16_t aa = RESCALE_AB(a, scale), bb = RESCALE_AB(b, scale);
     int16_t cc = RESCALE_C(c, scale) + FULL_VALUE / 2 - ((aa + bb) >> 1);
 
@@ -138,6 +142,8 @@ void SUFFIX(ass_fill_generic_tile)(uint8_t *restrict buf, ptrdiff_t stride,
                                    const struct segment *restrict line, size_t n_lines,
                                    int winding)
 {
+    ASSUME(!(stride % 16));
+
     int16_t res[TILE_SIZE][TILE_SIZE] = {0};
     int16_t delta[TILE_SIZE + 2] = {0};
 
@@ -221,6 +227,8 @@ void SUFFIX(ass_fill_generic_tile)(uint8_t *restrict buf, ptrdiff_t stride,
 void SUFFIX(ass_merge_tile)(uint8_t *restrict buf, ptrdiff_t stride,
                             const uint8_t *restrict tile)
 {
+    ASSUME(!(stride % 16));
+
     for (int y = 0; y < TILE_SIZE; y++) {
         for (int x = 0; x < TILE_SIZE; x++)
             buf[x] = FFMAX(buf[x], tile[x]);


### PR DESCRIPTION
First 3 commits of #749, rebased, as brought up by #819. Changes:
- `restrict`-qualify pointer args to all our C bitmap-engine functions
  - These never alias, and letting the compiler know that allows it to skip emitting some unnecessary defensive code
- Add an `ASSUME` macro
  - This tells the compiler that it can assume a particular expression will always evaluate to true, which can help it optimize more effectively (especially when autovectorizing)
- Use `ASSUME` to signal some trivial invariants in bitmap-engine routines
  - Stride is always 16-byte-aligned, width/height are never zero (or 1, for be_blur), etc