### PR TITLE
ass_shaper: map Encoding=-2 to FRIBIDI_PAR_RTL

### DIFF
--- a/libass/ass_shaper.c
+++ b/libass/ass_shaper.c
@@ -1130,13 +1130,15 @@ FriBidiStrIndex *ass_shaper_get_reorder_map(ASS_Shaper *shaper)
 /**
  * \brief Resolve a Windows font charset number to a suitable base
  * direction. Generally, use LTR for compatibility with VSFilter. The
- * special value -1, which is not a legal Windows font charset number,
- * can be used for autodetection.
+ * special values -1 and -2, which are not legal Windows font charset numbers,
+ * can be used for autodetection and forcing RTL, respectively.
  * \param enc Windows font encoding
  */
 FriBidiParType ass_resolve_base_direction(int enc)
 {
     switch (enc) {
+        case -2:
+            return FRIBIDI_PAR_RTL;
         case -1:
             return FRIBIDI_PAR_ON;
         default:


### PR DESCRIPTION
This is useful for forcing RTL rendering of text if they come from sources that sideload text layout information, such as Youtube where the text layout is set externally via CSS and isn't present in the sub file itself. It's not trivial to detect those cases, but it is trivial to provide a way to force RTL if the user chooses to.