### PR TITLE
ass_fontconfig: release libfontconfig global state on destroy paths

### DIFF
--- a/libass/ass_fontconfig.c
+++ b/libass/ass_fontconfig.c
@@ -85,6 +85,7 @@ static void destroy(void *priv)
     if (fc->fallbacks)
         FcFontSetDestroy(fc->fallbacks);
     FcConfigDestroy(fc->config);
+    FcFini();
     free(fc);
 }
 
@@ -380,6 +381,7 @@ ass_fontconfig_add_provider(ASS_Library *lib, ASS_FontSelector *selector,
         ass_msg(lib, MSGL_ERR,
                 "No valid fontconfig configuration found!");
         FcConfigDestroy(fc->config);
+        FcFini();
         free(fc);
         return NULL;
     }


### PR DESCRIPTION
FcConfigDestroy frees the FcConfig object but doesn't release libfontconfig's global state, which remains populated when parsing the font config XML. This causes LSAN to report leaks originating from ass_set_fonts when the fontconfig provider is selected.

Add FcFini in the regular destroy path, and in the error path of ass_fontconfig_add_provider where FcInitLoadConfig may have been called before bailing out.