### PR TITLE
[WIP/POC] Add API to obtain metrics and shape data

### DIFF
--- a/libass/Makefile_library.am
+++ b/libass/Makefile_library.am
@@ -11,7 +11,8 @@ libass_libass_internal_la_SOURCES = \
     libass/ass_string.h libass/ass_string.c \
     libass/ass_compat.h libass/ass_strtod.c \
     libass/ass_filesystem.h libass/ass_filesystem.c \
-    libass/ass_types.h libass/ass.h libass/ass_priv.h libass/ass.c \
+    libass/ass_types.h libass/ass_metrics.h \
+    libass/ass.h libass/ass_priv.h libass/ass.c \
     libass/ass_library.h libass/ass_library.c \
     libass/ass_cache_template.h libass/ass_cache.h libass/ass_cache.c \
     libass/ass_font.h libass/ass_font.c \
@@ -71,7 +72,7 @@ libass_libass_la_LDFLAGS = -no-undefined -version-info $(LIBASS_LT_CURRENT):$(LI
 libass_libass_la_LDFLAGS += -export-symbols $(top_srcdir)/libass/libass.sym
 
 assheadersdir = $(includedir)/ass
-dist_assheaders_HEADERS = libass/ass_types.h libass/ass.h
+dist_assheaders_HEADERS = libass/ass_types.h libass/ass_metrics.h libass/ass.h
 
 EXTRA_DIST += \
     libass/x86/x86inc.asm libass/x86/utils.asm \

--- a/libass/ass.h
+++ b/libass/ass.h
@@ -610,6 +610,9 @@ void ass_set_cache_limits(ASS_Renderer *priv, int glyph_max,
  * \param now video timestamp in milliseconds
  * \param detect_change compare to the previous call and set to 1
  * if positions may have changed, or set to 2 if content may have changed.
+ *
+ * The returned ASS_Images live until the next call to ass_render_frame,
+ * ass_get_metrics, or ass_renderer_done.
  */
 ASS_Image *ass_render_frame(ASS_Renderer *priv, ASS_Track *track,
                             long long now, int *detect_change);

--- a/libass/ass_metrics.h
+++ b/libass/ass_metrics.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2024 libass contributors
+ *
+ * This file is part of libass.
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef LIBASS_METRICS_H
+#define LIBASS_METRICS_H
+
+#include <stdio.h>
+
+#include "ass_types.h"
+
+/*
+ * API to obtain text metrics and shape data for subtitles.
+ * This API is intended to ease the authoring of subtitles by providing
+ * a unified and platform-independent method to obtain metrics.
+ * However, there are no guarantees for the stability of the data returned by
+ * this API. With future changes to libass and its rendering, the returned
+ * metrics and shape data may change too.
+ *
+ * For example, subtitle authors could use this API to determine when and
+ * where libass automatically breaks a subtitle line into two, but there is
+ * no guarantee that newer or older versions of libass (as well as other
+ * renderers) will always break this line in the same way. Subtitle authors
+ * that want to ensure that a line is broken in a certain way should instead
+ * use manual line breaks and overrides (e.g. \q2).
+ *
+ * API Usage:
+ * After initializing and configuring an ASS_Renderer and ASS_Track in the
+ * same way as one would for normal subtitle rendering, users may call
+ * ass_get_metrics to obtain metrics for all events rendered at the given
+ * point in time.
+ * This returns a list of event metrics, each of which consisting of a list
+ * of runs, with metrics for those runs. A run contains lists of shapes
+ * which, when drawn together, make up the shape for the fill or border of
+ * the run.
+ * The individual shapes correspond to individual glyphs rendered in the run,
+ * but due to font shaping there is no guarantee for these glyphs to
+ * correspond one-to-one to characters in the run's text.
+ */
+
+
+/*
+ * An outline is represented by an array of points and an array of segments.
+ * Segments can be splines of order 1 (line), 2 (quadratic) or 3 (cubic).
+ * Each segment owns a number of points equal to its order in the point array
+ * and uses the first point owned by the next segment as its last point.
+ * The last segment in each contour uses the first point owned by the first
+ * segment in each contour as its last point.
+ * Correspondingly, the total number of points is equal to the sum of the
+ * spline orders of all segments.
+ */
+
+enum {
+    ASS_METRICS_OUTLINE_LINE_SEGMENT     = 1,  // line segment
+    ASS_METRICS_OUTLINE_QUADRATIC_SPLINE = 2,  // quadratic spline
+    ASS_METRICS_OUTLINE_CUBIC_SPLINE     = 3,  // cubic spline
+    ASS_METRICS_OUTLINE_COUNT_MASK       = 3,  // spline order mask
+    ASS_METRICS_OUTLINE_CONTOUR_END      = 4   // last segment in contour flag
+};
+
+typedef struct ass_metrics_outline {
+    size_t n_points;
+    size_t n_segments;
+    ASS_DVector *points;
+    char *segments;
+
+    struct ass_metrics_outline *next;   // Next outline, or NULL
+} ASS_Metrics_Outline;
+
+/* ASS_RunMetrics is a set of metrics and shape data corresponding to a single run. */
+typedef struct ass_run_metrics {
+    ASS_DVector pos;
+    ASS_DVector advance;
+    double asc;
+    double desc;
+    // TODO: Add more fields here?
+
+    ASS_Metrics_Outline *fill;
+    ASS_Metrics_Outline *border;
+
+    struct ass_run_metrics *next;    // Next run, or NULL
+} ASS_RunMetrics;
+
+/* ASS_Metrics is a set of metrics corresponding to a single event. */
+typedef struct ass_metrics {
+    ASS_Event *event;   // Becomes invalid once the containing ASS_Track is modified, pruned, or freed
+    ASS_RunMetrics *runs;
+    struct ass_metrics *next;   // Next set of metrics, or NULL
+} ASS_Metrics;
+
+/**
+ * \brief Get metrics for a frame, producing a list of ASS_Metrics.
+ * The metrics returned live until the next call to ass_get_metrics, ass_render_frame,
+ * or ass_renderer_done.
+ *
+ * \param priv renderer handle
+ * \param track subtitle track
+ * \param now video timestamp in milliseconds
+ */
+ASS_Metrics *ass_get_metrics(ASS_Renderer *priv, ASS_Track *track, long long now);
+
+#endif /* LIBASS_METRICS_H */

--- a/libass/ass_outline.c
+++ b/libass/ass_outline.c
@@ -77,6 +77,48 @@ void ass_outline_free(ASS_Outline *outline)
 }
 
 
+/*
+ * \brief Allocate an ASS_Metrics_Outline's memory and copy the given
+ * ASS_Outline's data into it.
+ */
+void ass_metric_outline_copy(ASS_Metrics_Outline *metrics_outline, ASS_Outline *outline)
+{
+    metrics_outline->n_points = outline->n_points;
+    metrics_outline->n_segments = outline->n_segments;
+    metrics_outline->points = malloc(sizeof(ASS_DVector) * outline->n_points);
+    metrics_outline->segments = malloc(outline->n_segments);
+    if (!metrics_outline->points || !metrics_outline->segments) {
+        free(metrics_outline->points);
+        free(metrics_outline->segments);
+        metrics_outline->n_points = 0;
+        metrics_outline->n_segments = 0;
+        return;
+    }
+
+    memcpy(metrics_outline->segments, outline->segments, outline->n_segments);
+
+    for (int i = 0; i < outline->n_points; i++) {
+        metrics_outline->points[i].x = d6_to_double(outline->points[i].x);
+        metrics_outline->points[i].y = d6_to_double(outline->points[i].y);
+    }
+}
+
+/*
+ * \brief Free the point and segments lists of an ASS_Metrics_Outline
+ */
+void ass_metric_outline_free(ASS_Metrics_Outline *metrics_outline)
+{
+    if (!metrics_outline)
+        return;
+
+    free(metrics_outline->points);
+    free(metrics_outline->segments);
+    metrics_outline->points = NULL;
+    metrics_outline->segments = NULL;
+    metrics_outline->n_points = 0;
+    metrics_outline->n_segments = 0;
+}
+
 static bool valid_point(const FT_Vector *pt)
 {
     return labs(pt->x) <= OUTLINE_MAX && labs(pt->y) <= OUTLINE_MAX;

--- a/libass/ass_outline.h
+++ b/libass/ass_outline.h
@@ -24,16 +24,13 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "ass_metrics.h"
 #include "ass_utils.h"
 
 
 typedef struct {
     int32_t x, y;
 } ASS_Vector;
-
-typedef struct {
-    double x, y;
-} ASS_DVector;
 
 typedef struct {
     int32_t x_min, y_min, x_max, y_max;
@@ -90,6 +87,9 @@ typedef struct {
 void ass_outline_clear(ASS_Outline *outline);
 bool ass_outline_alloc(ASS_Outline *outline, size_t n_points, size_t n_segments);
 void ass_outline_free(ASS_Outline *outline);
+
+void ass_metric_outline_copy(ASS_Metrics_Outline *metrics_outline, ASS_Outline *outline);
+void ass_metric_outline_free(ASS_Metrics_Outline *metrics_outline);
 
 // expects preallocated outline and works inplace
 bool ass_outline_convert(ASS_Outline *outline, const FT_Outline *source);

--- a/libass/ass_render.h
+++ b/libass/ass_render.h
@@ -30,6 +30,7 @@
 #include <hb.h>
 
 #include "ass.h"
+#include "ass_metrics.h"
 #include "ass_font.h"
 #include "ass_bitmap.h"
 #include "ass_cache.h"
@@ -86,6 +87,7 @@ typedef struct {
     int detect_collisions;
     int shift_direction;
     ASS_Event *event;
+    ASS_Metrics metrics;
 } EventImages;
 
 typedef enum {
@@ -216,6 +218,10 @@ struct render_context {
 
     ASS_Event *event;
     ASS_Style *style;
+
+    bool collect_metrics;
+    ASS_RunMetrics *run_metrics;
+    ASS_RunMetrics *current_run_metrics;
 
     ASS_Font *font;
     double font_size;
@@ -355,6 +361,9 @@ typedef struct {
 } Rect;
 
 void ass_reset_render_context(RenderContext *state, ASS_Style *style);
+int ass_render_frame_internal(ASS_Renderer *priv, ASS_Track *track, long long now, int *detect_change, bool collect_metrics);
+void ass_outline_apply_transform(ASS_Outline *outline, BitmapHashKey *k);
+void ass_free_metrics(ASS_Renderer *priv);
 void ass_frame_ref(ASS_Image *img);
 void ass_frame_unref(ASS_Image *img);
 ASS_Vector ass_layout_res(ASS_Renderer *render_priv);

--- a/libass/ass_types.h
+++ b/libass/ass_types.h
@@ -305,4 +305,8 @@ typedef struct ass_track {
     // New fields can be added here in new ABI-compatible library releases.
 } ASS_Track;
 
+typedef struct {
+    double x, y;
+} ASS_DVector;
+
 #endif /* LIBASS_TYPES_H */

--- a/libass/libass.sym
+++ b/libass/libass.sym
@@ -48,3 +48,4 @@ ass_malloc
 ass_free
 ass_prune_events
 ass_configure_prune
+ass_get_metrics

--- a/libass/meson.build
+++ b/libass/meson.build
@@ -69,7 +69,7 @@ libass_src = files(
 
 libass_link_with = []
 
-libass_headers = files('ass.h', 'ass_types.h')
+libass_headers = files('ass.h', 'ass_types.h', 'ass_metrics.h')
 
 if fontconfig
     libass_src += src_fontconfig

--- a/test/test.c
+++ b/test/test.c
@@ -22,6 +22,7 @@
 #include <stdarg.h>
 #include <string.h>
 #include "../libass/ass.h"
+#include "../libass/ass_metrics.h"
 #include <png.h>
 
 typedef struct image_s {
@@ -247,6 +248,31 @@ int main(int argc, char *argv[])
     if (!track) {
         printf("track init failed!\n");
         return 1;
+    }
+
+    ASS_Metrics *metrics =
+        ass_get_metrics(ass_renderer, track, (int) (tm * 1000));
+
+    for (; metrics != NULL; metrics = metrics->next) {
+            printf("Got metrics:\n");
+            printf("    Event text: %s\n", metrics->event->Text);
+            for (ASS_RunMetrics *run = metrics->runs; run; run = run->next) {
+                printf("        Run with ascender %f, descender %f, advance (%f, %f), pos (%f, %f):\n", run->asc, run->desc, run->advance.x, run->advance.y, run->pos.x, run->pos.y);
+                for (int z = 0; z < 2; z++) {
+                    printf("        %s:\n", z == 0 ? "Fill" : "Border");
+                    for (ASS_Metrics_Outline *outline = z == 0 ? run->fill : run->border; outline; outline = outline->next) {
+                        printf("          Got outline with %ld points and %ld segments\n", outline->n_points, outline->n_segments);
+
+                        /* printf("            "); */
+                        /* for (int i = 0; i < outline->n_points; i++) { */
+                        /*     if (i != 0) */
+                        /*         printf(", "); */
+                        /*     printf("(%.2f, %.2f)", outline->points[i].x, outline->points[i].y); */
+                        /* } */
+                        /* printf("\n"); */
+                    }
+                }
+            }
     }
 
     ASS_Image *img =


### PR DESCRIPTION
This is an initial proof-of-concept attempt to implement an API along the lines of #825. It's not yet complete, but before spending more time on this I'd first like to ask if you would be open to adding such a metrics API at all, and if so, if you agree with the overall structure used in this PR. If that is the case, I can polish the PR and discuss some of the finer details (like what fields should be exposed, what data structures to use, and other implementation details).

A couple of comments.
- I went with the general structure outlined in #825, i.e. adding an `ass_get_metrics` function that internally does all the same operations as `ass_render_frame` (even including rasterization), but in the end returns shape data rather than bitmaps. The idea being that this is fairly easy to implement from libass's side and provides a very powerful API to the user. (To clarify, I'm imagining the user either creating a dedicated `ASS_Track` to pass to `ass_get_metrics`, or to add an extra event they want to measure to an existing track (which they might need if they care about collision detection) and picking out the `ASS_Metrics` struct pointing to that added event.) A downside may be that the user will need to create an entire `ASS_Track` with headers and styles and everything in order to obtain metrics, but since this API is mainly aimed at authoring tools, most programs that would use such an API should already have the machinery for this.
- I added the API in a separate header to not confuse users that just want to render subtitles, and so that the metrics API could theoretically be versioned separately (i.e. more finely) from the main API.
- My main aim when implementing the API was to impact the normal rendering code as little as possible, i.e. to not add any big separate code paths and to instead just write some of the intermediate data into structs. In particular, `ass_get_metrics` still runs the full rasterization code even though the result is not used (though this could also be avoided with more work). This being an authoring API, performance should not be as critical, and I feel like this way it should have better maintainability.

Again, the main feedback I'm interested in right now is whether you would consider adding this kind of API at all. If so, I can flesh this out further.