### PR TITLE
build: define FORCE_VEX_ENCODING=1 for nasm if compilers have avx

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -325,6 +325,13 @@ AS_IF([test "x$enable_asm" != xno], [
                         ))
                     ]
                 )
+
+                # Convert SSE asm into (128-bit) AVX when compiler baseline is set to use AVX.
+                # Switching between AVX and SSE instructions can incur penalties.
+                AC_CHECK_DECL([__AVX__], [
+                    ASFLAGS="$ASFLAGS -DFORCE_VEX_ENCODING=1"
+                ])
+
                 AC_MSG_CHECKING([if $AS supports vpmovzxwd])
                 echo "vpmovzxwd ymm0, xmm0" > conftest.asm
                 AS_IF([$AS conftest.asm $ASFLAGS -o conftest.o >conftest.log 2>&1], [

--- a/meson.build
+++ b/meson.build
@@ -310,6 +310,11 @@ if not asm_option.disabled()
                 )
             endif
 
+            # Convert SSE asm into (128-bit) AVX when compiler flags are set to use AVX instructions
+            if cc.get_define('__AVX__').strip() != ''
+                nasm_args += '-DFORCE_VEX_ENCODING=1'
+            endif
+
             add_project_arguments(nasm_args, language: 'nasm')
         endif
     elif generic_cpu_family == 'aarch64'


### PR DESCRIPTION
use a x86inc.asm feature to automatically convert sse asm to avx when compiling for avx targets

this fixes an edge issue in a special case where libass is built with -mavx but not -mavx2, and vzeroupper has been disabled. In addition, since DCE currently doesn't work for asm, this also reduces the number of sse instructions in the final build product targeted for avx2+.