### PR TITLE
drawing: reject overflowed vector coordinates

### DIFF
--- a/libass/ass_drawing.c
+++ b/libass/ass_drawing.c
@@ -58,13 +58,22 @@ static inline bool add_node(ASS_DrawingToken **tail, ASS_TokenType type, ASS_Vec
     return true;
 }
 
+static inline bool get_coord(const char **str, int32_t *coord)
+{
+    double val;
+    if (!mystrtod((char **) str, &val))
+        return false;
+    val *= 64;  // to D6
+    // Out of range coordinates (and NaN) count as invalid numbers
+    if (!(fabs(val) <= OUTLINE_MAX))
+        return false;
+    *coord = ass_lrint(val);
+    return true;
+}
+
 static inline bool get_point(const char **str, ASS_Vector *point)
 {
-    double x, y;
-    if (!mystrtod((char **) str, &x) || !mystrtod((char **) str, &y))
-        return false;
-    *point = (ASS_Vector) {double_to_d6(x), double_to_d6(y)};
-    return true;
+    return get_coord(str, &point->x) && get_coord(str, &point->y);
 }
 
 


### PR DESCRIPTION
Fixes #931.

The parser currently accepts impossible `\\p` drawing coordinates, converts them into D6 integers, and lets the invalid values flow into cached drawing bounds and later render math. Instead of continuing with wrapped/poisoned coordinates, reject them at the parser boundary.

This change:

- range-checks drawing coordinates in D6 space before conversion,
- propagates invalid-coordinate failures through tokenization,
- makes `ass_drawing_parse()` fail when tokenization rejected the drawing,
- adds a focused regression executable for the reported PoC shape.

Local verification:

- `build/test/drawing_overflow`
- `build/test/libass_test /hosttmp/libass-931.png /hosttmp/libass-931.ass 0`

Both were run under a GCC UBSan/float-cast-overflow Docker build; the PoC is now rejected and the render path completes with `0 images blended` and no sanitizer abort.