### PR TITLE
ci: add illumos job back

### DIFF
--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Restore cache
         if: matrix.config.msvc
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ${{ env.SCCACHE_DIR }}
           key: windows-msvc-${{ matrix.config.arch }}-${{ steps.get_time.outputs.timestamp }}
@@ -170,7 +170,7 @@ jobs:
         run: cat build/meson-logs/testlog.txt
 
       - name: Save Cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         if: always() && matrix.config.msvc
         with:
           path: ${{ env.SCCACHE_DIR }}

--- a/.github/workflows/qemu-arch.yml
+++ b/.github/workflows/qemu-arch.yml
@@ -122,7 +122,7 @@ jobs:
       # use it to store our (compressed) chroot dirs
       # (cache is branch scoped)
       - name: Retrieve Cached Chroots
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache
         with:
           path: /var/chroot/imgs

--- a/.github/workflows/vm.yml
+++ b/.github/workflows/vm.yml
@@ -65,14 +65,14 @@ jobs:
             # no libubsan available, thus just SIGILL
             CC: 'gcc -fsanitize=undefined,float-cast-overflow -fno-sanitize-recover=all -fsanitize-undefined-trap-on-error'
 
-          # No illumos in cross-platform-actions/action yet, see
-          #   https://github.com/cross-platform-actions/action/issues/20
-          #- name: 'ART (illumos32-qemu, OpenIndiana, i686)'
-          #  vbox: openindiana/hipster
-          #  CC: gcc -m32 -msse -msse2 -mfpmath=sse
-          #  confflags: '--host=i686-pc-solaris2.11'
-          #  ASAN_OPTIONS: ''
-          #  ART_REG_SKIP: 'font_nonunicode'
+          - name: 'ART(omnios64-qemu, illumos/OmniOS, amd64)'
+            os_image: omnios
+            os_version: r151056
+            # errors by default, but illumos has spec-incompliant iconv (const vs restrict)
+            CC: 'gcc -Wno-error=incompatible-pointer-types'
+            confenv: 'PKG_CONFIG_PATH=/opt/ooce/lib/64/pkgconfig'
+            ART_REG_SKIP: 'font_nonunicode'
+
     env:
       ASAN_OPTIONS: ${{ matrix.ASAN_OPTIONS }}
       AUTOCONF_VERSION: ${{ matrix.AUTOCONF_VERSION }}
@@ -132,21 +132,21 @@ jobs:
                   freetype_devel fribidi_devel harfbuzz_devel \
                   fontconfig_devel libunibreak_devel libpng16_devel
                 ;;
-              openindiana/*)
-                pfexec pkg install --no-backup-be \
-                    crypto/ca-certificates \
-                    developer/versioning/git \
-                    developer/gcc-10 \
-                    developer/assembler/nasm \
-                    developer/build/autoconf \
-                    developer/build/automake \
-                    developer/build/libtool \
-                    developer/build/pkg-config \
-                    system/library/freetype-2 \
-                    library/fribidi \
-                    library/c++/harfbuzz \
-                    system/library/fontconfig \
-                    image/library/libpng
+              omnios)
+                # "ooce" extra packages are not in regular search paths.
+                # Activate via /opt/ooce/lib/64/pkgconfig etc.
+                # Harfbuzz and fribidi are bundled with pango (no standalone package).
+                sudo pkg install --deny-new-be --no-backup-be \
+                  pkg:/developer/gcc14 \
+                  pkg:/developer/nasm \
+                  pkg:/developer/build/make \
+                  pkg:/developer/pkg-config \
+                  pkg:/developer/build/autoconf \
+                  pkg:/developer/build/automake \
+                  pkg:/developer/build/libtool \
+                  pkg:/ooce/library/fontconfig \
+                  pkg:/ooce/library/pango \
+                  pkg:/ooce/library/libpng
                 ;;
             esac
 
@@ -160,7 +160,8 @@ jobs:
           sync_files: true
           run: |
             ./autogen.sh
-            ./configure CC="${{ matrix.CC }}" ${{ matrix.confflags }} --enable-fuzz --enable-compare
+            env ${{ matrix.confenv }} \
+              ./configure CC="${{ matrix.CC }}" ${{ matrix.confflags }} --enable-fuzz --enable-compare
             make -j 2
 
       - name: Run Tests

--- a/.github/workflows/vm.yml
+++ b/.github/workflows/vm.yml
@@ -79,6 +79,26 @@ jobs:
       AUTOMAKE_VERSION: ${{ matrix.AUTOMAKE_VERSION }}
 
     steps:
+      # Available core count changes on runner type and over time, but GHA
+      # doesn’t easily expose this, so we’ll have to query this ourselves. Based on:
+      # https://github.com/orgs/community/discussions/25057#discussioncomment-5957241
+      - name: determine logical cpu core count
+        id: cpus
+        shell: python
+        run: |
+          import os
+          import multiprocessing
+
+          try:
+            num_cpus = len(os.sched_getaffinity(0))
+          except AttributeError:
+            num_cpus = multiprocessing.cpu_count()
+          print(f"num_cpus={num_cpus}")
+
+          output_file = os.environ["GITHUB_OUTPUT"]
+          with open(output_file, "a", encoding="utf-8") as output_stream:
+            output_stream.write(f"count={num_cpus}\n")
+
       - name: checkout libass
         uses: actions/checkout@v6
 
@@ -162,7 +182,7 @@ jobs:
             ./autogen.sh
             env ${{ matrix.confenv }} \
               ./configure CC="${{ matrix.CC }}" ${{ matrix.confflags }} --enable-fuzz --enable-compare
-            make -j 2
+            make -j '${{ steps.cpus.outputs.count }}'
 
       - name: Run Tests
         uses: cross-platform-actions/action@v1.0.0

--- a/.github/workflows/vm.yml
+++ b/.github/workflows/vm.yml
@@ -150,18 +150,6 @@ jobs:
                 ;;
             esac
 
-      - name: Fix git ownership
-        uses: cross-platform-actions/action@v1.0.0
-        with:
-          operating_system: ${{ matrix.os_image }}
-          version: ${{ matrix.os_version }}
-          environment_variables: ASAN_OPTIONS AUTOCONF_VERSION AUTOMAKE_VERSION
-          shutdown_vm: false
-          sync_files: true
-          run: |
-            # Work around https://github.com/cross-platform-actions/action/issues/108
-            git config --global --add safe.directory "$PWD"
-
       - name: Build libass
         uses: cross-platform-actions/action@v1.0.0
         with:


### PR DESCRIPTION
cross-platform actions now supports OmniOS. Unlike in OpenIndiana we don’t get our deps as "normal" system packages, but they are still available via the extra "ooce" *(OmniOS Community Edition)* repo just requiring an extra pkg-config opt-in