### PR TITLE
ASS/SSA Format: add animated transform for \pos behind header

### DIFF
--- a/fuzz/ass.dict
+++ b/fuzz/ass.dict
@@ -47,6 +47,7 @@
 "YCbCr Matrix"
 "Kerning"
 "Language"
+"PositionTransform"
 ## Interesting Script Info Header Values
 "v4.00"
 "v4.00+"

--- a/fuzz/writeout.c
+++ b/fuzz/writeout.c
@@ -112,6 +112,7 @@ static void write_header(FILE *f, ASS_Track *track, const char *originalformat_n
     HEADER_BOOL(ScaledBorderAndShadow);
     HEADER_BOOL(Kerning);
     HEADER_STR(Language);
+    HEADER_BOOL(PositionTransform);
     if (track->YCbCrMatrix != YCBCR_DEFAULT) /* Or normalise this to TV.601? */
         fprintf(f, "YCbCr Matrix: %s\n", ycbcr_to_str(track->YCbCrMatrix));
 

--- a/libass/ass.c
+++ b/libass/ass.c
@@ -575,6 +575,8 @@ void ass_process_force_style(ASS_Track *track)
             track->Kerning = parse_bool(token);
         else if (!ass_strcasecmp(*fs, "YCbCr Matrix"))
             track->YCbCrMatrix = parse_ycbcr_matrix(token);
+        else if (!ass_strcasecmp(*fs, "PositionTransform"))
+            track->PositionTransform = parse_bool(token);
 
         dt = strrchr(*fs, '.');
         if (dt) {
@@ -908,6 +910,10 @@ static int process_info_line(ASS_Track *track, char *str)
         while (*p && ass_isspace(*p)) p++;
         free(track->Language);
         track->Language = strndup(p, 2);
+    } else if (!strncmp(str, "PositionTransform:", 18)) {
+        check_duplicate_info_line(track, SINFO_POSTRANSFORM,
+                                    "PositionTransform");
+        track->PositionTransform = parse_bool(str + 18);
     } else if (!strncmp(str, "ScriptType:", 11)) {
         check_duplicate_info_line(track, SINFO_SCRIPTTYPE, "ScriptType");
         parse_script_type(track, str + 11);

--- a/libass/ass_parse.c
+++ b/libass/ass_parse.c
@@ -610,14 +610,18 @@ char *ass_parse_tags(RenderContext *state, char *p, char *end, double pwr,
                 v2 = argtod(args[1]);
             } else
                 continue;
-            if (state->evt_type & EVENT_POSITIONED) {
+
+            int allow_transform = state->renderer->track->PositionTransform;
+
+            if (state->evt_type & EVENT_POSITIONED && 
+                (!allow_transform || (allow_transform && !nested))) {
                 ass_msg(render_priv->library, MSGL_V, "Subtitle has a new \\pos "
                        "after \\move or \\pos, ignoring");
             } else {
                 state->evt_type |= EVENT_POSITIONED;
                 state->detect_collisions = 0;
-                state->pos_x = v1;
-                state->pos_y = v2;
+                state->pos_x = allow_transform ? v1 * pwr + state->pos_x * (1 - pwr) : v1;
+                state->pos_y = allow_transform ? v2 * pwr + state->pos_y * (1 - pwr) : v2;
             }
         } else if (complex_tag("fade") || complex_tag("fad")) {
             int32_t a1, a2, a3;

--- a/libass/ass_priv.h
+++ b/libass/ass_priv.h
@@ -44,6 +44,7 @@ typedef enum {
     SINFO_SCRIPTTYPE   = 1 << 8,
     SINFO_LAYOUTRESX   = 1 << 9,
     SINFO_LAYOUTRESY   = 1 << 10,
+    SINFO_POSTRANSFORM = 1 << 11,
     // for legacy detection
     GENBY_FFMPEG       = 1 << 14
     // max 32 enumerators

--- a/libass/ass_types.h
+++ b/libass/ass_types.h
@@ -291,6 +291,7 @@ typedef struct ass_track {
     int ScaledBorderAndShadow; // 0 or 1 (boolean)
     int Kerning; // 0 or 1 (boolean)
     char *Language; // zero-terminated ISO-639-1 code
+    int PositionTransform; // 0 or 1 (boolean)
     ASS_YCbCrMatrix YCbCrMatrix;
 
     int default_style;      // index of default style


### PR DESCRIPTION
Adding support for \pos in \t tags to allow use of acceleration and multiple movements within a single tag.

More discussion here: https://github.com/libass/libass/issues/886
