### PR TITLE
ass_fontconfig: use FcConfigSetDefaultSubstitute when available

### DIFF
--- a/libass/ass_fontconfig.c
+++ b/libass/ass_fontconfig.c
@@ -233,7 +233,7 @@ static void cache_fallbacks(ProviderPrivate *fc)
         return;
     FcPatternAddString(pat, FC_FAMILY, (FcChar8 *)"sans-serif");
     FcPatternAddBool(pat, FC_OUTLINE, FcTrue);
-    FcConfigSubstitute (fc->config, pat, FcMatchPattern);
+    FcConfigSubstitute(fc->config, pat, FcMatchPattern);
 #if FC_VERSION >= 21700
     FcConfigSetDefaultSubstitute(fc->config, pat);
 #else

--- a/libass/ass_fontconfig.c
+++ b/libass/ass_fontconfig.c
@@ -100,7 +100,11 @@ static bool scan_fonts(FcConfig *config, ASS_FontProvider *provider)
     if (!pat)
         return false;
 
+#if FC_VERSION >= 21700
+    FcConfigSetDefaultSubstitute(config, pat);
+#else
     FcDefaultSubstitute(pat);
+#endif
     FcResult res;
     // trim=FcFalse returns all system fonts
     fonts = FcFontSort(config, pat, FcFalse, NULL, &res);
@@ -230,7 +234,11 @@ static void cache_fallbacks(ProviderPrivate *fc)
     FcPatternAddString(pat, FC_FAMILY, (FcChar8 *)"sans-serif");
     FcPatternAddBool(pat, FC_OUTLINE, FcTrue);
     FcConfigSubstitute (fc->config, pat, FcMatchPattern);
-    FcDefaultSubstitute (pat);
+#if FC_VERSION >= 21700
+    FcConfigSetDefaultSubstitute(fc->config, pat);
+#else
+    FcDefaultSubstitute(pat);
+#endif
 
     // FC_LANG is automatically set according to locale, but this results
     // in strange sorting sometimes, so remove the attribute completely.


### PR DESCRIPTION
FcDefaultSubstitute allocates state into global context that is not freed by FcConfigDestroy. FcConfigSetDefaultSubstitute introduced in 2.17.0 by https://gitlab.freedesktop.org/fontconfig/fontconfig/-/commit/90a84c477c4006b5539973a5487f28b3ed09711d scopes the allocation to the provided FcConfig instance, allowing FcConfigDestroy to fully clean up all state and eliminating the LSAN reported leaks