### PR TITLE
Do not output fully transparent bitmaps

### DIFF
--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -3366,6 +3366,25 @@ static int ass_detect_change(ASS_Renderer *priv)
 }
 
 /**
+ * \brief free a single image.
+ * \param img image as returned by ass_render_frame().
+ *        Only img will be freed, not img->next.
+ * \return img->next
+ * Should not be called outside of ass_frame_unref
+ * once the image list's refcounting is set up.
+ */
+static ASS_Image *ass_free_image(ASS_Image *img) {
+    ASS_Image *next = img->next;
+
+    ASS_ImagePriv *priv = (ASS_ImagePriv *) img;
+    ass_cache_dec_ref(priv->source);
+    ass_aligned_free(priv->buffer);
+    free(priv);
+
+    return next;
+}
+
+/**
  * \brief render a frame
  * \param priv library handle
  * \param track track
@@ -3415,16 +3434,25 @@ ASS_Image *ass_render_frame(ASS_Renderer *priv, ASS_Track *track,
     if (cnt > 0)
         fix_collisions(priv, last, priv->eimg + cnt - last);
 
-    // concat lists
+    // concat lists, removing fully transparent bitmaps
     ASS_Image **tail = &priv->images_root;
     for (int i = 0; i < cnt; i++) {
         ASS_Image *cur = priv->eimg[i].imgs;
         while (cur) {
+            if (_a(cur->color) == 0xFF) {
+                cur = ass_free_image(cur);
+                continue;
+            }
+
             *tail = cur;
             tail = &cur->next;
             cur = cur->next;
         }
     }
+
+    // If the last image was skipped in the above loop, *tail may not be NULL and needs to be set to NULL.
+    *tail = NULL;
+
     ass_frame_ref(priv->images_root);
 
     if (detect_change)
@@ -3460,10 +3488,6 @@ void ass_frame_unref(ASS_Image *img)
     if (!img || --((ASS_ImagePriv *) img)->ref_count)
         return;
     do {
-        ASS_ImagePriv *priv = (ASS_ImagePriv *) img;
-        img = img->next;
-        ass_cache_dec_ref(priv->source);
-        ass_aligned_free(priv->buffer);
-        free(priv);
+        img = ass_free_image(img);
     } while (img);
 }


### PR DESCRIPTION
Work towards #532.

With this, fully transparent bitmaps are still fully rasterized, blurred, shifted, etc., but are at least not returned to the calling application to be blended.

---

The main objection I can see to this is the following comment in #532:

> it will affect output bitmap sizes, which some applications currently use for extent measurement.

I personally don't see how this would break such extent measurements, since applications can just not use `\alphaFF` in these cases, but if this *is* a problem this check could also just be implemented in all relevant downstream applications instead (with simpler code, too). But all else being equal it's nicer for this to be implemented upstream.