### PR TITLE
Security reporting and contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,165 @@
+# Contributing to libass
+
+## General
+
+If you’re not sure how to start, just getting an unpatched git HEAD
+building as per our `README.md` and checking out the available
+config options might be a good idea.
+
+If your patch is quite large and/or requires significant changes to the internal
+code organisation or interfaces or affects public API in any way, it is
+**strongly** recommended to discuss the concept with us first.
+This saves you time by not investing effort into drafting patches based on an
+unviable approach, and is better for us too as we don’t have to review and
+figure out how to salvage a large patch set based on a flawed concept.
+
+Try to match the existing coding style of the individual file(s) you modify.
+
+For discussion or to ask questions about the code base or your patch,
+you can reach us via IRC *(see `README.md`)*.
+For more lengthy or asynchronous discussions about patch concepts,
+RFC issues or GitHub discussions can be used too.
+
+## Code of Conduct
+
+Aim to stay courteous and respectful.
+We want to be welcoming space for all sorts of diverse participants.
+
+Naturally, to remain a generally welcoming and friendly space
+we must not be welcoming nor tolerant of anything or anyone
+inherently detrimental to this. Thus bigotry, \*ism, \*phobia
+and other such intolerance have no place here.
+
+## Testing
+
+Make sure your changes compile in all supported build systems.
+
+Beyond that, we have a simple *(unfortunately rather incomplete)*
+test suite at [libass-tests](https://github.com/libass/libass-tests).
+To use it, clone this repository and during configure time enable the
+`compare` and `fuzz` utilities and finally also indicate where the
+cloned repo is located.
+
+For autotools, this can be done with:
+
+```
+./configure --enable-compare --enable-fuzz ART_SAMPLES=../libass-tests
+make -j "$(nproc)"
+make check
+```
+
+For meson:
+
+```
+meson setup -Dcompare=enabled -Dfuzz=enabled -Dart-samples="$HOME"/code/libass-test build_meson
+meson compile -C build_meson
+meson test -C build_meson test
+```
+
+On some platforms certain tests relying on system libraries
+might need to be skipped. You can use our CI setup for reference
+and check documentation in the test repo for further info about
+how to tweak the test suite.
+
+## Commit guidelines
+
+### Split changes into multiple commits
+
+- Follow git good practices, and split independent changes into several commits.
+  It's usually OK to put them into a single pull request.
+- Try to separate cosmetic and functional changes.
+- Splitting changes does _not_ mean that you should make them as fine-grained
+  as possible. Commits should form logical steps in development. The way you
+  split changes is important for code review and analysing bugs.
+
+### Always squash fixup commits when making changes to pull requests
+
+- If you make fixup commits to your pull request, you should generally squash
+  them with `git rebase -i`, `git history fixup` or similar.
+  We prefer to have pull requests in a merge-ready state suitable
+  to be applied as a fast-forward to our development branch.
+
+### Write good commit messages
+
+- Write informative commit messages. Use present tense to describe the
+  situation with the patch applied, and past tense for the situation before
+  the change.
+- subject lines are preferred to be in the style of `subcomponent: description`
+  when the change is clearly limited or mainly related to one such subcomponent.
+  For cosmetic only changes, an additional `cosmetic/` prefix can be applied.
+  Check out the git log of the files you’re editing for reference.
+- The body of the commit message (everything else after the subject line) must
+  be as informative as possible and contain everything that isn't obvious. Don't
+  hesitate to dump as much information as you can - it doesn't cost you
+  anything. Put some effort into it. If someone finds a bug months or years
+  later, and finds that it's caused by your commit (even though your commit was
+  supposed to fix another bug), it would be bad if there wasn't enough
+  information to test the original bug. The old bug might be reintroduced while
+  fixing the new bug.
+
+  The commit message must be wrapped on 72 characters per line, because git
+  tools usually do not break text automatically. On the other hand, you do not
+  need to break text that would be unnatural to break (like data for test cases,
+  or long URLs).
+
+### Signed commits
+
+Signing your commits is all fine and good.
+To preserve your signature before pushing to our development branch
+we may need to ask you to rebase a patch series however.
+If you do not rebase in a reasonable amount of time, we may need to do so
+ourselves, unfortunately stripping the signature in the process.
+
+## Copyright and licencing
+
+- Make sure you own the copyright or have been granted permission by the
+  original author(s) for any patches you send.
+- If you’re not the original author of the content, make sure to say so and
+  properly attribute the original author(s)!
+- Any new submission must be licensed under the ISC licence matching the
+  project-wide default, or a compatible equivalent or more permissive licence.
+  If something is _not_ licensed under the ISC, make sure to explicitly
+  highlight this!
+- If a new copyright header is necessary (because a new file was created)
+  a generic copyright statement like “libass contributors” is preferred.
+  Naming each individual contributor in the header is not necessary nor helpful
+  for copyright and licence purposes
+
+## "AI"-assisted contributions
+
+All contributions must have been in full thought up by yourself and other attributed authors.  
+It is expressly forbidden to contribute any content whose essence has been created
+with the assistance of Natural Language Processing artificial intelligence tools.
+This also applies to how any parts re-used from other authors were authored.
+
+### Examples
+
+Usage of so called "generative AI" tools, "AI agents" or similar
+to generate a patch in full or part is thus never permissible.
+
+If you struggle with English to the degree of mostly relying on machine translation
+*(nowadays typically also marketed as "AI")* for any meaningful natural-text communication
+about libass and your patches, you are not forbidden from participating.
+However, please refrain from any more changes to existing documentation
+or other natural text parts then strictly necessary and do not add new natural text content.  
+_Only_ use plain translations of your native remarks though!
+Do **not** use any machine-generated prose extension or stylistic alterations.
+It doesn’t help; on the contrary it will make it harder to figure out what you mean.
+
+Using machine learning models for purely assistive purposes during the
+creation process, e.g. as the voice synthesiser of a screen reader
+or as a part of the voice-controlled input method, provided it
+merely acts as a direct input method of the logic and code you
+independently thought up, are permissible.
+
+However, to reiterate, all logic, code and other essence of the contribution
+must have always been independently thought up by yourself!
+
+## Sending patches
+
+Preferably send patches as a GitHub pull request.
+
+If the need for a GitHub account is a hurdle to you,
+you may also contact us on IRC and share a `format-patch`
+series. In this case, you will be expected to stay around
+on IRC for further discussion and revisions of the patches.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -68,3 +68,6 @@ Regardless of how you choose to contact us,
 please make sure to include details of what the bug is,
 why you believe it to be security relevant and
 how to trigger it with at least one reproducer test input.
