### PR TITLE
ci/gha/meson: build both static and dynamic lib on Windows

### DIFF
--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -22,7 +22,7 @@ jobs:
             msystem: MINGW64,
             shell: 'powershell',
             buildtype: release,
-            args: '-Ddefault_library=static'
+            args: '-Ddefault_library=both'
           }
           - {
             name: Windows MinGW Release,
@@ -32,7 +32,7 @@ jobs:
             msystem: MINGW64,
             shell: 'msys2 {0}',
             buildtype: debugoptimized,
-            args: ''
+            args: '-Ddefault_library=both'
           }
           - {
             name: Ubuntu Debug,

--- a/meson.build
+++ b/meson.build
@@ -46,6 +46,10 @@ if cc.get_argument_syntax() == 'gcc'
 elif cc.get_id() == 'msvc'
     cc_warnings += [
         '/we4013', # implicit function definition
+        '/we4775', # non-standard format strings
+        '/we4317', # not enough arguments for format string
+        '/we4473', # same as above
+        '/we4474', # too many arguments for format string
     ]
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -43,6 +43,10 @@ if cc.get_argument_syntax() == 'gcc'
         '-Wformat-non-iso',
         '-Werror=format-non-iso',
     ]
+elif cc.get_id() == 'msvc'
+    cc_warnings += [
+        '/we4013', # implicit function definition
+    ]
 endif
 
 add_project_arguments(


### PR DESCRIPTION
As brought up in the threading PR #793 

@astiob, do you know which flags we need with MSVC to enable similar errors as for GCC-like compilers?