### PR TITLE
x86inc.asm: add support for separate .text sections

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -41,6 +41,8 @@ AC_ARG_ENABLE([asm], AS_HELP_STRING([--disable-asm],
     [disable compiling with ASM @<:@default=check@:>@]))
 AC_ARG_ENABLE([large-tiles], AS_HELP_STRING([--enable-large-tiles],
     [use larger tiles in the rasterizer (better performance, slightly worse quality) @<:@default=disabled@:>@]))
+AC_ARG_ENABLE([trim-asm], AS_HELP_STRING([--enable-trim-asm],
+    [eliminate redundant asm functions where possible @<:@default=disabled@:>@]))
 
 AC_ARG_VAR([ART_SAMPLES],
     [Path to the root of libass' regression testing sample repository. If set, it is used in make check.])
@@ -332,6 +334,9 @@ AS_IF([test "x$enable_asm" != xno], [
                     ASFLAGS="$ASFLAGS -DFORCE_VEX_ENCODING=1"
                 ])
 
+                AS_IF([test "x$enable_trim_asm" = xyes], [
+                    ASFLAGS="$ASFLAGS -DFUNCTION_SECTIONS=1"
+                ])
                 AC_MSG_CHECKING([if $AS supports vpmovzxwd])
                 echo "vpmovzxwd ymm0, xmm0" > conftest.asm
                 AS_IF([$AS conftest.asm $ASFLAGS -o conftest.o >conftest.log 2>&1], [
@@ -384,6 +389,7 @@ AS_IF([test "x$enable_shared" != xno], [
 
 ## Setup conditionals for use in Makefiles
 AM_CONDITIONAL([ASM], [test "x$can_asm" = xtrue])
+AM_CONDITIONAL([TRIM_ASM], [test "x$enable_trim_asm" = xyes])
 AM_CONDITIONAL([X86], [test "x$cpu_family" = xx86])
 AM_CONDITIONAL([X86_64], [test "x$cpu_family" = xx86 && test "x$BITS" = x64])
 AM_CONDITIONAL([AARCH64], [test "x$cpu_family" = xaarch64])
@@ -404,6 +410,9 @@ AM_CONDITIONAL([DIRECTWRITE], [test "x$directwrite" = xtrue])
 ## Define C Macros not relating to libraries
 AM_COND_IF([ASM], [
     AC_DEFINE(CONFIG_ASM, 1, [ASM enabled])
+    AM_COND_IF([TRIM_ASM], [
+        AC_DEFINE(CONFIG_ASM_DCE, 1, [TRIM ASM enabled])
+    ])
     AM_COND_IF([X86], [
         AC_DEFINE(ARCH_X86, 1, [targeting a 32- or 64-bit x86 host architecture])
     ])

--- a/libass/x86/x86inc.asm
+++ b/libass/x86/x86inc.asm
@@ -84,6 +84,10 @@
     %define FORCE_VEX_ENCODING 0
 %endif
 
+%ifndef FUNCTION_SECTIONS
+    %define FUNCTION_SECTIONS 0
+%endif
+
 %macro SECTION_RODATA 0-1 16
     %ifidn __OUTPUT_FORMAT__,win32
         SECTION .rdata align=%1
@@ -828,12 +832,19 @@ BRANCH_INSTR jz, je, jnz, jne, jl, jle, jnl, jnle, jg, jge, jng, jnge, ja, jae, 
     %xdefine current_function_section __SECT__
     %if FORMAT_ELF
         %if %1
+            %if FUNCTION_SECTIONS
+                section .text.%2 progbits alloc exec nowrite
+                %define last_branch_adr $$
+            %endif
             global %2:function hidden
         %else
             global %2:function
         %endif
     %elif FORMAT_MACHO && HAVE_PRIVATE_EXTERN && %1
         global %2:private_extern
+    %elif WIN64 && %1 && FUNCTION_SECTIONS
+        section .text$%2 comdat=1:%2
+        %define last_branch_adr $$
     %else
         global %2
     %endif

--- a/meson.build
+++ b/meson.build
@@ -315,6 +315,10 @@ if not asm_option.disabled()
                 nasm_args += '-DFORCE_VEX_ENCODING=1'
             endif
 
+            if get_option('trim_asm').enabled()
+                nasm_args += '-DFUNCTION_SECTIONS=1'
+            endif
+
             add_project_arguments(nasm_args, language: 'nasm')
         endif
     elif generic_cpu_family == 'aarch64'
@@ -333,6 +337,9 @@ if not asm_option.disabled()
 
     if enable_asm
         conf.set('CONFIG_ASM', 1)
+        if get_option('trim_asm').enabled()
+            conf.set('CONFIG_ASM_DCE', 1)
+        endif
     elif asm_option.enabled()
         error(
             'Assembly was requested, but cannot be built; see prior messages.',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -17,3 +17,4 @@ option('require-system-font-provider', type: 'boolean', value: true,
        description: 'disallow compilation if no system font provider was found')
 option('large-tiles', type: 'boolean', value: false,
        description: 'use larger tiles in the rasterizer (better performance, slightly worse quality)')
+option('trim_asm', type: 'feature', description: 'eliminate redundant asm functions where possible')


### PR DESCRIPTION
this allows linkers to discard unused asm code

Separated from #909