+
+If you wish to immediately also propose a patch with a fix,
+make sure to check out the hints in our `CONTRIBUTING.md` file.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,70 @@
+# Reporting Security Issues
+
+Thanks for taking a look at and testing libass!  
+Below are some pointers helping with (further) testing and reporting.
+
+## Supported Versions
+
+Only the most recent release and the unreleased git HEAD state are considered supported.
+Testing and analysis are strongly encouraged to be performed on one or both of these.
+
+If you find something affecting an older but not the most recent release,
+we most likely not consider this relevant.
+
+If you find something affecting a git state after the most recent release
+but no longer current git HEAD, then if the fix seems intentional this too
+will no longer be relevant.  
+If however, it seems like a mere coincidence with the exploit fixed unintentionally
+by pure chance it might still be worth bringing to our attention.
+
+## What qualifies as a security bug
+
+Security bugs should be in the core libass library.
+Our extra utilities like `test`, `compare`, etc are not built by default,
+never installed and only intended for development and testing purposes.
+Nasty bugs here still ought to be fixed but do not warrant special treatment.
+
+The following are likely worth being tentatively treated as security relevant:
+
+- memory out-of-bounds writes and reads or use-after-free
+- arbitrary code execution
+- arbitrary file system write or reads
+- confidential information leakage to an attacker
+
+On the other hand, the following are not security relevant for libass:
+
+- memory leakage or other resource leakages like never-closed file descriptors
+- resource exhaustion; e.g. attempting to allocate as much or more memory than the system can provide
+- any other form of DOS
+- signed-integer overflows _unless_ this overflow
+  later leads to other exploitable issues like memory bugs
+- bugs not directly in libass, but our dependencies,
+  should be directly reported to the affected dependency instead
+
+## How to test
+
+The most convenient way to test libass behaviour on a test input file
+is our `fuzz` utility compile in the default standalone mode.
+You can enable it with `--enable-fuzz` during compilation.
+
+If our bug relies on other API usages, like e.g. Matroska packets as inputs
+instead of full files or obscure configurations, you may unfortunately need
+to write a small utility yourself, though `fuzz`’ source may be
+a useful starting point.
+
+## Reporting
+
+If after reading the above you believe you have found a bug with potential
+security implications making it unfit to just be publicly reported as a
+regular bug, you may use any of the following avenues:
+
+- use GitHub’s “Report a vulnerability” feature on our repo’s “Security” tab
+- ask on our IRC channel *(see `README.md`)* for
+- contact a maintainer listed **both** in our `MAINTAINERS` file _and_
+  [OSS-Fuzz’ contact list](https://github.com/google/oss-fuzz/blob/master/projects/libass/project.yaml)
+  via a PGP-encrypted email
+
+Regardless of how you choose to contact us,
+please make sure to include details of what the bug is,
+why you believe it to be security relevant and
+how to trigger it with at least one reproducer test input.


### PR DESCRIPTION
Inspired by recent private (per-email to a single maintainer) and public security reports, AI slop PRs and such. And often fuzzing or security reports reïnventing the existing `fuzz` utilities *(only once so far actually using different API)*, making reproduction a bit more tedious and also initially more effort for the reports. Hopefully, with this we’ll get things reported via the proper channels monitored by all maintainers.

The layout of both documents was inspired by mpv’s existing counterparts, but most of the text content was rewritten from scratch or at least modified in some way. The least changed parts are commit and copyright guidelines

I believe `SECURITY.md` just sums up what we converged on in prior discussion and thus should already match existing consesn, except for the alternative reporting approaches for those without a GitHub account. In particular, whether everyone affected is actually fine with the email-based reporting option and will notice incoming reports.  
Notably, the rendered version of this file will show up in GitHub’s “Security and quality” tab too.

`CONTRIBUTING.md` too describes an alternative patch submission way, but furthermore also has a short Code of Conduct and AI policy statement.  

The former is intentionally kept brief and thus also rather general. There’s also merit to being more detailed and explicit.
On the other hand, one can also argue, that in this case we might not need a CoC statement at all since everything worked well without.  
I chose to go with a brief and general statment for the following reasons:
- I suspect barely anyone will actually read a lengthy document before interacting
- being too specific and trying to explicitly enumerate each possible individual case is prone to forgetting sth or creating loopholes.
- nonetheless, having the general idea stated explicitly is nice imo and it can be a reassuring sign for potential contributors  

It is also true though, that no form of CoC helps if the actual culture doesn’t live up to it; fortunately imo we’re good on that rn? *(But if there’s anything currently bothering you I’m oblivious too, please do speak up)*  
In any event, I’m sure the wording could be tweaked a bit and if there’s a shared preference for taking another CoC approach, I’m open to discuss this too.

The latter is basically [Gentoo’s policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy) with a slight tweak and two additional sentences, to be explicit about vendored/copied code and to not _technically_ disallow assistive input and output methods like screenreaders and such. You were all likely already exposed to ""AI"" contribution and general ethic discussions over the past year(s), so I’ll spare you a recap of arguments for a ban *(but a non-exhaustive list can be found with the linked Gentoo policy)*. If you were lucky enough to avoid this or there’s disagreement about it, an elaboration can still follow.  
On a purely personal note apart from more general rationales though, I find the prospect and dealing with AI slop submission extremely demotivating.

One tangential observation made while writing: meson doesn’t accept path’s relative to the project root for `ART_SAMPLES` unlike autotools which is a bit inconvenient. But we recommend autotools for development anyway in our `README.md`