### PR TITLE
ASSUME: tighten assumptions even more

### DIFF
--- a/libass/ass_bitmap_engine.h
+++ b/libass/ass_bitmap_engine.h
@@ -26,7 +26,9 @@
  * All of these routines require some basic preconditions about their args:
  * - Widths and heights must be > 0
  * - For be_blur, width and height must be > 1
- * - All strides must be multiples of the engine alignment (16 or a greater power of 2)
+ * - All strides must be multiples of the engine alignment
+ * - All buffers, except for BitmapBlendFunc and sources of BitmapMulFunc,
+ *   must be aligned to the engine alignment
  */
 
 struct segment;

--- a/libass/c/blur_template.h
+++ b/libass/c/blur_template.h
@@ -37,7 +37,9 @@ inline static void SUFFIX(copy_line)(int16_t *buf, const int16_t *ptr, size_t of
 void SUFFIX(ass_stripe_unpack)(int16_t *restrict dst, const uint8_t *restrict src,
                                ptrdiff_t src_stride, size_t width, size_t height)
 {
-    ASSUME(!(src_stride % 16) && width > 0 && height > 0);
+    ASSUME(!((uintptr_t) dst % ALIGNMENT));
+    ASSUME(!((uintptr_t) src % ALIGNMENT) && !(src_stride % ALIGNMENT));
+    ASSUME(width > 0 && height > 0);
 
     for (size_t y = 0; y < height; y++) {
         int16_t *ptr = dst;
@@ -55,7 +57,9 @@ void SUFFIX(ass_stripe_unpack)(int16_t *restrict dst, const uint8_t *restrict sr
 void SUFFIX(ass_stripe_pack)(uint8_t *restrict dst, ptrdiff_t dst_stride,
                              const int16_t *restrict src, size_t width, size_t height)
 {
-    ASSUME(!(dst_stride % 16) && width > 0 && height > 0);
+    ASSUME(!((uintptr_t) dst % ALIGNMENT) && !(dst_stride % ALIGNMENT));
+    ASSUME(!((uintptr_t) src % ALIGNMENT));
+    ASSUME(width > 0 && height > 0);
 
     for (size_t x = 0; x < width; x += STRIPE_WIDTH) {
         uint8_t *ptr = dst;
@@ -86,6 +90,8 @@ void SUFFIX(ass_stripe_pack)(uint8_t *restrict dst, ptrdiff_t dst_stride,
 void SUFFIX(ass_shrink_horz)(int16_t *restrict dst, const int16_t *restrict src,
                              size_t src_width, size_t src_height)
 {
+    ASSUME(!((uintptr_t) dst % ALIGNMENT));
+    ASSUME(!((uintptr_t) src % ALIGNMENT));
     ASSUME(src_width > 0 && src_height > 0);
 
     size_t dst_width = (src_width + 5) >> 1;
@@ -114,6 +120,8 @@ void SUFFIX(ass_shrink_horz)(int16_t *restrict dst, const int16_t *restrict src,
 void SUFFIX(ass_shrink_vert)(int16_t *restrict dst, const int16_t *restrict src,
                              size_t src_width, size_t src_height)
 {
+    ASSUME(!((uintptr_t) dst % ALIGNMENT));
+    ASSUME(!((uintptr_t) src % ALIGNMENT));
     ASSUME(src_width > 0 && src_height > 0);
 
     size_t dst_height = (src_height + 5) >> 1;
@@ -146,6 +154,8 @@ void SUFFIX(ass_shrink_vert)(int16_t *restrict dst, const int16_t *restrict src,
 void SUFFIX(ass_expand_horz)(int16_t *restrict dst, const int16_t *restrict src,
                              size_t src_width, size_t src_height)
 {
+    ASSUME(!((uintptr_t) dst % ALIGNMENT));
+    ASSUME(!((uintptr_t) src % ALIGNMENT));
     ASSUME(src_width > 0 && src_height > 0);
 
     size_t dst_width = 2 * src_width + 4;
@@ -188,6 +198,8 @@ void SUFFIX(ass_expand_horz)(int16_t *restrict dst, const int16_t *restrict src,
 void SUFFIX(ass_expand_vert)(int16_t *restrict dst, const int16_t *restrict src,
                              size_t src_width, size_t src_height)
 {
+    ASSUME(!((uintptr_t) dst % ALIGNMENT));
+    ASSUME(!((uintptr_t) src % ALIGNMENT));
     ASSUME(src_width > 0 && src_height > 0);
 
     size_t dst_height = 2 * src_height + 4;
@@ -221,6 +233,8 @@ static inline void SUFFIX(blur_horz)(int16_t *restrict dst, const int16_t *restr
                                      size_t src_width, size_t src_height,
                                      const int16_t *restrict param, const int n)
 {
+    ASSUME(!((uintptr_t) dst % ALIGNMENT));
+    ASSUME(!((uintptr_t) src % ALIGNMENT));
     ASSUME(src_width > 0 && src_height > 0);
 
     size_t dst_width = src_width + 2 * n;
@@ -254,6 +268,8 @@ static inline void SUFFIX(blur_vert)(int16_t *restrict dst, const int16_t *restr
                                      size_t src_width, size_t src_height,
                                      const int16_t *restrict param, const int n)
 {
+    ASSUME(!((uintptr_t) dst % ALIGNMENT));
+    ASSUME(!((uintptr_t) src % ALIGNMENT));
     ASSUME(src_width > 0 && src_height > 0);
 
     size_t dst_height = src_height + 2 * n;

--- a/libass/c/c_be_blur.c
+++ b/libass/c/c_be_blur.c
@@ -24,6 +24,8 @@
 #include <stdint.h>
 
 
+#define ALIGNMENT  16
+
 static inline uint16_t sliding_sum(uint16_t *prev, uint16_t next)
 {
     uint16_t sum = *prev + next;
@@ -39,7 +41,9 @@ static inline uint16_t sliding_sum(uint16_t *prev, uint16_t next)
 void ass_be_blur_c(uint8_t *restrict buf, ptrdiff_t stride,
                    size_t width, size_t height, uint16_t *restrict tmp)
 {
-    ASSUME(!(stride % 16) && width > 1 && height > 1);
+    ASSUME(!((uintptr_t) buf % ALIGNMENT) && !(stride % ALIGNMENT));
+    ASSUME(!((uintptr_t) tmp % ALIGNMENT));
+    ASSUME(width > 1 && height > 1);
 
     uint16_t *col_pix_buf = tmp;
     uint16_t *col_sum_buf = tmp + stride;

--- a/libass/c/c_blend_bitmaps.c
+++ b/libass/c/c_blend_bitmaps.c
@@ -25,6 +25,8 @@
 #include "ass_utils.h"
 
 
+#define ALIGNMENT  16
+
 /**
  * \brief Add two bitmaps together at a given position
  * Uses additive blending, clipped to [0,255]. Pure C implementation.
@@ -33,7 +35,9 @@ void ass_add_bitmaps_c(uint8_t *restrict dst, ptrdiff_t dst_stride,
                        const uint8_t *restrict src, ptrdiff_t src_stride,
                        size_t width, size_t height)
 {
-    ASSUME(!(dst_stride % 16) && !(src_stride % 16) && width > 0 && height > 0);
+    ASSUME(!(dst_stride % ALIGNMENT));
+    ASSUME(!(src_stride % ALIGNMENT));
+    ASSUME(width > 0 && height > 0);
 
     uint8_t *end = dst + dst_stride * height;
     while (dst < end) {
@@ -50,7 +54,9 @@ void ass_imul_bitmaps_c(uint8_t *restrict dst, ptrdiff_t dst_stride,
                         const uint8_t *restrict src, ptrdiff_t src_stride,
                         size_t width, size_t height)
 {
-    ASSUME(!(dst_stride % 16) && !(src_stride % 16) && width > 0 && height > 0);
+    ASSUME(!(dst_stride % ALIGNMENT));
+    ASSUME(!(src_stride % ALIGNMENT));
+    ASSUME(width > 0 && height > 0);
 
     uint8_t *end = dst + dst_stride * height;
     while (dst < end) {
@@ -67,8 +73,10 @@ void ass_mul_bitmaps_c(uint8_t *restrict dst, ptrdiff_t dst_stride,
                        const uint8_t *restrict src2, ptrdiff_t src2_stride,
                        size_t width, size_t height)
 {
-    ASSUME(!(dst_stride % 16) && !(src1_stride % 16) && !(src2_stride % 16) &&
-           width > 0 && height > 0);
+    ASSUME(!((uintptr_t) dst % ALIGNMENT) && !(dst_stride % ALIGNMENT));
+    ASSUME(!(src1_stride % ALIGNMENT));
+    ASSUME(!(src2_stride % ALIGNMENT));
+    ASSUME(width > 0 && height > 0);
 
     uint8_t *end = dst + dst_stride * height;
     while (dst < end) {

--- a/libass/c/c_rasterizer.c
+++ b/libass/c/c_rasterizer.c
@@ -24,6 +24,8 @@
 #include "ass_rasterizer.h"
 
 
+#define ALIGNMENT  16
+
 #define TILE_SIZE  16
 #include "rasterizer_template.h"
 #undef TILE_SIZE

--- a/libass/c/rasterizer_template.h
+++ b/libass/c/rasterizer_template.h
@@ -35,7 +35,7 @@
 
 void SUFFIX(ass_fill_solid_tile)(uint8_t *buf, ptrdiff_t stride, int set)
 {
-    ASSUME(!(stride % 16));
+    ASSUME(!((uintptr_t) buf % ALIGNMENT) && !(stride % ALIGNMENT));
 
     uint8_t value = set ? 255 : 0;
     for (int y = 0; y < TILE_SIZE; y++) {
@@ -71,7 +71,7 @@ void SUFFIX(ass_fill_solid_tile)(uint8_t *buf, ptrdiff_t stride, int set)
 void SUFFIX(ass_fill_halfplane_tile)(uint8_t *buf, ptrdiff_t stride,
                                      int32_t a, int32_t b, int64_t c, int32_t scale)
 {
-    ASSUME(!(stride % 16));
+    ASSUME(!((uintptr_t) buf % ALIGNMENT) && !(stride % ALIGNMENT));
 
     int16_t aa = RESCALE_AB(a, scale), bb = RESCALE_AB(b, scale);
     int16_t cc = RESCALE_C(c, scale) + FULL_VALUE / 2 - ((aa + bb) >> 1);
@@ -142,7 +142,7 @@ void SUFFIX(ass_fill_generic_tile)(uint8_t *restrict buf, ptrdiff_t stride,
                                    const struct segment *restrict line, size_t n_lines,
                                    int winding)
 {
-    ASSUME(!(stride % 16));
+    ASSUME(!((uintptr_t) buf % ALIGNMENT) && !(stride % ALIGNMENT));
 
     int16_t res[TILE_SIZE][TILE_SIZE] = {0};
     int16_t delta[TILE_SIZE + 2] = {0};
@@ -227,7 +227,7 @@ void SUFFIX(ass_fill_generic_tile)(uint8_t *restrict buf, ptrdiff_t stride,
 void SUFFIX(ass_merge_tile)(uint8_t *restrict buf, ptrdiff_t stride,
                             const uint8_t *restrict tile)
 {
-    ASSUME(!(stride % 16));
+    ASSUME(!((uintptr_t) buf % ALIGNMENT) && !(stride % ALIGNMENT));
 
     for (int y = 0; y < TILE_SIZE; y++) {
         for (int x = 0; x < TILE_SIZE; x++)


### PR DESCRIPTION
I think explicitly specified pointer alignment can be beneficial too.

Also we should definitely replace `ASSUME` with `assert` for CI builds. I.e.
```c
#ifdef TESTING
    #define ASSUME(x) assert(x)
#elif __has_builtin(__builtin_assume)
    #define ASSUME(x) __builtin_assume(x)
#elif defined(_MSC_VER)
    #define ASSUME(x) __assume(x)
#elif __has_builtin(__builtin_unreachable)
    #define ASSUME(x) if (!(x)) __builtin_unreachable()
#else
    #define ASSUME(x) (void) 0
#endif
```
We can reuse the same define later for threading cache asserts too.