### PR TITLE
build: do not treat signed integer over- or underflow as UB

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -55,6 +55,11 @@ FUZZ_CPPFLAGS="${FUZZ_CPPFLAGS:--DASS_FUZZMODE=0}"
 AX_APPEND_COMPILE_FLAGS([-fno-math-errno])
 AX_APPEND_COMPILE_FLAGS([/clang:-fno-math-errno])
 
+## No UB on signed integer overflow
+## (this also enforces complement-of-two wrap around, but we shouldn’ŧ rely on that)
+AX_APPEND_COMPILE_FLAGS([-fwrapv])
+AX_APPEND_COMPILE_FLAGS([/clang:-fwrapv])
+
 ## Warnings
 AX_APPEND_COMPILE_FLAGS([ \
     -Wall -Wextra -Wno-sign-compare -Wno-unused-parameter -Wstrict-prototypes \

--- a/meson.build
+++ b/meson.build
@@ -26,9 +26,9 @@ cc_warnings = []
 cc_features = []
 
 if cc.get_id() == 'clang-cl'
-    cc_features += '/clang:-fno-math-errno'
+    cc_features += ['/clang:-fno-math-errno', '/clang:-fwrapv']
 elif cc.get_id() != 'msvc'
-    cc_features += ['-D_GNU_SOURCE', '-D_XPLATFORM_SOURCE', '-fno-math-errno']
+    cc_features += ['-D_GNU_SOURCE', '-D_XPLATFORM_SOURCE', '-fno-math-errno', '-fwrapv']
 endif
 
 if cc.get_argument_syntax() == 'gcc'


### PR DESCRIPTION
We long struggled with how to deal with signed overflows during rendering, where overflow detection/prevention is unacceptably costly. At the same time, as long as the overflow itself doesn’t blow up, regardless of what value we end up with in those  rendering computations we never end up with something _unsafe_, only a nonsensical output image (sometimes we even _want_ to overflow with wrap around to emulate VSFilter).

This patch is not necessarily the best final solution *(for one, it only works on some compilers; additionally we now also won’t get warnings on places where overflow is actually unsafe)*, but intended to (re)start the discussion about how to tackle this. Alternatively we could explicitly cast operands to unsigned types in all such "safe" calculations at the cost of more unwieldy code.  
Ideally imho, we had different types for safely wrapping signed integers, signed integers where overflow is considered unsafe and also the same for _unsigned_ types, as we typically do _not_ want to ever over- or underflow `size_t` values used as pointer offsets or to track the size of a memory region.  
Maybe if [`__attribute__((overflow_behavior(…)))`](https://clang.llvm.org/docs/OverflowBehaviorTypes.html) stabilises and becomes more wide-spread we can do that, but for now, I don’t think this is possible.
