### PR TITLE
[Experiment] Clip/cull (partially-)offscreen glyphs

### DIFF
--- a/libass/ass_bitmap.c
+++ b/libass/ass_bitmap.c
@@ -147,7 +147,8 @@ bool ass_copy_bitmap(const BitmapEngine *engine, Bitmap *dst, const Bitmap *src)
 }
 
 bool ass_outline_to_bitmap(RenderContext *state, Bitmap *bm,
-                           ASS_Outline *outline1, ASS_Outline *outline2)
+                           ASS_Outline *outline1, ASS_Outline *outline2,
+                           ASS_Rect *clip)
 {
     ASS_Renderer *render_priv = state->renderer;
     RasterizerData *rst = &state->rasterizer;
@@ -167,6 +168,19 @@ bool ass_outline_to_bitmap(RenderContext *state, Bitmap *bm,
     int32_t y_min = (rst->bbox.y_min -   1) >> 6;
     int32_t x_max = (rst->bbox.x_max + 127) >> 6;
     int32_t y_max = (rst->bbox.y_max + 127) >> 6;
+
+
+    if (clip->x_min != 0 || clip->y_min != 0 || clip->x_max != 0 || clip->y_max != 0) {
+        x_min = FFMAX(x_min, clip->x_min);
+        y_min = FFMAX(y_min, clip->y_min);
+        x_max = FFMIN(x_max, clip->x_max);
+        y_max = FFMIN(y_max, clip->y_max);
+
+        if (x_max <= x_min || y_max <= y_min) {
+            return false;
+        }
+    }
+
     int32_t w = x_max - x_min;
     int32_t h = y_max - y_min;
 

--- a/libass/ass_bitmap.h
+++ b/libass/ass_bitmap.h
@@ -47,6 +47,7 @@ bool ass_outline_to_bitmap(struct render_context *state, Bitmap *bm,
 void ass_synth_blur(const BitmapEngine *engine, Bitmap *bm,
                     int be, double blur_r2x, double blur_r2y);
 
+uint32_t ass_blur_padding(double r2);
 bool ass_gaussian_blur(const BitmapEngine *engine, Bitmap *bm, double r2x, double r2y);
 void ass_shift_bitmap(Bitmap *bm, int shift_x, int shift_y);
 void ass_fix_outline(Bitmap *bm_g, Bitmap *bm_o);

--- a/libass/ass_bitmap.h
+++ b/libass/ass_bitmap.h
@@ -42,7 +42,8 @@ void ass_free_bitmap(Bitmap *bm);
 struct render_context;
 
 bool ass_outline_to_bitmap(struct render_context *state, Bitmap *bm,
-                           ASS_Outline *outline1, ASS_Outline *outline2);
+                           ASS_Outline *outline1, ASS_Outline *outline2,
+                           ASS_Rect *clip);
 
 void ass_synth_blur(const BitmapEngine *engine, Bitmap *bm,
                     int be, double blur_r2x, double blur_r2y);

--- a/libass/ass_cache_template.h
+++ b/libass/ass_cache_template.h
@@ -8,6 +8,8 @@
         ASS_StringView member;
 #define VECTOR(member) \
         ASS_Vector member;
+#define RECT(member) \
+        ASS_Rect member;
 #define END(typedefnamename) \
     } typedefnamename;
 
@@ -25,6 +27,10 @@
             ass_string_equal(a->member, b->member) &&
 #define VECTOR(member) \
             a->member.x == b->member.x && a->member.y == b->member.y &&
+#define RECT(member) \
+            a->member.x_min == b->member.x_min && a->member.y_min == b->member.y_min && \
+            a->member.x_max == b->member.x_max && a->member.y_max == b->member.y_max &&
+
 #define END(typedefname) \
             true; \
     }
@@ -40,6 +46,9 @@
 #define STRING(member) \
         hval = ass_hash_buf(p->member.str, p->member.len, hval);
 #define VECTOR(member) GENERIC(, member.x); GENERIC(, member.y);
+#define RECT(member) \
+        GENERIC(, member.x_min); GENERIC(, member.y_min); \
+        GENERIC(, member.x_max); GENERIC(, member.y_max);
 #define END(typedefname) \
         return hval; \
     }
@@ -135,4 +144,5 @@ END(BitmapRef)
 #undef GENERIC
 #undef STRING
 #undef VECTOR
+#undef RECT
 #undef END

--- a/libass/ass_cache_template.h
+++ b/libass/ass_cache_template.h
@@ -75,6 +75,8 @@ START(bitmap, bitmap_hash_key)
     VECTOR(matrix_x)
     VECTOR(matrix_y)
     VECTOR(matrix_z)
+    // clip region
+    RECT(clip)
 END(BitmapHashKey)
 
 // font is refed when inserted and unrefed when dropped


### PR DESCRIPTION
This vastly improves performance on some samples by culling (parts of) glyphs that are far enough offscreen that they can't possibly affect our final output. It's a very large strict improvement on things like "star wars title crawls", but results in increased CPU usage (though still generally better worst-frame performance and fewer framedrops) on some simple 2D-scrolling signs (since it results in more cache misses when the same glyph with the same parameters is drawn with multiple clips).

TODO:
- `ass_blur_padding()` is trash and should be rewritten (@MrSmile, any interest?)
- `USE_RECT_CLIP` is currently disabled because I expect it would worsen clip-sliced gradients
- Probably would be good to have a "cache peek" routine to check if an unclipped bitmap *already* exists in cache and fetch it immediately (this would mean we'd also want a second clip in `ass_composite_construct`)
- There might be some heuristics we could use to improve behavior on 2D-scroll cases? Maybe something like "never actually render a partial glyph if position is animated but rotation isn't; instead, make a decision on whether to reject rasterizing at all [if fully offscreen], or to re-request the unclipped glyph from cache"?