### PR TITLE
[.gitignore] Ignore Visual Studio Code folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ Makefile.in
 
 # Meson
 /subprojects
+
+# Visual Studio Code
+/.vscode


### PR DESCRIPTION
I'm currently working on fixing an issue.
I use Visual Studio Code as my IDE, and this keeps bothering me because I don't want to commit my [``launch.json``](https://code.visualstudio.com/docs/cpp/launch-json-reference) and [``tasks.json``](https://code.visualstudio.com/docs/editor/tasks) files.