### PR TITLE
ci/gha/meson: use ubuntu-latest directly for tarball test

### DIFF
--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -232,9 +232,6 @@ jobs:
 
   build-from-tarball:
     runs-on: ubuntu-latest
-    container:
-      # currently GHA’s ubuntu-latest still has a too old meson
-      image: debian:stable
 
     strategy:
       fail-fast: false
@@ -244,8 +241,8 @@ jobs:
     steps:
       - name: install dependencies
         run: |
-          apt-get update #&& sudo apt-get upgrade
-          apt-get install -y --no-install-recommends \
+          sudo apt-get update #&& sudo apt-get upgrade
+          sudo apt-get install -y --no-install-recommends \
                   autoconf automake make libtool \
                   libfontconfig1-dev libfreetype6-dev libfribidi-dev \
                   libharfbuzz-dev nasm ${{ matrix.cc }} \

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -266,4 +266,4 @@ jobs:
           cd libass-*/
           meson setup build
           ninja -C build
-          DESTIDR="$PWD/TEST_INSTALL" ninja -C build install
+          DESTDIR="$PWD/TEST_INSTALL" ninja -C build install


### PR DESCRIPTION
It has been upgraded to 24.04 which should be new enough.