### PR TITLE
Fix \fay with glyph clusters

### DIFF
--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -2316,9 +2316,11 @@ static void apply_baseline_shear(RenderContext *state)
             info->skip = true;
         if (info->skip)
             continue;
-        for (GlyphInfo *cur = info; cur; cur = cur->next)
-            cur->pos.y += shear;
-        shear += (info->fay / info->scale_x * info->scale_y) * info->cluster_advance.x;
+        double fay = info->fay / info->scale_x * info->scale_y;
+        for (GlyphInfo *cur = info; cur; cur = cur->next) {
+            cur->pos.y += shear + fay * cur->offset.x;
+            shear += fay * cur->advance.x;
+        }
     }
 }
 


### PR DESCRIPTION
For `offset.x`, `{\fnArial}a͉` seems to work as a test.

---

Glyphs within multiglyph clusters weren't adjusted correctly. In particular, for Burmese, HarfBuzz produces clusters that contain multiple glyphs laid out in a horizontal sequence, with large positive intra-cluster advances, which were not getting translated to vertical offsets by our \fay code, causing the later glyphs within the cluster to appear raised, as though forming a staircase.

Fixes: https://github.com/libass/libass/issues/887