### PR TITLE
ci/gha/vm: disable per-step file sync

### DIFF
--- a/.github/workflows/vm.yml
+++ b/.github/workflows/vm.yml
@@ -80,7 +80,8 @@ jobs:
 
     defaults:
       run:
-        shell: cpa.sh {0}
+        # Avoid syncing after each step, we only need an initial sync for repos
+        shell: cpa.sh {0} --sync-files none
 
     steps:
       # Available core count changes on runner type and over time, but GHA
@@ -119,12 +120,7 @@ jobs:
           operating_system: ${{ matrix.os_image }}
           version: ${{ matrix.os_version }}
           environment_variables: ASAN_OPTIONS AUTOCONF_VERSION AUTOMAKE_VERSION
-          # Avoid syncing after each step, we only need an initial sync for repos
-          sync_files: false
-
-      - name: Sync Files to VM
-        shell: bash
-        run: cpa.sh --sync-files runner-to-vm
+          sync_files: runner-to-vm
 
       - name: Install Packages
         run: |


### PR DESCRIPTION
The sync_files input only controls the synchronization performed by the VM start step itself. The cpa.sh shell does not consult it and defaults to syncing both directions around every step. Pass --sync-files none to the shell to get the intended behavior of a single initial sync.