### PR TITLE
libass: export ass_{prune_events,configure_prune} symbols

### DIFF
--- a/libass/libass.sym
+++ b/libass/libass.sym
@@ -46,3 +46,5 @@ ass_set_check_readorder
 ass_track_set_feature
 ass_malloc
 ass_free
+ass_prune_events
+ass_configure_prune


### PR DESCRIPTION
Fixes: dcc9eb722ebd485d2ed0e21c261b0a1b05497154