### PR TITLE
meson: add support for oss-fuzz

### DIFF
--- a/fuzz/meson.build
+++ b/fuzz/meson.build
@@ -9,6 +9,8 @@ libass_fuzz = executable(
     install: false,
     include_directories: incs,
     dependencies: deps,
+    link_args: get_option('fuzz-link-args'),
+    link_language: get_option('fuzz-link-language'),
     link_with: libass_for_tools,
 )
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,6 +4,8 @@ option('profile', type: 'feature', description: 'enable profiling program')
 option('fuzz', type: 'feature', description: 'enable fuzzing consumer')
 option('checkasm', type: 'feature', description: 'enable assembly unit test program')
 option('art-samples', type: 'string', description: 'Path to the root of regression testing sample repository. If set, it is used in meson test.')
+option('fuzz-link-args', type: 'string', description: 'Additional link flags for fuzz targets.')
+option('fuzz-link-language', type : 'combo', choices : ['c', 'cpp'], value : 'c', description: 'Linking language for fuzz targets.')
 
 option('fontconfig', type: 'feature', description: 'Fontconfig support')
 option('directwrite', type: 'feature', description: 'DirectWrite support (win32 only)')


### PR DESCRIPTION
This will allow to enable MSAN and i386 builds in oss-fuzz. See: https://github.com/kasper93/oss-fuzz/commit/2709d7fed5303a0601c6e7c85792a2ba58258119