### PR TITLE
ci/gha: convert UWP job to regular desktop UCRT

### DIFF
--- a/.github/workflows/ghci.yml
+++ b/.github/workflows/ghci.yml
@@ -98,10 +98,10 @@ jobs:
             output_stream.write(f"count={num_cpus}\n")
 
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: download test samples
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: libass/libass-tests
           path: ${{ env.ART_SAMPLES }}

--- a/.github/workflows/ghci.yml
+++ b/.github/workflows/ghci.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     name: build(${{ matrix.msystem || matrix.docker_image || matrix.os }},
-      ${{ matrix.cc }}${{ matrix.api && ', ' }}${{ matrix.api }}${{ matrix.jobname_suffix && ', ' }}${{ matrix.jobname_suffix }})
+      ${{ matrix.cc }}${{ matrix.jobname_suffix && ', ' }}${{ matrix.jobname_suffix }})
     strategy:
       fail-fast: false
       matrix:
@@ -62,14 +62,10 @@ jobs:
           - os: windows-latest
             msystem: MINGW32
             cc: gcc
-            api: desktop
             shell: 'msys2 {0}'
-          # Add a best-effort build for UWP apps for Microsoft Store
           - os: windows-latest
             msystem: UCRT64
             cc: gcc
-            api: app
-            extra_cflags: -DWINAPI_FAMILY=WINAPI_FAMILY_APP -specs=/tmp/windowsapp.specs
             shell: 'msys2 {0}'
 
     defaults:
@@ -220,14 +216,6 @@ jobs:
 
           echo "SANFLAGS=$flags"
           echo "flags=${flags}" >> $GITHUB_OUTPUT
-
-      - name: Customize compiler
-        if: matrix.api == 'app' && matrix.cc == 'gcc'
-        run: >
-          gcc -dumpspecs
-          | sed 's/-lmsvcrt/-lucrtapp/g; s/-lkernel32/-lwindowsapp/g;
-          s/-ladvapi32//g; s/-lshell32//g; s/-luser32//g'
-          > /tmp/windowsapp.specs
 
       - name: configure
         run: |

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -76,12 +76,12 @@ jobs:
       SCCACHE_MAXSIZE: 200M
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: '0'
 
       - name: Download test samples
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: libass/libass-tests
           path: ${{ env.ART_SAMPLES }}
@@ -200,7 +200,7 @@ jobs:
                   fontconfig-dev libpng-dev git
 
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: configure
         run: |
@@ -262,7 +262,7 @@ jobs:
                   libpng-dev meson ninja-build
 
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: setup distdir
         run: |

--- a/.github/workflows/qemu-arch.yml
+++ b/.github/workflows/qemu-arch.yml
@@ -214,12 +214,12 @@ jobs:
 
 
       - name: Checkout libass
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: '${{ steps.config.outputs.chr_dir }}/home/artci/workarea/libass'
 
       - name: Checkout tests
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ github.event.inputs.test_repo || 'libass/libass-tests'}}
           ref: ${{ github.event.inputs.test_ref }}

--- a/.github/workflows/vm.yml
+++ b/.github/workflows/vm.yml
@@ -80,17 +80,17 @@ jobs:
 
     steps:
       - name: checkout libass
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: download test samples
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ github.event.inputs.test_repo || 'libass/libass-tests'}}
           ref: ${{ github.event.inputs.test_ref }}
           path: './libass-tests'
 
       - name: Install Packages
-        uses: cross-platform-actions/action@v0.30.0
+        uses: cross-platform-actions/action@v1.0.0
         with:
           operating_system: ${{ matrix.os_image }}
           version: ${{ matrix.os_version }}
@@ -151,7 +151,7 @@ jobs:
             esac
 
       - name: Fix git ownership
-        uses: cross-platform-actions/action@v0.30.0
+        uses: cross-platform-actions/action@v1.0.0
         with:
           operating_system: ${{ matrix.os_image }}
           version: ${{ matrix.os_version }}
@@ -163,7 +163,7 @@ jobs:
             git config --global --add safe.directory "$PWD"
 
       - name: Build libass
-        uses: cross-platform-actions/action@v0.30.0
+        uses: cross-platform-actions/action@v1.0.0
         with:
           operating_system: ${{ matrix.os_image }}
           version: ${{ matrix.os_version }}
@@ -176,7 +176,7 @@ jobs:
             make -j 2
 
       - name: Run Tests
-        uses: cross-platform-actions/action@v0.30.0
+        uses: cross-platform-actions/action@v1.0.0
         with:
           operating_system: ${{ matrix.os_image }}
           version: ${{ matrix.os_version }}
@@ -190,7 +190,7 @@ jobs:
 
       - name: Shutdown VM
         if: always()
-        uses: cross-platform-actions/action@v0.30.0
+        uses: cross-platform-actions/action@v1.0.0
         with:
           operating_system: ${{ matrix.os_image }}
           version: ${{ matrix.os_version }}


### PR DESCRIPTION
The job failed for over four months now as the result of toolchain changes and UWP is deprecated making a future fix seems unlikely. Nobody stepped up to fix the CI setup either.
A permanently failing job brings no benefit, so let’s not.