### PR TITLE
Consistent C standard and feature flags

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,7 +4,14 @@ AM_CPPFLAGS = -I$(top_srcdir)/libass
 # Using gnu99 to gain compatibility between const and
 # non-const array types without needing to jump to ISO C23.
 # Otherwise intended to be compatible with ISO C.
-AM_CFLAGS = -std=gnu99 -D_GNU_SOURCE
+#
+# Similarly we only strictly _need_ ISO C APIs, but we’ll use
+# some additional APIs from e.g. GNU and POSIX when available.
+# Unfortunately defining _POSIX_C_SOURCE may end up hiding additional
+# non-POSIX interfaces even if their respective feature macro is set too.
+# However, POSIX interfaces are usually implicitly enabled
+# with other feature macros, thus omit the POSIX one.
+AM_CFLAGS = -std=gnu99 -D_GNU_SOURCE -D_XPLATFORM_SOURCE
 
 EXTRA_DIST = libass.pc.in Changelog MAINTAINERS RELEASEVERSION ltnasm.sh
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,9 @@
 ACLOCAL_AMFLAGS = -I m4
 AM_CPPFLAGS = -I$(top_srcdir)/libass
+
+# Using gnu99 to gain compatibility between const and
+# non-const array types without needing to jump to ISO C23.
+# Otherwise intended to be compatible with ISO C.
 AM_CFLAGS = -std=gnu99 -D_GNU_SOURCE
 
 EXTRA_DIST = libass.pc.in Changelog MAINTAINERS RELEASEVERSION ltnasm.sh

--- a/configure.ac
+++ b/configure.ac
@@ -50,11 +50,12 @@ AC_ARG_VAR([FUZZ_CPPFLAGS],
     [If fuzzing program is enabled, set this to select alternative modes; see fuzzer source for options.])
 FUZZ_CPPFLAGS="${FUZZ_CPPFLAGS:--DASS_FUZZMODE=0}"
 
-# Checks for flags support
+# Configure Compiler
+## Perf tuning features
 AX_APPEND_COMPILE_FLAGS([-fno-math-errno])
 AX_APPEND_COMPILE_FLAGS([/clang:-fno-math-errno])
 
-# Enable some warnings
+## Warnings
 AX_APPEND_COMPILE_FLAGS([ \
     -Wall -Wextra -Wno-sign-compare -Wno-unused-parameter -Wstrict-prototypes \
     -Wpointer-arith -Werror-implicit-function-declaration -Wredundant-decls \

--- a/meson.build
+++ b/meson.build
@@ -28,7 +28,7 @@ cc_features = []
 if cc.get_id() == 'clang-cl'
     cc_features += '/clang:-fno-math-errno'
 elif cc.get_id() != 'msvc'
-    cc_features += ['-D_POSIX_C_SOURCE=200809L', '-fno-math-errno']
+    cc_features += ['-D_GNU_SOURCE', '-fno-math-errno']
 endif
 
 if cc.get_argument_syntax() == 'gcc'

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@ project(
     license: 'ISC',
     meson_version: '>= 0.64.0',
     default_options: [
-        'c_std=c99',
+        'c_std=gnu99',
         'buildtype=debugoptimized',
         'warning_level=2',
         'default_library=static',

--- a/meson.build
+++ b/meson.build
@@ -28,7 +28,7 @@ cc_features = []
 if cc.get_id() == 'clang-cl'
     cc_features += '/clang:-fno-math-errno'
 elif cc.get_id() != 'msvc'
-    cc_features += ['-D_GNU_SOURCE', '-fno-math-errno']
+    cc_features += ['-D_GNU_SOURCE', '-D_XPLATFORM_SOURCE', '-fno-math-errno']
 endif
 
 if cc.get_argument_syntax() == 'gcc'


### PR DESCRIPTION
If someone figures out how to sidestep the array type incompatibility in C99 without additional copies, we can also use `c99` everywhere instead.