### PR TITLE
fontconfig: fix minor memory leak in fallback font selection

### DIFF
--- a/libass/ass_fontconfig.c
+++ b/libass/ass_fontconfig.c
@@ -243,8 +243,11 @@ static void cache_fallbacks(ProviderPrivate *fc)
 
     // If this fails, just add an empty set
     // (if it fails, cache_fallbacks will just be reattempted later)
-    if (result != FcResultMatch)
+    if (result != FcResultMatch) {
+        if (fc->fallbacks)
+            FcFontSetDestroy(fc->fallbacks);
         fc->fallbacks = FcFontSetCreate();
+    }
 
     FcPatternDestroy(pat);
 }


### PR DESCRIPTION
When the used config is completely devoid of fonts FcFontSort will attempt to allocate an empty set and return it while still setting the result to invalid.

Similar case as fixed in 6e83137cdbaf4006439d526fef902e123129707b.