### PR TITLE
ci: add read-only permissions and pin action SHAs

### DIFF
--- a/.github/workflows/ghci.yml
+++ b/.github/workflows/ghci.yml
@@ -5,6 +5,9 @@ on:
     branches: [master, ci, coverity_scan]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -98,10 +101,10 @@ jobs:
             output_stream.write(f"count={num_cpus}\n")
 
       - name: checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
 
       - name: download test samples
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         with:
           repository: libass/libass-tests
           path: ${{ env.ART_SAMPLES }}
@@ -135,7 +138,7 @@ jobs:
           chmod a+x /tmp/docker_shell
 
       - name: Setup MSys2
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c  # v2
         if: matrix.msystem
         with:
           msystem: ${{ matrix.msystem }}

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: ${{ matrix.config.name }}
@@ -75,19 +78,19 @@ jobs:
       SCCACHE_MAXSIZE: 200M
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         with:
           fetch-depth: '0'
 
       - name: Download test samples
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         with:
           repository: libass/libass-tests
           path: ${{ env.ART_SAMPLES }}
 
       - name: Setup MSYS2
         if: matrix.config.msystem
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c  # v2
         with:
           msystem: ${{ matrix.config.msystem }}
           pacboy: >-
@@ -109,7 +112,7 @@ jobs:
 
       - name: Restore cache
         if: matrix.config.msvc
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: ${{ env.SCCACHE_DIR }}
           key: windows-msvc-${{ matrix.config.arch }}-${{ steps.get_time.outputs.timestamp }}
@@ -178,7 +181,7 @@ jobs:
         run: cat build/meson-logs/testlog.txt
 
       - name: Save Cache
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         if: always() && matrix.config.msvc
         with:
           path: ${{ env.SCCACHE_DIR }}
@@ -208,7 +211,7 @@ jobs:
                   fontconfig-dev libpng-dev git
 
       - name: checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
 
       - name: configure
         run: |
@@ -270,7 +273,7 @@ jobs:
                   libpng-dev meson ninja-build
 
       - name: checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
 
       - name: setup distdir
         run: |

--- a/.github/workflows/qemu-arch.yml
+++ b/.github/workflows/qemu-arch.yml
@@ -16,6 +16,9 @@ on:
         required: false
         default: ''
 
+permissions:
+  contents: read
+
 jobs:
   ART:
     runs-on: ${{ matrix.host_os || 'ubuntu-latest' }}
@@ -122,7 +125,7 @@ jobs:
       # use it to store our (compressed) chroot dirs
       # (cache is branch scoped)
       - name: Retrieve Cached Chroots
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         id: cache
         with:
           path: /var/chroot/imgs
@@ -214,12 +217,12 @@ jobs:
 
 
       - name: Checkout libass
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         with:
           path: '${{ steps.config.outputs.chr_dir }}/home/artci/workarea/libass'
 
       - name: Checkout tests
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         with:
           repository: ${{ github.event.inputs.test_repo || 'libass/libass-tests'}}
           ref: ${{ github.event.inputs.test_ref }}

--- a/.github/workflows/vm.yml
+++ b/.github/workflows/vm.yml
@@ -16,6 +16,9 @@ on:
         required: false
         default: ''
 
+permissions:
+  contents: read
+
 jobs:
   ART-VM:
     # This does NOT have KVM, but the only runners with native virtualisation (MacOS) are unreliable
@@ -104,17 +107,17 @@ jobs:
             output_stream.write(f"count={num_cpus}\n")
 
       - name: checkout libass
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
 
       - name: download test samples
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         with:
           repository: ${{ github.event.inputs.test_repo || 'libass/libass-tests'}}
           ref: ${{ github.event.inputs.test_ref }}
           path: './libass-tests'
 
       - name: Start VM
-        uses: cross-platform-actions/action@v1.4.0
+        uses: cross-platform-actions/action@24ef01df165c76df1ed2b9f9e9212e78dc2fc963  # v1.4.0
         with:
           operating_system: ${{ matrix.os_image }}
           version: ${{ matrix.os_version }}


### PR DESCRIPTION
## Summary

CI workflows were missing top-level `permissions` declarations and referenced actions by mutable tags/branch names.

### Changes

- Add explicit workflow-level `permissions: contents: read` to the affected workflows
- Pin third-party action references to full commit SHAs

The workflows only need repository read access for checkout/build/test execution. Pinning action references to commit SHAs also ensures the audited action revisions are used instead of mutable tags.

### Verification

```bash
python3 - <<'PY'
import pathlib, yaml
for p in pathlib.Path('.github/workflows').glob('*.yml'):
    yaml.safe_load(p.read_text())
for p in pathlib.Path('.github/workflows').glob('*.yaml'):
    yaml.safe_load(p.read_text())
print('yaml ok')
PY
```

Result: `yaml ok`.