### PR TITLE
Scale margin values received from user override style.

### DIFF
--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -991,9 +991,9 @@ static ASS_Style *handle_selective_style_overrides(RenderContext *state,
         new->Justify = user->Justify;
 
     if (requested & ASS_OVERRIDE_BIT_MARGINS) {
-        new->MarginL = user->MarginL;
-        new->MarginR = user->MarginR;
-        new->MarginV = user->MarginV;
+        new->MarginL = user->MarginL * scale;
+        new->MarginR = user->MarginR * scale;
+        new->MarginV = user->MarginV * scale;
     }
 
     if (!new->FontName)


### PR DESCRIPTION
These are also effected by script resolution and the override style is supposed to be resolution independent.
